### PR TITLE
Fixes #1989. ListView: Ensures SelectedItem visibility on MoveDown and MoveUp.

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -529,8 +529,8 @@ namespace Terminal.Gui {
 			} else if (selected == 0) {
 				OnSelectedChanged ();
 				SetNeedsDisplay ();
-			} else if (selected >= top + VisibleItems) {
-				top = source.Count - VisibleItems;
+			} else if (selected >= top + Frame.Height) {
+				top = source.Count - Frame.Height;
 				SetNeedsDisplay ();
 			}
 

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -521,11 +521,16 @@ namespace Terminal.Gui {
 					top++;
 				} else if (selected < top) {
 					top = selected;
+				} else if (selected < top) {
+					top = selected;
 				}
 				OnSelectedChanged ();
 				SetNeedsDisplay ();
 			} else if (selected == 0) {
 				OnSelectedChanged ();
+				SetNeedsDisplay ();
+			} else if (selected >= top + VisibleItems) {
+				top = source.Count - VisibleItems;
 				SetNeedsDisplay ();
 			}
 
@@ -560,6 +565,9 @@ namespace Terminal.Gui {
 					top = Math.Max (selected - Frame.Height + 1, 0);
 				}
 				OnSelectedChanged ();
+				SetNeedsDisplay ();
+			} else if (selected < top) {
+				top = selected;
 				SetNeedsDisplay ();
 			}
 			return true;

--- a/UnitTests/ListViewTests.cs
+++ b/UnitTests/ListViewTests.cs
@@ -5,9 +5,17 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Terminal.Gui.Views {
 	public class ListViewTests {
+		readonly ITestOutputHelper output;
+
+		public ListViewTests (ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
 		[Fact]
 		public void Constructors_Defaults ()
 		{
@@ -220,6 +228,208 @@ namespace Terminal.Gui.Views {
 				}
 				return item;
 			}
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void Ensures_Visibility_SelectedItem_On_MoveDown_And_MoveUp ()
+		{
+			var source = new List<string> ();
+			for (int i = 0; i < 20; i++) {
+				source.Add ($"Line{i}");
+			}
+			var lv = new ListView (source) { Width = Dim.Fill (), Height = Dim.Fill () };
+			var win = new Window ();
+			win.Add (lv);
+			Application.Top.Add (win);
+			Application.Begin (Application.Top);
+			((FakeDriver)Application.Driver).SetBufferSize (12, 12);
+			Application.Refresh ();
+
+			Assert.Equal (0, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line0     │
+│Line1     │
+│Line2     │
+│Line3     │
+│Line4     │
+│Line5     │
+│Line6     │
+│Line7     │
+│Line8     │
+│Line9     │
+└──────────┘", output);
+
+			Assert.True (lv.ScrollDown (10));
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (0, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line10    │
+│Line11    │
+│Line12    │
+│Line13    │
+│Line14    │
+│Line15    │
+│Line16    │
+│Line17    │
+│Line18    │
+│Line19    │
+└──────────┘", output);
+
+			Assert.True (lv.MoveDown ());
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (1, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line1     │
+│Line2     │
+│Line3     │
+│Line4     │
+│Line5     │
+│Line6     │
+│Line7     │
+│Line8     │
+│Line9     │
+│Line10    │
+└──────────┘", output);
+
+			Assert.True (lv.MoveEnd ());
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (19, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line19    │
+│          │
+│          │
+│          │
+│          │
+│          │
+│          │
+│          │
+│          │
+│          │
+└──────────┘", output);
+
+			Assert.True (lv.ScrollUp (20));
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (19, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line0     │
+│Line1     │
+│Line2     │
+│Line3     │
+│Line4     │
+│Line5     │
+│Line6     │
+│Line7     │
+│Line8     │
+│Line9     │
+└──────────┘", output);
+
+			Assert.True (lv.MoveDown ());
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (19, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line10    │
+│Line11    │
+│Line12    │
+│Line13    │
+│Line14    │
+│Line15    │
+│Line16    │
+│Line17    │
+│Line18    │
+│Line19    │
+└──────────┘", output);
+
+			Assert.True (lv.ScrollUp (20));
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (19, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line0     │
+│Line1     │
+│Line2     │
+│Line3     │
+│Line4     │
+│Line5     │
+│Line6     │
+│Line7     │
+│Line8     │
+│Line9     │
+└──────────┘", output);
+
+			Assert.True (lv.MoveDown ());
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (19, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line10    │
+│Line11    │
+│Line12    │
+│Line13    │
+│Line14    │
+│Line15    │
+│Line16    │
+│Line17    │
+│Line18    │
+│Line19    │
+└──────────┘", output);
+
+			Assert.True (lv.MoveHome ());
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (0, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line0     │
+│Line1     │
+│Line2     │
+│Line3     │
+│Line4     │
+│Line5     │
+│Line6     │
+│Line7     │
+│Line8     │
+│Line9     │
+└──────────┘", output);
+
+			Assert.True (lv.ScrollDown (20));
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (0, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line19    │
+│          │
+│          │
+│          │
+│          │
+│          │
+│          │
+│          │
+│          │
+│          │
+└──────────┘", output);
+
+			Assert.True (lv.MoveUp ());
+			lv.Redraw (lv.Bounds);
+			Assert.Equal (0, lv.SelectedItem);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌──────────┐
+│Line0     │
+│Line1     │
+│Line2     │
+│Line3     │
+│Line4     │
+│Line5     │
+│Line6     │
+│Line7     │
+│Line8     │
+│Line9     │
+└──────────┘", output);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1989 - After scrolling down or up, the selected isn't visible and this is a normal behavior. But if the cursor down and cursor up are pressed the selected item must be visible to be more easier to find it.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
