### PR TITLE
Fixes #1987. Textview insert text newline fix

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -3628,6 +3628,8 @@ namespace Terminal.Gui {
 				model.AddLine (currentRow + 1, new List<Rune> ());
 				currentRow++;
 				currentColumn = 0;
+			} else if ((uint)kb.Key == 13) {
+				currentColumn = 0;
 			} else {
 				if (Used) {
 					Insert ((uint)kb.Key);

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -3624,16 +3624,22 @@ namespace Terminal.Gui {
 			if (selecting) {
 				ClearSelectedRegion ();
 			}
-			if (Used) {
-				Insert ((uint)kb.Key);
-				currentColumn++;
-				if (currentColumn >= leftColumn + Frame.Width) {
-					leftColumn++;
-					SetNeedsDisplay ();
-				}
+			if (kb.Key == Key.Enter) {
+				model.AddLine (currentRow + 1, new List<Rune> ());
+				currentRow++;
+				currentColumn = 0;
 			} else {
-				Insert ((uint)kb.Key);
-				currentColumn++;
+				if (Used) {
+					Insert ((uint)kb.Key);
+					currentColumn++;
+					if (currentColumn >= leftColumn + Frame.Width) {
+						leftColumn++;
+						SetNeedsDisplay ();
+					}
+				} else {
+					Insert ((uint)kb.Key);
+					currentColumn++;
+				}
 			}
 
 			historyText.Add (new List<List<Rune>> () { new List<Rune> (GetCurrentLine ()) }, CursorPosition,

--- a/UnitTests/TextViewTests.cs
+++ b/UnitTests/TextViewTests.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace Terminal.Gui.Views {
 	public class TextViewTests {
@@ -6274,16 +6273,88 @@ This is the second line.
 
 		[Fact]
 		[InitShutdown]
-		public void TextView_InsertText_Newline ()
+		public void TextView_InsertText_Newline_LF ()
 		{
 			var tv = new TextView {
 				Width = 10,
 				Height = 10,
 			};
 			tv.InsertText ("\naaa\nbbb");
-			//this fails
-			Assert.Throws<EqualException> (() => Assert.Equal ("\naaa\nbbb", tv.Text));
+			var p = Environment.OSVersion.Platform;
+			if (p == PlatformID.Win32NT || p == PlatformID.Win32S || p == PlatformID.Win32Windows) {
+				Assert.Equal ("\r\naaa\r\nbbb", tv.Text);
+			} else {
+				Assert.Equal ("\naaa\nbbb", tv.Text);
+			}
+			Assert.Equal ($"{Environment.NewLine}aaa{Environment.NewLine}bbb", tv.Text);
+
+			var win = new Window ();
+			win.Add (tv);
+			Application.Top.Add (win);
+			Application.Begin (Application.Top);
+			((FakeDriver)Application.Driver).SetBufferSize (15, 15);
+			Application.Refresh ();
 			//this passes
+			var pos = GraphViewTests.AssertDriverContentsWithFrameAre (
+			@"
+┌─────────────┐
+│             │
+│aaa          │
+│bbb          │
+│             │
+│             │
+│             │
+│             │
+│             │
+│             │
+│             │
+│             │
+│             │
+│             │
+└─────────────┘", output);
+
+			Assert.Equal (new Rect (0, 0, 15, 15), pos);
+
+			Assert.True (tv.Used);
+			tv.Used = false;
+			tv.CursorPosition = new Point (0, 0);
+			tv.InsertText ("\naaa\nbbb");
+			Application.Refresh ();
+
+			GraphViewTests.AssertDriverContentsWithFrameAre (
+			@"
+┌─────────────┐
+│             │
+│aaa          │
+│bbb          │
+│aaa          │
+│bbb          │
+│             │
+│             │
+│             │
+│             │
+│             │
+│             │
+│             │
+│             │
+└─────────────┘", output);
+		}
+
+		[Fact]
+		[InitShutdown]
+		public void TextView_InsertText_Newline_CRLF ()
+		{
+			var tv = new TextView {
+				Width = 10,
+				Height = 10,
+			};
+			tv.InsertText ("\r\naaa\r\nbbb");
+			var p = Environment.OSVersion.Platform;
+			if (p == PlatformID.Win32NT || p == PlatformID.Win32S || p == PlatformID.Win32Windows) {
+				Assert.Equal ("\r\naaa\r\nbbb", tv.Text);
+			} else {
+				Assert.Equal ("\naaa\nbbb", tv.Text);
+			}
 			Assert.Equal ($"{Environment.NewLine}aaa{Environment.NewLine}bbb", tv.Text);
 
 			var win = new Window ();
@@ -6317,7 +6388,7 @@ This is the second line.
 			Assert.True (tv.Used);
 			tv.Used = false;
 			tv.CursorPosition = new Point (0, 0);
-			tv.InsertText ("\naaa\nbbb");
+			tv.InsertText ("\r\naaa\r\nbbb");
 			Application.Refresh ();
 
 			GraphViewTests.AssertDriverContentsWithFrameAre (


### PR DESCRIPTION
Fixes #1987 - `InsertText` method doesn't differentiate any key because it's used in batch without being processed by the `ProcessKey` method. At least `Key.Enter` '\n' (Line Feed) and '\r' (Carriage Return) are now handled.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
