### PR TITLE
Fixes #1953. TextView cursor position is not updating by mouse.

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -2332,15 +2332,15 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Invoke the <see cref="UnwrappedCursorPosition"/> event with the unwrapped <see cref="CursorPosition"/>.
 		/// </summary>
-		public virtual void OnUnwrappedCursorPosition ()
+		public virtual void OnUnwrappedCursorPosition (int? cRow = null, int? cCol = null)
 		{
-			var row = currentRow;
-			var col = currentColumn;
-			if (wordWrap) {
+			var row = cRow == null ? currentRow : cRow;
+			var col = cCol == null ? currentColumn : cCol;
+			if (cRow == null && cCol == null && wordWrap) {
 				row = wrapManager.GetModelLineFromWrappedLines (currentRow);
 				col = wrapManager.GetModelColFromWrappedLines (currentRow, currentColumn);
 			}
-			UnwrappedCursorPosition?.Invoke (new Point (col, row));
+			UnwrappedCursorPosition?.Invoke (new Point ((int)col, (int)row));
 		}
 
 		ustring GetSelectedRegion ()
@@ -2357,7 +2357,7 @@ namespace Terminal.Gui {
 				startCol = wrapManager.GetModelColFromWrappedLines (selectionStartRow, selectionStartColumn);
 				model = wrapManager.Model;
 			}
-			UnwrappedCursorPosition?.Invoke (new Point (cCol, cRow));
+			OnUnwrappedCursorPosition (cRow, cCol);
 			return GetRegion (startRow, startCol, cRow, cCol, model);
 		}
 

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -2357,6 +2357,7 @@ namespace Terminal.Gui {
 				startCol = wrapManager.GetModelColFromWrappedLines (selectionStartRow, selectionStartColumn);
 				model = wrapManager.Model;
 			}
+			UnwrappedCursorPosition?.Invoke (new Point (cCol, cRow));
 			return GetRegion (startRow, startCol, cRow, cCol, model);
 		}
 

--- a/UnitTests/TextViewTests.cs
+++ b/UnitTests/TextViewTests.cs
@@ -6024,6 +6024,25 @@ secon
 d    
 line.
 ", output);
+
+			Assert.True (tv.MouseEvent (new MouseEvent () { X = 0, Y = 3, Flags = MouseFlags.Button1Pressed }));
+			tv.Redraw (tv.Bounds);
+			Assert.Equal (new Point (0, 3), tv.CursorPosition);
+			Assert.Equal (new Point (12, 0), cp);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+This 
+is   
+the  
+first
+     
+line.
+This 
+is   
+the  
+secon
+d    
+line.
+", output);
 		}
 	}
 }


### PR DESCRIPTION
![textview-mouse-cursor-position-fix](https://user-images.githubusercontent.com/13117724/184414189-b8032c34-987d-40fa-9aff-5d763b573196.gif)
