### PR TITLE
Fixes #1963. Only remove one character on backspace when wordwrap is on

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -3760,9 +3760,12 @@ namespace Terminal.Gui {
 
 				historyText.Add (new List<List<Rune>> () { new List<Rune> (currentLine) }, CursorPosition);
 
-				currentLine.RemoveAt (currentColumn - 1);
-				if (wordWrap && wrapManager.RemoveAt (currentRow, currentColumn - 1)) {
-					wrapNeeded = true;
+				if (wordWrap) {
+					if (wrapManager.RemoveAt (currentRow, currentColumn - 1)) {
+						wrapNeeded = true;
+					}
+				} else {
+					currentLine.RemoveAt (currentColumn - 1);
 				}
 				currentColumn--;
 


### PR DESCRIPTION
Fixes #1963 check if word wrap is enabled before removing the character from the model. If its enabled, use the wrap manager instead.
