### PR TITLE
Fixes #1984. Setting Label.Visible to false does not hide the Label

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -2562,8 +2562,11 @@ namespace Terminal.Gui {
 			set {
 				if (base.Visible != value) {
 					base.Visible = value;
-					if (!value && HasFocus) {
-						SetHasFocus (false, this);
+					if (!value) {
+						if (HasFocus) {
+							SetHasFocus (false, this);
+						}
+						Clear ();
 					}
 					OnVisibleChanged ();
 					SetNeedsDisplay ();

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -3803,5 +3803,34 @@ e
 ", output);
 		}
 
+		[Fact, AutoInitShutdown]
+		public void Visible_Clear_The_View_Output ()
+		{
+			var label = new Label ("Testing visibility.");
+			var win = new Window ();
+			win.Add (label);
+			var top = Application.Top;
+			top.Add (win);
+			Application.Begin (top);
+
+			Assert.True (label.Visible);
+			((FakeDriver)Application.Driver).SetBufferSize (30, 5);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌────────────────────────────┐
+│Testing visibility.         │
+│                            │
+│                            │
+└────────────────────────────┘
+", output);
+
+			label.Visible = false;
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌────────────────────────────┐
+│                            │
+│                            │
+│                            │
+└────────────────────────────┘
+", output);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1984 - This issue only happens with the `Reactive` Api. It seems that the console is redraw on the first bind and not redraw on subsequent bindings. The `Visible` property is set to false but by itself it doesn't nothing until the container is redraw, so a force clear is needed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
