### PR TITLE
Fixes #1999. Prevents the mouseGrabView being executed with a null view.

### DIFF
--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -638,6 +638,11 @@ namespace Terminal.Gui {
 			}
 			RootMouseEvent?.Invoke (me);
 			if (mouseGrabView != null) {
+				if (view == null) {
+					UngrabMouse ();
+					return;
+				}
+
 				var newxy = mouseGrabView.ScreenToView (me.X, me.Y);
 				var nme = new MouseEvent () {
 					X = newxy.X,
@@ -653,7 +658,9 @@ namespace Terminal.Gui {
 				// System.Diagnostics.Debug.WriteLine ($"{nme.Flags};{nme.X};{nme.Y};{mouseGrabView}");
 				if (mouseGrabView != null) {
 					mouseGrabView.OnMouseEvent (nme);
-					return;
+					if (mouseGrabView != null) {
+						return;
+					}
 				}
 			}
 

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -517,7 +517,6 @@ namespace Terminal.Gui {
 				horizontal.MouseEvent (me);
 			} else if (IsOverridden (me.View)) {
 				Application.UngrabMouse ();
-				return false;
 			}
 			return true;
 		}

--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -1408,5 +1408,85 @@ namespace Terminal.Gui.Core {
 
 			Application.Shutdown ();
 		}
+
+		[Fact, AutoInitShutdown]
+		public void MouseGrabView_WithNullMouseEventView ()
+		{
+			var tf = new TextField () { Width = 10 };
+			var sv = new ScrollView () {
+				Width = Dim.Fill (),
+				Height = Dim.Fill (),
+				ContentSize = new Size (100, 100)
+			};
+
+			sv.Add (tf);
+			Application.Top.Add (sv);
+
+			var iterations = -1;
+
+			Application.Iteration = () => {
+				iterations++;
+				if (iterations == 0) {
+					Assert.True (tf.HasFocus);
+					Assert.Null (Application.mouseGrabView);
+
+					ReflectionTools.InvokePrivate (
+						typeof (Application),
+						"ProcessMouseEvent",
+						new MouseEvent () {
+							X = 5,
+							Y = 5,
+							Flags = MouseFlags.ReportMousePosition
+						});
+
+					Assert.Equal (sv, Application.mouseGrabView);
+
+					MessageBox.Query ("Title", "Test", "Ok");
+
+					Assert.Null (Application.mouseGrabView);
+				} else if (iterations == 1) {
+					Assert.Equal (sv, Application.mouseGrabView);
+
+					ReflectionTools.InvokePrivate (
+						typeof (Application),
+						"ProcessMouseEvent",
+						new MouseEvent () {
+							X = 5,
+							Y = 5,
+							Flags = MouseFlags.ReportMousePosition
+						});
+
+					Assert.Null (Application.mouseGrabView);
+
+					ReflectionTools.InvokePrivate (
+						typeof (Application),
+						"ProcessMouseEvent",
+						new MouseEvent () {
+							X = 40,
+							Y = 12,
+							Flags = MouseFlags.ReportMousePosition
+						});
+
+					ReflectionTools.InvokePrivate (
+						typeof (Application),
+						"ProcessMouseEvent",
+						new MouseEvent () {
+							X = 0,
+							Y = 0,
+							Flags = MouseFlags.Button1Pressed
+						});
+
+					Assert.Null (Application.mouseGrabView);
+
+					Application.RequestStop ();
+				} else if (iterations == 2) {
+					Assert.Null (Application.mouseGrabView);
+
+					Application.RequestStop ();
+				}
+			};
+
+			Application.Run ();
+		}
 	}
 }

--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -1467,6 +1467,8 @@ namespace Terminal.Gui.Core {
 							Flags = MouseFlags.ReportMousePosition
 						});
 
+					Assert.Null (Application.mouseGrabView);
+
 					ReflectionTools.InvokePrivate (
 						typeof (Application),
 						"ProcessMouseEvent",

--- a/UnitTests/ReflectionTools.cs
+++ b/UnitTests/ReflectionTools.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Reflection;
+
+public static class ReflectionTools {
+	// If the class is non-static
+	public static Object InvokePrivate (Object objectUnderTest, string method, params object [] args)
+	{
+		Type t = objectUnderTest.GetType ();
+		return t.InvokeMember (method,
+		    BindingFlags.InvokeMethod |
+		    BindingFlags.NonPublic |
+		    BindingFlags.Instance |
+		    BindingFlags.Static,
+		    null,
+		    objectUnderTest,
+		    args);
+	}
+	// if the class is static
+	public static Object InvokePrivate (Type typeOfObjectUnderTest, string method, params object [] args)
+	{
+		MemberInfo [] members = typeOfObjectUnderTest.GetMembers (BindingFlags.NonPublic | BindingFlags.Static);
+		foreach (var member in members) {
+			if (member.Name == method) {
+				return typeOfObjectUnderTest.InvokeMember (method,
+					BindingFlags.NonPublic |
+					BindingFlags.Static |
+					BindingFlags.InvokeMethod,
+					null,
+					typeOfObjectUnderTest,
+					args);
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Fixes #1999 - There were two bugs. Firstly on `ScrollView` which was returns false after the `UngrabMouse` even if the `MouseEvent.View` property isn't null and thus didn't run the view's mouse event. Secondly the `mouseGrabView` was run with the `MouseEvent.View` property equal to null. Now if the view is null the `mouseGrabView` will also be null by running the `UngrabMouse` method.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
