### PR TITLE
Add example of auto scrolling TextView

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -334,6 +334,22 @@ namespace Terminal.Gui {
 		bool oldCanFocus;
 		int oldTabIndex;
 
+
+		/// <summary>
+		/// Performs the requested command.  Returns true if
+		/// the command is of a Type supported by the view
+		/// and the command was successful
+		/// </summary>
+		public bool DoCommand(Command cmd)
+		{
+			if (!CommandImplementations.ContainsKey(cmd))
+			{
+				return false;
+			}
+
+			return CommandImplementations[cmd]() ?? false;
+		}
+
 		/// <inheritdoc/>
 		public override bool CanFocus {
 			get => base.CanFocus;

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -336,9 +336,9 @@ namespace Terminal.Gui {
 
 
 		/// <summary>
-		/// Performs the requested command.  Returns true if
+		/// Performs the requested command. Returns true if
 		/// the command is supported by the view and the 
-		/// command was successful
+		/// command was successful.
 		/// </summary>
 		public bool DoCommand(Command cmd)
 		{

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -337,8 +337,8 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Performs the requested command.  Returns true if
-		/// the command is of a Type supported by the view
-		/// and the command was successful
+		/// the command is supported by the view and the 
+		/// command was successful
 		/// </summary>
 		public bool DoCommand(Command cmd)
 		{

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1456,10 +1456,22 @@ namespace Terminal.Gui {
 			}
 		}
 
+
+		/// <summary>
+		/// Appends <paramref name="toAppend"/> to <see cref="Text"/> optional 
+		/// preserving the current selection
+		/// </summary>
+		/// <param name="resetCursorPosition">true to clear currently selected text (if any) and jump to 0,0.  False to retain current selection</param>
+		/// <param name="toAppend">The text to append to the end of <see cref="Text"/></param>
+		public void AppendText(ustring toAppend, bool resetCursorPosition)
+		{
+			SetText(Text + toAppend,resetCursorPosition);
+		}
+
 		/// <summary>
 		/// Updates the text displayed to the provided value.
 		/// </summary>
-		public void SetText(ustring value, bool resetCursorPosition=true)
+		private void SetText(ustring value, bool resetCursorPosition=true)
 		{
 			if (resetCursorPosition)
 			{

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1452,17 +1452,29 @@ namespace Terminal.Gui {
 			}
 
 			set {
-				ResetPosition ();
-				model.LoadString (value);
-				if (wordWrap) {
-					wrapManager = new WordWrapManager (model);
-					model = wrapManager.WrapModel (Math.Max (Frame.Width - 2, 0), out _, out _, out _, out _);
-				}
-				TextChanged?.Invoke ();
-				SetNeedsDisplay ();
-
-				historyText.Clear (Text);
+				SetText(value,true);
 			}
+		}
+
+		/// <summary>
+		/// Updates the text displayed to the provided value.
+		/// </summary>
+		public void SetText(ustring value, bool resetCursorPosition=true)
+		{
+			if (resetCursorPosition)
+			{
+				ResetPosition ();
+			}
+
+			model.LoadString (value);
+			if (wordWrap) {
+				wrapManager = new WordWrapManager (model);
+				model = wrapManager.WrapModel (Math.Max (Frame.Width - 2, 0), out _, out _, out _, out _);
+			}
+			TextChanged?.Invoke ();
+			SetNeedsDisplay ();
+
+			historyText.Clear (Text);
 		}
 
 		///<inheritdoc/>
@@ -3278,7 +3290,10 @@ namespace Terminal.Gui {
 			DoNeededAction ();
 		}
 
-		void MoveStartOfLine ()
+		/// <summary>
+		/// Moves the cursor to the start of the current line
+		/// </summary>
+		public void MoveStartOfLine ()
 		{
 			currentColumn = 0;
 			leftColumn = 0;

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -3305,7 +3305,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Moves the cursor to the start of the current line
 		/// </summary>
-		public void MoveStartOfLine ()
+		private void MoveStartOfLine ()
 		{
 			currentColumn = 0;
 			leftColumn = 0;

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -3305,7 +3305,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Moves the cursor to the start of the current line
 		/// </summary>
-		private void MoveStartOfLine ()
+		void MoveStartOfLine ()
 		{
 			currentColumn = 0;
 			leftColumn = 0;

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1458,7 +1458,7 @@ namespace Terminal.Gui {
 
 
 		/// <summary>
-		/// Appends <paramref name="toAppend"/> to <see cref="Text"/> optional 
+		/// Appends <paramref name="toAppend"/> to <see cref="Text"/> optionally 
 		/// preserving the current selection
 		/// </summary>
 		/// <param name="resetCursorPosition">true to clear currently selected text (if any) and jump to 0,0.  False to retain current selection</param>

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -3303,7 +3303,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Moves the cursor to the start of the current line
+		/// Moves the cursor to the start of the current line.
 		/// </summary>
 		void MoveStartOfLine ()
 		{

--- a/UICatalog/Scenarios/AutoScrollingChat.cs
+++ b/UICatalog/Scenarios/AutoScrollingChat.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using Terminal.Gui;
+using System.Linq;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using NStack;
+using System.Text.RegularExpressions;
+using Terminal.Gui.Graphs;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UICatalog.Scenarios {
+
+	[ScenarioMetadata (Name: "Auto Scrolling Text", Description: "Demonstrates async update and auto scrolling.")]
+	[ScenarioCategory ("Controls")]
+	[ScenarioCategory ("Text and Formatting")]
+	public class AutoScrollingChat : Scenario 
+	{
+        const string Words = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum";
+		const string Users = "Bot232 Frank Mary Harley";
+		private TextView textView;
+
+		CancellationTokenSource cts = new CancellationTokenSource();
+
+
+		public override void Setup ()
+		{
+			Win.Title = this.GetName();
+			textView = new TextView {
+				Width = Dim.Fill(),
+				Height = Dim.Fill(2),
+				ReadOnly = true
+			};
+			
+			var line = new LineView(Orientation.Horizontal){
+				Y = Pos.AnchorEnd(2)
+			};
+
+			Win.Add(textView);
+			Win.Add(line);
+
+			var textfield = new TextField(){
+				Y = Pos.AnchorEnd(1),
+				Width = Dim.Fill(),
+				X = 10
+			};
+
+			// when user presses enter in text box
+			textfield.KeyPress += (e)=>
+			{
+				if(e.KeyEvent.Key == Key.Enter){
+					// post the chat message
+					AddChatEntry("You",textfield.Text.ToString());
+					textfield.Text = "";
+					GoToEndOfTextView();
+					e.Handled = true;
+				}
+			};
+
+			var lbl = new Label("Message:"){
+				Y = Pos.AnchorEnd(1),
+				Width = Dim.Fill(),
+				X = 0
+			};
+			Win.Add(lbl);
+			Win.Add(textfield);
+
+			// start generating async chat messages
+			Task.Run(GenerateChatLogs);
+
+			// when view is closed, stop generating text messages
+			Win.Closing += (e)=>cts.Cancel();
+		}
+
+		private void GenerateChatLogs()
+		{
+			while(!cts.IsCancellationRequested)
+			{
+				AddChatEntry(GetRandomUser(),GetRandomSentence());
+				Task.Delay(2000,cts.Token).Wait(cts.Token);
+			}
+		}
+
+		private void AddChatEntry (string user, string sentence)
+		{
+			// schedule on the UI thread
+			Application.MainLoop.Invoke(
+				()=>
+				{
+					// autoscroll unless the user has manually scrolled up to look at history
+					var autoscroll =
+					 textView.CurrentRow >= textView.Lines-1;
+
+					// append the chat log
+					textView.SetText(textView.Text + $"\n{user}: {sentence}",false);
+										
+					if(autoscroll)
+					{
+						GoToEndOfTextView();
+					}
+				}
+			);
+		}
+
+		private void GoToEndOfTextView ()
+		{			
+			textView.MoveEnd();
+			textView.MoveStartOfLine();
+		}
+
+		private string GetRandomSentence ()
+		{
+			var r = new Random();
+			var words = Words.Split(' ');
+
+			var sentenceLength = r.Next(60);
+			var sentence = new StringBuilder();
+
+			for(int i=0 ;i <sentenceLength;i++)
+			{
+				sentence.Append(words[r.Next(words.Length)] + " ");
+			}
+
+			return sentence.ToString().TrimEnd();
+		}
+
+		private string GetRandomUser ()
+		{
+			var r = new Random();
+			var u = Users.Split(' ');
+			return u[r.Next(u.Length)];
+		}
+	}
+}

--- a/UICatalog/Scenarios/AutoScrollingChat.cs
+++ b/UICatalog/Scenarios/AutoScrollingChat.cs
@@ -17,6 +17,7 @@ namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "Auto Scrolling Text", Description: "Demonstrates async update and auto scrolling.")]
 	[ScenarioCategory ("Controls")]
 	[ScenarioCategory ("Text and Formatting")]
+	[ScenarioCategory ("TextView")]
 	public class AutoScrollingChat : Scenario 
 	{
         const string Words = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum";

--- a/UICatalog/Scenarios/AutoScrollingChat.cs
+++ b/UICatalog/Scenarios/AutoScrollingChat.cs
@@ -107,8 +107,8 @@ namespace UICatalog.Scenarios {
 
 		private void GoToEndOfTextView ()
 		{			
-			textView.MoveEnd();
-			textView.MoveStartOfLine();
+			textView.DoCommand(Command.BottomEnd);
+			textView.DoCommand(Command.StartOfLine);
 		}
 
 		private string GetRandomSentence ()

--- a/UICatalog/Scenarios/AutoScrollingChat.cs
+++ b/UICatalog/Scenarios/AutoScrollingChat.cs
@@ -95,7 +95,7 @@ namespace UICatalog.Scenarios {
 					 textView.CurrentRow >= textView.Lines-1;
 
 					// append the chat log
-					textView.SetText(textView.Text + $"\n{user}: {sentence}",false);
+					textView.AppendText($"\n{user}: {sentence}",false);
 										
 					if(autoscroll)
 					{

--- a/UnitTests/TextViewTests.cs
+++ b/UnitTests/TextViewTests.cs
@@ -5707,5 +5707,32 @@ line.
 			});
 			Assert.Null (exception);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void TestAppendText()
+		{
+			var tv = new TextView{
+				Width = 100,
+				Height = 100,
+				Text = "I've got a lovely bunch of coconuts"
+			};
+
+			tv.SelectAll();
+			Assert.Equal(0,tv.SelectionStartColumn);
+			Assert.Equal(0,tv.SelectionStartRow);
+			Assert.Equal(35,tv.SelectedLength);
+			Assert.Equal("I've got a lovely bunch of coconuts",tv.SelectedText.ToString());
+
+			tv.AppendText(". Here they are sitting in a row",false);
+
+			// Text should be appended
+			Assert.Equal("I've got a lovely bunch of coconuts. Here they are sitting in a row",tv.Text.ToString());
+
+			// but selection should be retained
+			Assert.Equal(0,tv.SelectionStartColumn);
+			Assert.Equal(0,tv.SelectionStartRow);
+			Assert.Equal(35,tv.SelectedLength);
+			Assert.Equal("I've got a lovely bunch of coconuts",tv.SelectedText.ToString());
+		}
 	}
 }

--- a/UnitTests/TextViewTests.cs
+++ b/UnitTests/TextViewTests.cs
@@ -5709,7 +5709,7 @@ line.
 		}
 
 		[Fact, AutoInitShutdown]
-		public void TestAppendText()
+		public void TestAppendText_PreserveSelection()
 		{
 			var tv = new TextView{
 				Width = 100,
@@ -5733,6 +5733,33 @@ line.
 			Assert.Equal(0,tv.SelectionStartRow);
 			Assert.Equal(35,tv.SelectedLength);
 			Assert.Equal("I've got a lovely bunch of coconuts",tv.SelectedText.ToString());
+		}
+
+		[Fact, AutoInitShutdown]
+		public void TestAppendText_ResetSelection()
+		{
+			var tv = new TextView{
+				Width = 100,
+				Height = 100,
+				Text = "I've got a lovely bunch of coconuts"
+			};
+
+			tv.SelectAll();
+			Assert.Equal(0,tv.SelectionStartColumn);
+			Assert.Equal(0,tv.SelectionStartRow);
+			Assert.Equal(35,tv.SelectedLength);
+			Assert.Equal("I've got a lovely bunch of coconuts",tv.SelectedText.ToString());
+
+			tv.AppendText(". Here they are sitting in a row",true);
+
+			// Text should be appended
+			Assert.Equal("I've got a lovely bunch of coconuts. Here they are sitting in a row",tv.Text.ToString());
+
+			// and selection reset
+			Assert.Equal(0,tv.SelectionStartColumn);
+			Assert.Equal(0,tv.SelectionStartRow);
+			Assert.Equal(0,tv.SelectedLength);
+			Assert.True(string.IsNullOrEmpty(tv.SelectedText.ToString()));
 		}
 	}
 }


### PR DESCRIPTION
I've opened this PR to explore the best way to enable an 'auto scrolling' log style view.  The two problems I encountered implementing the scenario were:

- When updating the `Text` the cursor position is reset to 0
- There doesn't seem to be a way to scroll to easily reposition the cursor (e.g. to the first Column of the last Row) 

![chat](https://user-images.githubusercontent.com/31306100/175807244-51dd6b92-f6cc-4b7b-8cfa-2b7ff36fc034.gif)

I am a little nervous about my changes to `TextView` so am creating this as a draft.  I did think that instead of adding `void SetText(ustring value, bool resetCursorPosition=true)`  we could have a bool flag e.g. `PreserveSelectionWhenChangingText`.  Also I'm not sure if this could result in unstable behaviour if clearing text etc (could result in invalid selections).

Or if there is a way to achieve this same effect without making any changes to `TextView` that would be ideal.