### PR TITLE
Fixes #820. Added HideDropdownListOnClick property.

### DIFF
--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -108,6 +108,19 @@ namespace Terminal.Gui {
 			SetSource (source);
 		}
 
+		/// <summary>
+		/// Initialize with the source.
+		/// </summary>
+		/// <param name="source">The source.</param>
+		public ComboBox (IList source) : this (string.Empty)
+		{
+			search = new TextField ("");
+			listview = new ListView (source) { LayoutStyle = LayoutStyle.Computed, ColorScheme = Colors.Base };
+
+			Initialize ();
+			SetSource (source);
+		}
+
 		bool itemPressed;
 		bool itemClicked;
 
@@ -146,7 +159,7 @@ namespace Terminal.Gui {
 					}
 					OnOpenSelectedItem ();
 				}
-				if (searchset.Count > 0) {
+				if (!HideDropdownListOnClick && searchset.Count > 0) {
 					SetValue (searchset [listview.SelectedItem]);
 				}
 			};
@@ -223,6 +236,7 @@ namespace Terminal.Gui {
 
 		private bool isShow = false;
 		private int selectedItem = -1;
+		private int lastSelectedItem = -1;
 
 		/// <summary>
 		/// Gets the index of the currently selected item in the <see cref="Source"/>
@@ -314,6 +328,7 @@ namespace Terminal.Gui {
 		private void FocusSelectedItem ()
 		{
 			listview.SelectedItem = SelectedItem > -1 ? SelectedItem : 0;
+			lastSelectedItem = SelectedItem;
 			if (SelectedItem > -1) {
 				listview.TabStop = true;
 				listview.SetFocus ();
@@ -370,6 +385,7 @@ namespace Terminal.Gui {
 		public virtual bool OnOpenSelectedItem ()
 		{
 			var value = search.Text;
+			lastSelectedItem = SelectedItem;
 			OpenSelectedItem?.Invoke (new ListViewItemEventArgs (SelectedItem, value));
 
 			return true;
@@ -408,8 +424,15 @@ namespace Terminal.Gui {
 		bool CancelSelected ()
 		{
 			search.SetFocus ();
-			search.Text = text = "";
-			OnSelectedChanged ();
+			if (HideDropdownListOnClick) {
+				SelectedItem = lastSelectedItem;
+				if (SelectedItem > -1 && listview.Source?.Count > 0) {
+					search.Text = text = listview.Source.ToList () [SelectedItem].ToString ();
+				}
+			} else {
+				search.Text = text = "";
+				OnSelectedChanged ();
+			}
 			Collapse ();
 			return true;
 		}

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -144,6 +144,7 @@ namespace Terminal.Gui {
 						isShow = false;
 						HideList ();
 					}
+					OnOpenSelectedItem ();
 				}
 				if (searchset.Count > 0) {
 					SetValue (searchset [listview.SelectedItem]);

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -72,7 +72,7 @@ namespace Terminal.Gui {
 					return true;
 				} else if (me.Flags == MouseFlags.ReportMousePosition && HideDropdownListOnClick) {
 					if (isMousePositionValid) {
-						highlighted = Math.Min (TopItem + me.Y / itemHeight, Source.Count);
+						highlighted = Math.Min (TopItem + me.Y, Source.Count);
 						SetNeedsDisplay ();
 					}
 					isFocusing = false;
@@ -101,7 +101,7 @@ namespace Terminal.Gui {
 				int col = AllowsMarking ? 2 : 0;
 				int start = LeftItem;
 
-				for (int row = 0; row < f.Height; row += itemHeight, item++) {
+				for (int row = 0; row < f.Height; row++, item++) {
 					bool isSelected = item == container.SelectedItem;
 					bool isHighlighted = hideDropdownListOnClick && item == highlighted;
 

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -140,7 +140,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public void SetSource (IList source)
 		{
-			if (source == null)
+			if (source == null && (Source == null || !(Source is ListWrapper)))
 				Source = null;
 			else {
 				Source = MakeWrapper (source);
@@ -157,7 +157,7 @@ namespace Terminal.Gui {
 		public Task SetSourceAsync (IList source)
 		{
 			return Task.Factory.StartNew (() => {
-				if (source == null)
+				if (source == null && (Source == null || !(Source is ListWrapper)))
 					Source = null;
 				else
 					Source = MakeWrapper (source);
@@ -827,7 +827,7 @@ namespace Terminal.Gui {
 
 		int GetMaxLengthItem ()
 		{
-			if (src?.Count == 0) {
+			if (src == null || src?.Count == 0) {
 				return 0;
 			}
 
@@ -883,7 +883,7 @@ namespace Terminal.Gui {
 		public void Render (ListView container, ConsoleDriver driver, bool marked, int item, int col, int line, int width, int start = 0)
 		{
 			container.Move (col, line);
-			var t = src [item];
+			var t = src? [item];
 			if (t == null) {
 				RenderUstr (driver, ustring.Make (""), col, line, width);
 			} else {

--- a/UICatalog/Scenarios/ComboBoxIteration.cs
+++ b/UICatalog/Scenarios/ComboBoxIteration.cs
@@ -33,7 +33,8 @@ namespace UICatalog.Scenarios {
 				X = Pos.Right (listview) + 1,
 				Y = Pos.Bottom (lbListView) + 1,
 				Height = Dim.Fill (2),
-				Width = Dim.Percent (40)
+				Width = Dim.Percent (40),
+				HideDropdownListOnClick = true
 			};
 			comboBox.SetSource (items);
 

--- a/UnitTests/ComboBoxTests.cs
+++ b/UnitTests/ComboBoxTests.cs
@@ -244,11 +244,13 @@ Three
 		[Fact, AutoInitShutdown]
 		public void HideDropdownListOnClick_Gets_Sets ()
 		{
+			var selected = "";
 			var cb = new ComboBox {
 				Height = 4,
 				Width = 5
 			};
 			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
 			Application.Top.Add (cb);
 			Application.Begin (Application.Top);
 
@@ -285,6 +287,7 @@ Three
 				Y = 1,
 				Flags = MouseFlags.Button1Clicked
 			}));
+			Assert.Equal ("", selected);
 			Assert.True (cb.IsShow);
 			Assert.Equal (1, cb.SelectedItem);
 
@@ -311,6 +314,7 @@ Three
 				Y = 2,
 				Flags = MouseFlags.Button1Clicked
 			}));
+			Assert.Equal ("Three", selected);
 			Assert.False (cb.IsShow);
 			Assert.Equal (2, cb.SelectedItem);
 
@@ -343,6 +347,7 @@ Three
 				Y = 2,
 				Flags = MouseFlags.Button1Clicked
 			}));
+			Assert.Equal ("Three", selected);
 			lock (Application.MainLoop.IdleHandlers) {
 				while (cb.IsShow) {
 					Application.MainLoop.MainIteration ();

--- a/UnitTests/ComboBoxTests.cs
+++ b/UnitTests/ComboBoxTests.cs
@@ -21,18 +21,42 @@ namespace Terminal.Gui.Views {
 			Assert.Null (cb.Source);
 			Assert.False (cb.AutoSize);
 			Assert.Equal (new Rect (0, 0, 0, 2), cb.Frame);
+			Assert.Equal (-1, cb.SelectedItem);
 
 			cb = new ComboBox ("Test");
 			Assert.Equal ("Test", cb.Text);
 			Assert.Null (cb.Source);
 			Assert.False (cb.AutoSize);
 			Assert.Equal (new Rect (0, 0, 0, 2), cb.Frame);
+			Assert.Equal (-1, cb.SelectedItem);
 
 			cb = new ComboBox (new Rect (1, 2, 10, 20), new List<string> () { "One", "Two", "Three" });
 			Assert.Equal (string.Empty, cb.Text);
 			Assert.NotNull (cb.Source);
 			Assert.False (cb.AutoSize);
 			Assert.Equal (new Rect (1, 2, 10, 20), cb.Frame);
+			Assert.Equal (-1, cb.SelectedItem);
+
+			cb = new ComboBox (new List<string> () { "One", "Two", "Three" });
+			Assert.Equal (string.Empty, cb.Text);
+			Assert.NotNull (cb.Source);
+			Assert.False (cb.AutoSize);
+			Assert.Equal (new Rect (0, 0, 0, 2), cb.Frame);
+			Assert.Equal (-1, cb.SelectedItem);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void Constructor_With_Source_Initialize_With_The_Passed_SelectedItem ()
+		{
+			var cb = new ComboBox (new List<string> () { "One", "Two", "Three" }) {
+				SelectedItem = 1
+			};
+			Assert.Equal ("Two", cb.Text);
+			Assert.NotNull (cb.Source);
+			Assert.False (cb.AutoSize);
+			Assert.Equal (new Rect (0, 0, 0, 2), cb.Frame);
+			Assert.Equal (1, cb.SelectedItem);
 		}
 
 		[Fact]
@@ -355,6 +379,136 @@ Three
 			}
 			Assert.False (cb.IsShow);
 			Assert.Equal (2, cb.SelectedItem);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_True_OpenSelectedItem_With_Mouse_And_Key_And_Mouse ()
+		{
+			var selected = "";
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5,
+				HideDropdownListOnClick = true
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.True (cb.HideDropdownListOnClick);
+			Assert.False (cb.IsShow);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorUp, new KeyModifiers ())));
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_True_OpenSelectedItem_With_Mouse_And_Key_CursorDown_And_Esc ()
+		{
+			var selected = "";
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5,
+				HideDropdownListOnClick = true
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.True (cb.HideDropdownListOnClick);
+			Assert.False (cb.IsShow);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.Esc, new KeyModifiers ())));
+			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_True_OpenSelectedItem_With_Mouse_And_Key_F4 ()
+		{
+			var selected = "";
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5,
+				HideDropdownListOnClick = true
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.True (cb.HideDropdownListOnClick);
+			Assert.False (cb.IsShow);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
 		}
 	}
 }

--- a/UnitTests/ComboBoxTests.cs
+++ b/UnitTests/ComboBoxTests.cs
@@ -280,32 +280,19 @@ Three
 
 			Assert.False (cb.HideDropdownListOnClick);
 			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
 
 			Assert.True (cb.MouseEvent (new MouseEvent {
 				X = cb.Bounds.Right - 1,
 				Y = 0,
 				Flags = MouseFlags.Button1Pressed
 			}));
+			Assert.Equal ("", selected);
 			Assert.True (cb.IsShow);
 			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal ("One", cb.Text);
 
-			Assert.False (cb.Subviews [1].OnMouseEvent (new MouseEvent {
-				X = 0,
-				Y = 1,
-				Flags = MouseFlags.Button1Pressed
-			}));
-			Assert.False (cb.Subviews [1].MouseEvent (new MouseEvent {
-				X = 0,
-				Y = 1,
-				Flags = MouseFlags.Button1Pressed
-			}));
-			Assert.True (cb.IsShow);
-			Assert.Equal (0, cb.SelectedItem);
-			Assert.True (cb.Subviews [1].OnMouseEvent (new MouseEvent {
-				X = 0,
-				Y = 1,
-				Flags = MouseFlags.Button1Clicked
-			}));
 			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
 				X = 0,
 				Y = 1,
@@ -314,25 +301,19 @@ Three
 			Assert.Equal ("", selected);
 			Assert.True (cb.IsShow);
 			Assert.Equal (1, cb.SelectedItem);
-
-			cb.HideDropdownListOnClick = true;
-			Assert.False (cb.Subviews [1].OnMouseEvent (new MouseEvent {
+			Assert.Equal ("Two", cb.Text);
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
 				X = 0,
-				Y = 2,
-				Flags = MouseFlags.Button1Pressed
-			}));
-			Assert.False (cb.Subviews [1].MouseEvent (new MouseEvent {
-				X = 0,
-				Y = 2,
-				Flags = MouseFlags.Button1Pressed
-			}));
-			Assert.True (cb.IsShow);
-			Assert.Equal (1, cb.SelectedItem);
-			Assert.True (cb.Subviews [1].OnMouseEvent (new MouseEvent {
-				X = 0,
-				Y = 2,
+				Y = 1,
 				Flags = MouseFlags.Button1Clicked
 			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+
+			cb.HideDropdownListOnClick = true;
+
 			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
 				X = 0,
 				Y = 2,
@@ -341,44 +322,41 @@ Three
 			Assert.Equal ("Three", selected);
 			Assert.False (cb.IsShow);
 			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
 
 			Assert.True (cb.MouseEvent (new MouseEvent {
 				X = cb.Bounds.Right - 1,
 				Y = 0,
 				Flags = MouseFlags.Button1Pressed
 			}));
-			Assert.True (cb.IsShow);
-			Assert.Equal (2, cb.SelectedItem);
-			Assert.False (cb.Subviews [1].OnMouseEvent (new MouseEvent {
-				X = 0,
-				Y = 2,
-				Flags = MouseFlags.Button1Pressed
-			}));
-			Assert.False (cb.Subviews [1].MouseEvent (new MouseEvent {
-				X = 0,
-				Y = 2,
-				Flags = MouseFlags.Button1Pressed
-			}));
-			Assert.True (cb.IsShow);
-			Assert.Equal (2, cb.SelectedItem);
-			Assert.True (cb.Subviews [1].OnMouseEvent (new MouseEvent {
-				X = 0,
-				Y = 2,
-				Flags = MouseFlags.Button1Clicked
-			}));
 			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
 				X = 0,
 				Y = 2,
 				Flags = MouseFlags.Button1Clicked
 			}));
 			Assert.Equal ("Three", selected);
-			lock (Application.MainLoop.IdleHandlers) {
-				while (cb.IsShow) {
-					Application.MainLoop.MainIteration ();
-				}
-			}
 			Assert.False (cb.IsShow);
 			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("Three", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = 0,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("One", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal ("One", cb.Text);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -397,6 +375,8 @@ Three
 
 			Assert.True (cb.HideDropdownListOnClick);
 			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
 
 			Assert.True (cb.MouseEvent (new MouseEvent {
 				X = cb.Bounds.Right - 1,
@@ -457,6 +437,8 @@ Three
 
 			Assert.True (cb.HideDropdownListOnClick);
 			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
 
 			Assert.True (cb.MouseEvent (new MouseEvent {
 				X = cb.Bounds.Right - 1,
@@ -492,6 +474,8 @@ Three
 
 			Assert.True (cb.HideDropdownListOnClick);
 			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
 
 			Assert.True (cb.MouseEvent (new MouseEvent {
 				X = cb.Bounds.Right - 1,

--- a/UnitTests/ComboBoxTests.cs
+++ b/UnitTests/ComboBoxTests.cs
@@ -240,5 +240,116 @@ Three
 			Assert.Equal (-1, cb.SelectedItem);
 			Assert.Equal ("", cb.Text);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_Gets_Sets ()
+		{
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.False (cb.HideDropdownListOnClick);
+			Assert.False (cb.IsShow);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.True (cb.IsShow);
+			Assert.Equal (0, cb.SelectedItem);
+
+			Assert.False (cb.Subviews [1].OnMouseEvent (new MouseEvent {
+				X = 0,
+				Y = 1,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.False (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = 1,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.True (cb.IsShow);
+			Assert.Equal (0, cb.SelectedItem);
+			Assert.True (cb.Subviews [1].OnMouseEvent (new MouseEvent {
+				X = 0,
+				Y = 1,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = 1,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+
+			cb.HideDropdownListOnClick = true;
+			Assert.False (cb.Subviews [1].OnMouseEvent (new MouseEvent {
+				X = 0,
+				Y = 2,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.False (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = 2,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.True (cb.Subviews [1].OnMouseEvent (new MouseEvent {
+				X = 0,
+				Y = 2,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = 2,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.False (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.True (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.False (cb.Subviews [1].OnMouseEvent (new MouseEvent {
+				X = 0,
+				Y = 2,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.False (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = 2,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.True (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.True (cb.Subviews [1].OnMouseEvent (new MouseEvent {
+				X = 0,
+				Y = 2,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = 2,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			lock (Application.MainLoop.IdleHandlers) {
+				while (cb.IsShow) {
+					Application.MainLoop.MainIteration ();
+				}
+			}
+			Assert.False (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+		}
 	}
 }

--- a/UnitTests/ComboBoxTests.cs
+++ b/UnitTests/ComboBoxTests.cs
@@ -451,11 +451,154 @@ Three
 			Assert.Equal ("", cb.Text);
 
 			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
-			Assert.True (cb.ProcessKey (new KeyEvent (Key.Esc, new KeyModifiers ())));
 			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.Esc, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_False_OpenSelectedItem_With_Mouse_And_Key_CursorDown_And_Esc ()
+		{
+			var selected = "";
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5,
+				HideDropdownListOnClick = false
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.False (cb.HideDropdownListOnClick);
+			Assert.False (cb.ReadOnly);
 			Assert.False (cb.IsShow);
 			Assert.Equal (-1, cb.SelectedItem);
 			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal ("One", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.Esc, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_False_ReadOnly_True_OpenSelectedItem_With_Mouse_And_Key_CursorDown_And_Esc ()
+		{
+			var selected = "";
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5,
+				HideDropdownListOnClick = false,
+				ReadOnly = true
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.False (cb.HideDropdownListOnClick);
+			Assert.True (cb.ReadOnly);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal ("One", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.Esc, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -490,6 +633,304 @@ Three
 			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
 			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
 			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_False_OpenSelectedItem_With_Mouse_And_Key_F4 ()
+		{
+			var selected = "";
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5,
+				HideDropdownListOnClick = false
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.False (cb.HideDropdownListOnClick);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal ("One", cb.Text);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.Equal ("Two", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (1, cb.SelectedItem);
+			Assert.Equal ("Two", cb.Text);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_True_Colapse_On_Click_Outside_Frame ()
+		{
+			var selected = "";
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5,
+				HideDropdownListOnClick = true
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.True (cb.HideDropdownListOnClick);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = -1,
+				Y = 0,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = -1,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = cb.Frame.Width,
+				Y = 0,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+			Assert.True (cb.Subviews [1].MouseEvent (new MouseEvent {
+				X = 0,
+				Y = cb.Frame.Height,
+				Flags = MouseFlags.Button1Clicked
+			}));
+			Assert.Equal ("", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void HideDropdownListOnClick_True_Highlight_Current_Item ()
+		{
+			var selected = "";
+			var cb = new ComboBox {
+				Width = 6,
+				Height = 4,
+				HideDropdownListOnClick = true,
+			};
+			cb.SetSource (new List<string> { "One", "Two", "Three" });
+			cb.OpenSelectedItem += (e) => selected = e.Value.ToString ();
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.True (cb.HideDropdownListOnClick);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.MouseEvent (new MouseEvent {
+				X = cb.Bounds.Right - 1,
+				Y = 0,
+				Flags = MouseFlags.Button1Pressed
+			}));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+			cb.Redraw (cb.Bounds);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+     ▼
+One   
+Two   
+Three ", output);
+
+			var attributes = new Attribute [] {
+				// 0
+				cb.Subviews [0].ColorScheme.Focus,
+				// 1
+				cb.Subviews [1].ColorScheme.HotFocus,
+				// 2
+				cb.Subviews [1].GetNormalColor ()
+			};
+
+			GraphViewTests.AssertDriverColorsAre (@"
+000000
+00000
+22222
+22222", attributes);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+			cb.Redraw (cb.Bounds);
+			GraphViewTests.AssertDriverColorsAre (@"
+000000
+22222
+00000
+22222", attributes);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
+			Assert.Equal ("", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+			cb.Redraw (cb.Bounds);
+			GraphViewTests.AssertDriverColorsAre (@"
+000000
+22222
+22222
+00000", attributes);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
+			Assert.Equal ("Three", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.Equal ("Three", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+			cb.Redraw (cb.Bounds);
+			GraphViewTests.AssertDriverColorsAre (@"
+000000
+22222
+22222
+00000", attributes);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorUp, new KeyModifiers ())));
+			Assert.Equal ("Three", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+			cb.Redraw (cb.Bounds);
+			GraphViewTests.AssertDriverColorsAre (@"
+000000
+22222
+00000
+11111", attributes);
+
+			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorUp, new KeyModifiers ())));
+			Assert.Equal ("Three", selected);
+			Assert.True (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+			cb.Redraw (cb.Bounds);
+			GraphViewTests.AssertDriverColorsAre (@"
+000000
+00000
+22222
+11111", attributes);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.Equal ("Three", selected);
+			Assert.False (cb.IsShow);
+			Assert.Equal (2, cb.SelectedItem);
+			Assert.Equal ("Three", cb.Text);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void Expanded_Collapsed_Events ()
+		{
+			var cb = new ComboBox {
+				Height = 4,
+				Width = 5
+			};
+			var list = new List<string> { "One", "Two", "Three" };
+
+			cb.Expanded += () => cb.SetSource (list);
+			cb.Collapsed += () => cb.Source = null;
+
+			Application.Top.Add (cb);
+			Application.Begin (Application.Top);
+
+			Assert.Null (cb.Source);
+			Assert.False (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.NotNull (cb.Source);
+			Assert.True (cb.IsShow);
+			Assert.Equal (-1, cb.SelectedItem);
+			Assert.Equal ("", cb.Text);
+
+			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
+			Assert.Null (cb.Source);
 			Assert.False (cb.IsShow);
 			Assert.Equal (-1, cb.SelectedItem);
 			Assert.Equal ("", cb.Text);

--- a/UnitTests/ListViewTests.cs
+++ b/UnitTests/ListViewTests.cs
@@ -431,5 +431,25 @@ namespace Terminal.Gui.Views {
 │Line9     │
 └──────────┘", output);
 		}
+
+		[Fact]
+		public void SetSource_Preserves_ListWrapper_Instance_If_Not_Null ()
+		{
+			var lv = new ListView (new List<string> { "One", "Two" });
+
+			Assert.NotNull (lv.Source);
+
+			lv.SetSource (null);
+			Assert.NotNull (lv.Source);
+
+			lv.Source = null;
+			Assert.Null (lv.Source);
+
+			lv = new ListView (new List<string> { "One", "Two" });
+			Assert.NotNull (lv.Source);
+
+			lv.SetSourceAsync (null);
+			Assert.NotNull (lv.Source);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #820 - To not break the initial auto-hide behavior I decided to create a new flag `HideDropdownListOnClick` which will hide the dropdown list on click, avoiding the double click, instead of made a `AutoHide` public property. If this property is false the current behavior is valid.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
