### PR TITLE
Nullable Reference Types (NRT) migration

### DIFF
--- a/Terminal.Gui/Core/Window.cs
+++ b/Terminal.Gui/Core/Window.cs
@@ -40,7 +40,7 @@ namespace Terminal.Gui {
 		public override Border Border {
 			get => base.Border;
 			set {
-				if (base.Border != null && base.Border.Child != null && value.Child == null) {
+				if (base.Border != null && base.Border.Child != null && value.Child == null) { // <- nrt found a null ref here which is quite logical
 					value.Child = base.Border.Child;
 				}
 				base.Border = value;

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -15,10 +15,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <InternalsVisibleTo Include="UnitTests" />
+    <PackageReference Include="Nullable" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <!-- <None Remove="ConsoleDrivers\#ConsoleDriver.cs#" /> -->
   </ItemGroup>
   <PropertyGroup>
       <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
     <!-- See Terminal.Gui/README.md for how version numbering works -->
@@ -26,6 +31,7 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
 
     <TargetFrameworks>net472;netstandard2.0;net5.0</TargetFrameworks>
+    <LangVersion>9</LangVersion>
     <RootNamespace>Terminal.Gui</RootNamespace>
     <AssemblyName>Terminal.Gui</AssemblyName>
     <DocumentationFile>bin\Release\Terminal.Gui.xml</DocumentationFile>


### PR DESCRIPTION
Please look at this. Migrating to latest C# is not a problem (it's always been this way - it's just that certain features require either special type or runtime support, lang-only features have always worked well).

So C# 9 just requires LangVersion attribute set to 9. Somefeatures require either manual code copy-pasting or a nuget.

For NRT I've utilized https://github.com/manuelroemer/Nullable package

I don't have all the context about gui.cs sadly, but this is not meant to be "the great refactoring", morel ike a poco.
There are many questions we need to decide when migrating to NRT - mainly what really can be null and should be validated and what is not.

NRT really brings out the fact that there are lots of null landmines, sadly.

I would really like to bring out "Empty" versions of type like Dim.Empty, View.Empty etc but the problem is that they are not readonly. So I guess we have to stick with nulls. But at least I believe we have to make some things null-clear.

@BDisp @tig @tznind 