### PR TITLE
Fixes #1959. GoToEnd should not fail on an empty TreeView

### DIFF
--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -907,7 +907,7 @@ namespace Terminal.Gui {
 		{
 			var map = BuildLineMap ();
 			ScrollOffsetVertical = Math.Max (0, map.Count - Bounds.Height + 1);
-			SelectedObject = map.Last ().Model;
+			SelectedObject = map.LastOrDefault ()?.Model;
 
 			SetNeedsDisplay ();
 		}

--- a/UnitTests/TreeViewTests.cs
+++ b/UnitTests/TreeViewTests.cs
@@ -543,6 +543,15 @@ namespace Terminal.Gui.Views {
 			Assert.Equal (1, tree.ScrollOffsetVertical);
 		}
 
+		[Fact]
+		public void GoToEnd_ShouldNotFailOnEmptyTreeView ()
+		{
+			var tree = new TreeView ();
+
+			var exception = Record.Exception (() => tree.GoToEnd ());
+
+			Assert.Null (exception);
+		}
 
 		[Fact]
 		public void ObjectActivated_CustomKey ()


### PR DESCRIPTION
Fixes #1959  - GoToEnd should not fail on an empty TreeView

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
