### PR TITLE
Fixes #1800. TextView now uses the same colors as TextField.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -2971,8 +2971,9 @@ namespace Terminal.Gui {
 		/// Determines the current <see cref="ColorScheme"/> based on the <see cref="Enabled"/> value.
 		/// </summary>
 		/// <returns><see cref="ColorScheme.Normal"/> if <see cref="Enabled"/> is <see langword="true"/>
-		/// or <see cref="ColorScheme.Disabled"/> if <see cref="Enabled"/> is <see langword="false"/></returns>
-		public Attribute GetNormalColor ()
+		/// or <see cref="ColorScheme.Disabled"/> if <see cref="Enabled"/> is <see langword="false"/>.
+		/// If it's overridden can return other values.</returns>
+		public virtual Attribute GetNormalColor ()
 		{
 			return Enabled ? ColorScheme.Normal : ColorScheme.Disabled;
 		}

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -412,7 +412,7 @@ namespace Terminal.Gui {
 			var selColor = new Attribute (ColorScheme.Focus.Background, ColorScheme.Focus.Foreground);
 			SetSelectedStartSelectedLength ();
 
-			Driver.SetAttribute (ColorScheme.Focus);
+			Driver.SetAttribute (GetNormalColor ());
 			Move (0, 0);
 
 			int p = first;
@@ -462,6 +462,12 @@ namespace Terminal.Gui {
 				CursorPosition - ScrollOffset, 0);
 
 			Autocomplete.RenderOverlay (renderAt);
+		}
+
+		/// <inheritdoc/>
+		public override Attribute GetNormalColor ()
+		{
+			return Enabled ? ColorScheme.Focus : ColorScheme.Disabled;
 		}
 
 		Attribute GetReadOnlyColor ()

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1936,7 +1936,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Sets the driver to the default color for the control where no text is being rendered.  Defaults to <see cref="ColorScheme.Normal"/>.
 		/// </summary>
-		protected virtual void ColorNormal ()
+		protected virtual void SetNormalColor ()
 		{
 			Driver.SetAttribute (GetNormalColor ());
 		}
@@ -1948,7 +1948,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="line"></param>
 		/// <param name="idx"></param>
-		protected virtual void ColorNormal (List<Rune> line, int idx)
+		protected virtual void SetNormalColor (List<Rune> line, int idx)
 		{
 			Driver.SetAttribute (GetNormalColor ());
 		}
@@ -1960,7 +1960,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="line"></param>
 		/// <param name="idx"></param>
-		protected virtual void ColorSelection (List<Rune> line, int idx)
+		protected virtual void SetSelectionColor (List<Rune> line, int idx)
 		{
 			Driver.SetAttribute (new Attribute (ColorScheme.Focus.Background, ColorScheme.Focus.Foreground));
 		}
@@ -1972,7 +1972,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="line"></param>
 		/// <param name="idx"></param>
-		protected virtual void ColorReadOnly (List<Rune> line, int idx)
+		protected virtual void SetReadOnlyColor (List<Rune> line, int idx)
 		{
 			Attribute attribute;
 			if (ColorScheme.Disabled.Foreground == ColorScheme.Focus.Background) {
@@ -1990,7 +1990,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="line"></param>
 		/// <param name="idx"></param>
-		protected virtual void ColorUsed (List<Rune> line, int idx)
+		protected virtual void SetUsedColor (List<Rune> line, int idx)
 		{
 			Driver.SetAttribute (ColorScheme.HotFocus);
 		}
@@ -2382,7 +2382,7 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override void Redraw (Rect bounds)
 		{
-			ColorNormal ();
+			SetNormalColor ();
 
 			var offB = OffSetBackground ();
 			int right = Frame.Width + offB.width + RightOffset;
@@ -2398,14 +2398,14 @@ namespace Terminal.Gui {
 					var rune = idxCol >= lineRuneCount ? ' ' : line [idxCol];
 					var cols = Rune.ColumnWidth (rune);
 					if (idxCol < line.Count && selecting && PointInSelection (idxCol, idxRow)) {
-						ColorSelection (line, idxCol);
+						SetSelectionColor (line, idxCol);
 					} else if (idxCol == currentColumn && idxRow == currentRow && !selecting && !Used
 						&& HasFocus && idxCol < lineRuneCount) {
-						ColorSelection (line, idxCol);
+						SetSelectionColor (line, idxCol);
 					} else if (ReadOnly) {
-						ColorReadOnly (line, idxCol);
+						SetReadOnlyColor (line, idxCol);
 					} else {
-						ColorNormal (line, idxCol);
+						SetNormalColor (line, idxCol);
 					}
 
 					if (rune == '\t') {
@@ -2429,13 +2429,13 @@ namespace Terminal.Gui {
 					}
 				}
 				if (col < right) {
-					ColorNormal ();
+					SetNormalColor ();
 					ClearRegion (col, row, right, row + 1);
 				}
 				row++;
 			}
 			if (row < bottom) {
-				ColorNormal ();
+				SetNormalColor ();
 				ClearRegion (bounds.Left, row, right, bottom);
 			}
 

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1962,7 +1962,25 @@ namespace Terminal.Gui {
 		/// <param name="idx"></param>
 		protected virtual void ColorSelection (List<Rune> line, int idx)
 		{
-			Driver.SetAttribute (ColorScheme.Focus);
+			Driver.SetAttribute (new Attribute (ColorScheme.Focus.Background, ColorScheme.Focus.Foreground));
+		}
+
+		/// <summary>
+		/// Sets the <see cref="View.Driver"/> to an appropriate color for rendering the given <paramref name="idx"/> of the
+		/// current <paramref name="line"/>.  Override to provide custom coloring by calling <see cref="ConsoleDriver.SetAttribute(Attribute)"/>
+		/// Defaults to <see cref="ColorScheme.Focus"/>.
+		/// </summary>
+		/// <param name="line"></param>
+		/// <param name="idx"></param>
+		protected virtual void ColorReadOnly (List<Rune> line, int idx)
+		{
+			Attribute attribute;
+			if (ColorScheme.Disabled.Foreground == ColorScheme.Focus.Background) {
+				attribute = new Attribute (ColorScheme.Focus.Foreground, ColorScheme.Focus.Background);
+			} else {
+				attribute = new Attribute (ColorScheme.Disabled.Foreground, ColorScheme.Focus.Background);
+			}
+			Driver.SetAttribute (attribute);
 		}
 
 		/// <summary>
@@ -2383,7 +2401,9 @@ namespace Terminal.Gui {
 						ColorSelection (line, idxCol);
 					} else if (idxCol == currentColumn && idxRow == currentRow && !selecting && !Used
 						&& HasFocus && idxCol < lineRuneCount) {
-						ColorUsed (line, idxCol);
+						ColorSelection (line, idxCol);
+					} else if (ReadOnly) {
+						ColorReadOnly (line, idxCol);
 					} else {
 						ColorNormal (line, idxCol);
 					}
@@ -2434,6 +2454,12 @@ namespace Terminal.Gui {
 					: 0);
 
 			Autocomplete.RenderOverlay (renderAt);
+		}
+
+		/// <inheritdoc/>
+		public override Attribute GetNormalColor ()
+		{
+			return Enabled ? ColorScheme.Focus : ColorScheme.Disabled;
 		}
 
 		///<inheritdoc/>

--- a/Terminal.Gui/Windows/Wizard.cs
+++ b/Terminal.Gui/Windows/Wizard.cs
@@ -203,11 +203,6 @@ namespace Terminal.Gui {
 
 				base.Add (contentView);
 
-				helpTextView.ColorScheme = new ColorScheme () {  
-					Normal = new Attribute(Color.Gray, Color.DarkGray),
-					Focus = new Attribute(Color.DarkGray, Color.Gray),
-					HotFocus = new Attribute(Color.White, Color.DarkGray)
-				};
 				helpTextView.ReadOnly = true;
 				helpTextView.WordWrap = true;
 				base.Add (helpTextView);

--- a/UICatalog/Scenarios/AutoSizeAndDirectionText.cs
+++ b/UICatalog/Scenarios/AutoSizeAndDirectionText.cs
@@ -33,7 +33,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.Center (),
 				Width = 20,
 				Height = 5,
-				ColorScheme = color,
 				Text = text
 			};
 

--- a/UICatalog/Scenarios/BordersComparisons.cs
+++ b/UICatalog/Scenarios/BordersComparisons.cs
@@ -46,7 +46,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.AnchorEnd (2),
 				Width = 10,
 				Height = Dim.Fill (),
-				ColorScheme = Colors.Dialog,
 				Text = "1234567890"
 			};
 			var tf2 = new TextField ("1234567890") {
@@ -86,7 +85,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.AnchorEnd (2),
 				Width = 10,
 				Height = Dim.Fill (),
-				ColorScheme = Colors.Dialog,
 				Text = "1234567890"
 			};
 			var tf4 = new TextField ("1234567890") {
@@ -123,7 +121,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.AnchorEnd (2),
 				Width = 10,
 				Height = Dim.Fill (),
-				ColorScheme = Colors.Dialog,
 				Text = "1234567890"
 			};
 			var tf6 = new TextField ("1234567890") {

--- a/UICatalog/Scenarios/BordersOnFrameView.cs
+++ b/UICatalog/Scenarios/BordersOnFrameView.cs
@@ -56,7 +56,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.AnchorEnd (2),
 				Width = 10,
 				Height = Dim.Fill (),
-				ColorScheme = Colors.Dialog,
 				Text = "1234567890"
 			};
 			smartView.Add (tf1, button, label, tf2, tv);

--- a/UICatalog/Scenarios/BordersOnToplevel.cs
+++ b/UICatalog/Scenarios/BordersOnToplevel.cs
@@ -56,7 +56,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.AnchorEnd (2),
 				Width = 10,
 				Height = Dim.Fill (),
-				ColorScheme = Colors.Dialog,
 				Text = "1234567890"
 			};
 			smartView.Add (tf1, button, label, tf2, tv);

--- a/UICatalog/Scenarios/BordersOnWindow.cs
+++ b/UICatalog/Scenarios/BordersOnWindow.cs
@@ -56,7 +56,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.AnchorEnd (2),
 				Width = 10,
 				Height = Dim.Fill (),
-				ColorScheme = Colors.Dialog,
 				Text = "1234567890"
 			};
 			smartView.Add (tf1, button, label, tf2, tv);

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -681,7 +681,6 @@ namespace UICatalog.Scenarios {
 				Add (_lblAction);
 
 				_txtAction = new TextView () {
-					ColorScheme = Colors.Dialog,
 					X = Pos.Left (_txtTitle),
 					Y = Pos.Top (_lblAction),
 					Width = Dim.Fill (),

--- a/UICatalog/Scenarios/DynamicStatusBar.cs
+++ b/UICatalog/Scenarios/DynamicStatusBar.cs
@@ -383,7 +383,6 @@ namespace UICatalog.Scenarios {
 				Add (_lblAction);
 
 				_txtAction = new TextView () {
-					ColorScheme = Colors.Dialog,
 					X = Pos.Left (_txtTitle),
 					Y = Pos.Top (_lblAction),
 					Width = Dim.Fill (),

--- a/UICatalog/Scenarios/MessageBoxes.cs
+++ b/UICatalog/Scenarios/MessageBoxes.cs
@@ -90,7 +90,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.Top (label),
 				Width = Dim.Fill (),
 				Height = 5,
-				ColorScheme = Colors.Dialog,
 			};
 			frame.Add (messageEdit);
 

--- a/UICatalog/Scenarios/SyntaxHighlighting.cs
+++ b/UICatalog/Scenarios/SyntaxHighlighting.cs
@@ -38,7 +38,7 @@ namespace UICatalog.Scenarios {
 				Height = Dim.Fill (1),
 			};
 
-			textView.Init();
+			textView.Init ();
 
 			textView.Text = "SELECT TOP 100 * \nfrom\n MyDb.dbo.Biochemistry;";
 
@@ -63,49 +63,49 @@ namespace UICatalog.Scenarios {
 			Application.RequestStop ();
 		}
 
-		private class SqlTextView : TextView{
+		private class SqlTextView : TextView {
 
-			private HashSet<string> keywords = new HashSet<string>(StringComparer.CurrentCultureIgnoreCase);
+			private HashSet<string> keywords = new HashSet<string> (StringComparer.CurrentCultureIgnoreCase);
 			private Attribute blue;
 			private Attribute white;
 			private Attribute magenta;
 
 
-		public void Init()
+			public void Init ()
 			{
-				keywords.Add("select");
-				keywords.Add("distinct");
-				keywords.Add("top");
-				keywords.Add("from");
-				keywords.Add("create");
-				keywords.Add("CIPHER");
-				keywords.Add("CLASS_ORIGIN");
-				keywords.Add("CLIENT");
-				keywords.Add("CLOSE");
-				keywords.Add("COALESCE");
-				keywords.Add("CODE");
-				keywords.Add("COLUMNS");
-				keywords.Add("COLUMN_FORMAT");
-				keywords.Add("COLUMN_NAME");
-				keywords.Add("COMMENT");
-				keywords.Add("COMMIT");
-				keywords.Add("COMPACT");
-				keywords.Add("COMPLETION");
-				keywords.Add("COMPRESSED");
-				keywords.Add("COMPRESSION");
-				keywords.Add("CONCURRENT");
-				keywords.Add("CONNECT");
-				keywords.Add("CONNECTION");
-				keywords.Add("CONSISTENT");
-				keywords.Add("CONSTRAINT_CATALOG");
-				keywords.Add("CONSTRAINT_SCHEMA");
-				keywords.Add("CONSTRAINT_NAME");
-				keywords.Add("CONTAINS");
-				keywords.Add("CONTEXT");
-				keywords.Add("CONTRIBUTORS");
-				keywords.Add("COPY");
-				keywords.Add("CPU");
-				keywords.Add("CURSOR_NAME");
+				keywords.Add ("select");
+				keywords.Add ("distinct");
+				keywords.Add ("top");
+				keywords.Add ("from");
+				keywords.Add ("create");
+				keywords.Add ("CIPHER");
+				keywords.Add ("CLASS_ORIGIN");
+				keywords.Add ("CLIENT");
+				keywords.Add ("CLOSE");
+				keywords.Add ("COALESCE");
+				keywords.Add ("CODE");
+				keywords.Add ("COLUMNS");
+				keywords.Add ("COLUMN_FORMAT");
+				keywords.Add ("COLUMN_NAME");
+				keywords.Add ("COMMENT");
+				keywords.Add ("COMMIT");
+				keywords.Add ("COMPACT");
+				keywords.Add ("COMPLETION");
+				keywords.Add ("COMPRESSED");
+				keywords.Add ("COMPRESSION");
+				keywords.Add ("CONCURRENT");
+				keywords.Add ("CONNECT");
+				keywords.Add ("CONNECTION");
+				keywords.Add ("CONSISTENT");
+				keywords.Add ("CONSTRAINT_CATALOG");
+				keywords.Add ("CONSTRAINT_SCHEMA");
+				keywords.Add ("CONSTRAINT_NAME");
+				keywords.Add ("CONTAINS");
+				keywords.Add ("CONTEXT");
+				keywords.Add ("CONTRIBUTORS");
+				keywords.Add ("COPY");
+				keywords.Add ("CPU");
+				keywords.Add ("CURSOR_NAME");
 				keywords.Add ("primary");
 				keywords.Add ("key");
 				keywords.Add ("insert");
@@ -138,29 +138,26 @@ namespace UICatalog.Scenarios {
 				keywords.Add ("union");
 				keywords.Add ("exists");
 
-				Autocomplete.AllSuggestions = keywords.ToList();
+				Autocomplete.AllSuggestions = keywords.ToList ();
 
 				magenta = Driver.MakeAttribute (Color.Magenta, Color.Black);
 				blue = Driver.MakeAttribute (Color.Cyan, Color.Black);
 				white = Driver.MakeAttribute (Color.White, Color.Black);
 			}
 
-			protected override void ColorNormal ()
+			protected override void SetNormalColor ()
 			{
 				Driver.SetAttribute (white);
 			}
 
-			protected override void ColorNormal (List<System.Rune> line, int idx)
+			protected override void SetNormalColor (List<System.Rune> line, int idx)
 			{
-				if(IsInStringLiteral(line,idx)) {
+				if (IsInStringLiteral (line, idx)) {
 					Driver.SetAttribute (magenta);
-				}
-				else
-				if(IsKeyword(line,idx))
-				{
+				} else
+				if (IsKeyword (line, idx)) {
 					Driver.SetAttribute (blue);
-				}
-				else{
+				} else {
 					Driver.SetAttribute (white);
 				}
 			}
@@ -168,9 +165,9 @@ namespace UICatalog.Scenarios {
 			private bool IsInStringLiteral (List<System.Rune> line, int idx)
 			{
 				string strLine = new string (line.Select (r => (char)r).ToArray ());
-				
-				foreach(Match m in Regex.Matches(strLine, "'[^']*'")) {
-					if(idx >= m.Index && idx < m.Index+m.Length) {
+
+				foreach (Match m in Regex.Matches (strLine, "'[^']*'")) {
+					if (idx >= m.Index && idx < m.Index + m.Length) {
 						return true;
 					}
 				}
@@ -178,37 +175,36 @@ namespace UICatalog.Scenarios {
 				return false;
 			}
 
-			private bool IsKeyword(List<System.Rune> line, int idx)
+			private bool IsKeyword (List<System.Rune> line, int idx)
 			{
-				var word = IdxToWord(line,idx);
-				
-				if(string.IsNullOrWhiteSpace(word)){
+				var word = IdxToWord (line, idx);
+
+				if (string.IsNullOrWhiteSpace (word)) {
 					return false;
 				}
 
-				return keywords.Contains(word,StringComparer.CurrentCultureIgnoreCase);
+				return keywords.Contains (word, StringComparer.CurrentCultureIgnoreCase);
 			}
 
-			private string IdxToWord(List<System.Rune> line, int idx)
+			private string IdxToWord (List<System.Rune> line, int idx)
 			{
-				var words = Regex.Split(
-					new string(line.Select(r=>(char)r).ToArray()),
+				var words = Regex.Split (
+					new string (line.Select (r => (char)r).ToArray ()),
 					"\\b");
 
 
 				int count = 0;
 				string current = null;
 
-				foreach(var word in words)
-				{
+				foreach (var word in words) {
 					current = word;
-					count+= word.Length;
-					if(count > idx){
+					count += word.Length;
+					if (count > idx) {
 						break;
 					}
 				}
 
-				return current?.Trim();
+				return current?.Trim ();
 			}
 		}
 	}

--- a/UICatalog/Scenarios/Text.cs
+++ b/UICatalog/Scenarios/Text.cs
@@ -49,7 +49,6 @@ namespace UICatalog.Scenarios {
 				Y = 3,
 				Width = Dim.Percent (50),
 				Height = Dim.Percent (30),
-				ColorScheme = Colors.Dialog
 			};
 			textView.Text = s;
 			textView.DrawContent += TextView_DrawContent;

--- a/UICatalog/Scenarios/TextAlignmentsAndDirection.cs
+++ b/UICatalog/Scenarios/TextAlignmentsAndDirection.cs
@@ -105,7 +105,7 @@ namespace UICatalog.Scenarios {
 				Y = Pos.Bottom (container) + 1,
 				Width = Dim.Fill (10),
 				Height = Dim.Fill (1),
-				ColorScheme = color2,
+				ColorScheme = Colors.TopLevel,
 				Text = txt
 			};
 

--- a/UICatalog/Scenarios/TextViewAutocompletePopup.cs
+++ b/UICatalog/Scenarios/TextViewAutocompletePopup.cs
@@ -24,7 +24,6 @@ namespace UICatalog.Scenarios {
 		{
 			Win.Title = GetName ();
 			var width = 20;
-			var colorScheme = Colors.Dialog;
 			var text = " jamp jemp jimp jomp jump";
 
 			var menu = new MenuBar (new MenuBarItem [] {
@@ -39,7 +38,6 @@ namespace UICatalog.Scenarios {
 			textViewTopLeft = new TextView () {
 				Width = width,
 				Height = height,
-				ColorScheme = colorScheme,
 				Text = text
 			};
 			textViewTopLeft.DrawContent += TextViewTopLeft_DrawContent;
@@ -49,7 +47,6 @@ namespace UICatalog.Scenarios {
 				X = Pos.AnchorEnd (width),
 				Width = width,
 				Height = height,
-				ColorScheme = colorScheme,
 				Text = text
 			};
 			textViewTopRight.DrawContent += TextViewTopRight_DrawContent;
@@ -59,7 +56,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.AnchorEnd (height),
 				Width = width,
 				Height = height,
-				ColorScheme = colorScheme,
 				Text = text
 			};
 			textViewBottomLeft.DrawContent += TextViewBottomLeft_DrawContent;
@@ -70,7 +66,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.AnchorEnd (height),
 				Width = width,
 				Height = height,
-				ColorScheme = colorScheme,
 				Text = text
 			};
 			textViewBottomRight.DrawContent += TextViewBottomRight_DrawContent;
@@ -81,7 +76,6 @@ namespace UICatalog.Scenarios {
 				Y = Pos.Center (),
 				Width = width,
 				Height = height,
-				ColorScheme = colorScheme,
 				Text = text
 			};
 			textViewCentered.DrawContent += TextViewCentered_DrawContent;

--- a/UICatalog/Scenarios/Wizards.cs
+++ b/UICatalog/Scenarios/Wizards.cs
@@ -217,6 +217,7 @@ namespace UICatalog.Scenarios {
 						Height = Dim.Fill (1),
 						WordWrap = true,
 						AllowsTab = false,
+						ColorScheme = Colors.Base
 					};
 					var help = "This is helpful.";
 					fourthStep.Add (someText);


### PR DESCRIPTION
Fixes #1800.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
