### PR TITLE
Fixes #1981. Added SplitNewLine method to the TextFormatter.

### DIFF
--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -417,6 +417,50 @@ namespace Terminal.Gui {
 			return ustring.Make (runes);
 		}
 
+		/// <summary>
+		/// Splits all newlines in the <paramref name="text"/> into a list
+		/// and supports both CRLF and LF, preserving the ending newline.
+		/// </summary>
+		/// <param name="text">The text.</param>
+		/// <returns>A list of text without the newline characters.</returns>
+		public static List<ustring> SplitNewLine (ustring text)
+		{
+			var runes = text.ToRuneList ();
+			var lines = new List<ustring> ();
+			var start = 0;
+			var end = 0;
+
+			for (int i = 0; i < runes.Count; i++) {
+				end = i;
+				switch (runes [i]) {
+				case '\n':
+					lines.Add (ustring.Make (runes.GetRange (start, end - start)));
+					i++;
+					start = i;
+					break;
+
+				case '\r':
+					if ((i + 1) < runes.Count && runes [i + 1] == '\n') {
+						lines.Add (ustring.Make (runes.GetRange (start, end - start)));
+						i += 2;
+						start = i;
+					} else {
+						lines.Add (ustring.Make (runes.GetRange (start, end - start)));
+						i++;
+						start = i;
+					}
+					break;
+				}
+			}
+			if (runes.Count > 0 && lines.Count == 0) {
+				lines.Add (ustring.Make (runes));
+			} else if (runes.Count > 0 && start < runes.Count) {
+				lines.Add (ustring.Make (runes.GetRange (start, runes.Count - start)));
+			} else {
+				lines.Add (ustring.Make (""));
+			}
+			return lines;
+		}
 
 		/// <summary>
 		/// Adds trailing whitespace or truncates <paramref name="text"/>

--- a/UnitTests/TextFormatterTests.cs
+++ b/UnitTests/TextFormatterTests.cs
@@ -4012,5 +4012,47 @@ e
 			Assert.Equal ("Line2", formated [1]);
 			Assert.Equal ("Line3", formated [^1]);
 		}
+
+		[Fact]
+		public void SplitNewLine_Ending_Without_NewLine_Probably_CRLF ()
+		{
+			var text = $"First Line 界{Environment.NewLine}Second Line 界{Environment.NewLine}Third Line 界";
+			var splited = TextFormatter.SplitNewLine (text);
+			Assert.Equal ("First Line 界", splited [0]);
+			Assert.Equal ("Second Line 界", splited [1]);
+			Assert.Equal ("Third Line 界", splited [^1]);
+		}
+
+		[Fact]
+		public void SplitNewLine_Ending_With_NewLine_Probably_CRLF ()
+		{
+			var text = $"First Line 界{Environment.NewLine}Second Line 界{Environment.NewLine}Third Line 界{Environment.NewLine}";
+			var splited = TextFormatter.SplitNewLine (text);
+			Assert.Equal ("First Line 界", splited [0]);
+			Assert.Equal ("Second Line 界", splited [1]);
+			Assert.Equal ("Third Line 界", splited [2]);
+			Assert.Equal ("", splited [^1]);
+		}
+
+		[Fact]
+		public void SplitNewLine_Ending_Without_NewLine_Only_LF ()
+		{
+			var text = $"First Line 界\nSecond Line 界\nThird Line 界";
+			var splited = TextFormatter.SplitNewLine (text);
+			Assert.Equal ("First Line 界", splited [0]);
+			Assert.Equal ("Second Line 界", splited [1]);
+			Assert.Equal ("Third Line 界", splited [^1]);
+		}
+
+		[Fact]
+		public void SplitNewLine_Ending_With_NewLine_Only_LF ()
+		{
+			var text = $"First Line 界\nSecond Line 界\nThird Line 界\n";
+			var splited = TextFormatter.SplitNewLine (text);
+			Assert.Equal ("First Line 界", splited [0]);
+			Assert.Equal ("Second Line 界", splited [1]);
+			Assert.Equal ("Third Line 界", splited [2]);
+			Assert.Equal ("", splited [^1]);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1981- It consider CRLF and LF and preserving the ending newline.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
