### PR TITLE
Revert "Fixes #1979. MessageBox.Query not wrapping since 1.7.1"

### DIFF
--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -284,7 +284,6 @@ namespace Terminal.Gui {
 				l.Y = Pos.Center ();
 				l.Width = Dim.Fill (2);
 				l.Height = Dim.Fill (1);
-				l.AutoSize = false;
 				d.Add (l);
 			}
 


### PR DESCRIPTION
Reverts gui-cs/Terminal.Gui#1980

This broke UI Catalog's about box:

<img width="311" alt="image" src="https://user-images.githubusercontent.com/585482/188470248-c2a422d7-c43a-49d2-b364-c55d4b430735.png">
