### PR TITLE
Fixes #1961 Null reference in Keybindings Scenario and hotkey collision

### DIFF
--- a/UICatalog/KeyBindingsDialog.cs
+++ b/UICatalog/KeyBindingsDialog.cs
@@ -132,7 +132,7 @@ namespace UICatalog {
 				Width = Dim.Percent (50),
 				Height = Dim.Percent (100) - 1,
 			};
-			commandsListView.SelectedItemChanged += CommandsListView_SelectedItemChanged;
+
 			Add (commandsListView);
 
 			keyLabel = new Label () {
@@ -143,7 +143,7 @@ namespace UICatalog {
 			};
 			Add (keyLabel);
 
-			var btnChange = new Button ("Change") {
+			var btnChange = new Button ("Ch_ange") {
 				X = Pos.Percent (50),
 				Y = 1,
 			};
@@ -160,6 +160,13 @@ namespace UICatalog {
 			var cancel = new Button ("Cancel");
 			cancel.Clicked += ()=>Application.RequestStop();
 			AddButton (cancel);
+
+			// Register event handler as the last thing in constructor to prevent early calls
+			// before it is even shown (e.g. OnEnter)
+			commandsListView.SelectedItemChanged += CommandsListView_SelectedItemChanged;
+
+			// Setup to show first ListView entry
+			SetTextBoxToShowBinding (commands.First());
 		}
 
 		private void RemapKey ()


### PR DESCRIPTION
Fixes #1961- Fixes null reference caused by OnEnter event procing SelectedItemChanged before view was finished loading

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

![l-for-down](https://user-images.githubusercontent.com/31306100/186620824-132ccf93-a963-46cd-8fd0-272ec365b5ef.gif)
_Switching the 'down' command to `l` instead of cursor down_

Ensures:
- When opening the keybindings window the first entry is correctly displayed
- No null reference occurs
- Alt + 'a' is now the hotkey for Change instead of 'c' which collides with the Cancel button

When I ran `CTRL-K-D` I get a lot of whitespace changes so didn't commit it.  Let me know if you want those rolled into this commit or if it is possible to do a different PR where we do that reformat for all the files in the solution? Or if it doesn't matter at all.