### PR TITLE
Fixes #1979. MessageBox.Query not wrapping since 1.7.1

### DIFF
--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -284,6 +284,7 @@ namespace Terminal.Gui {
 				l.Y = Pos.Center ();
 				l.Width = Dim.Fill (2);
 				l.Height = Dim.Fill (1);
+				l.AutoSize = false;
 				d.Add (l);
 			}
 


### PR DESCRIPTION
Fixes #1979 - By default a Label view has the `AutoSize` property enabled. So, to fix this issue it must be set to `false`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working


![imagem](https://user-images.githubusercontent.com/13117724/187963890-65d1e511-959c-4a7a-bca3-0de923f1f614.png)
