### PR TITLE
Fixes #2002. Added feature to fill the remaining width with spaces.

### DIFF
--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -1141,7 +1141,7 @@ namespace Terminal.Gui {
 		/// <param name="normalColor">The color to use for all text except the hotkey</param>
 		/// <param name="hotColor">The color to use to draw the hotkey</param>
 		/// <param name="containerBounds">Specifies the screen-relative location and maximum container size.</param>
-		/// <param name="fillRemaining">Determines if the bounds width will be used (default)or only the text width will be used.</param>
+		/// <param name="fillRemaining">Determines if the bounds width will be used (default) or only the text width will be used.</param>
 		public void Draw (Rect bounds, Attribute normalColor, Attribute hotColor, Rect containerBounds = default, bool fillRemaining = true)
 		{
 			// With this check, we protect against subclasses with overrides of Text (like Button)

--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -356,7 +356,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets whether the <see cref="TextFormatter"/> needs to format the text when <see cref="Draw(Rect, Attribute, Attribute, Rect)"/> is called.
+		/// Gets or sets whether the <see cref="TextFormatter"/> needs to format the text when <see cref="Draw(Rect, Attribute, Attribute, Rect, bool)"/> is called.
 		/// If it is <c>false</c> when Draw is called, the Draw call will be faster.
 		/// </summary>
 		/// <remarks>
@@ -1141,7 +1141,8 @@ namespace Terminal.Gui {
 		/// <param name="normalColor">The color to use for all text except the hotkey</param>
 		/// <param name="hotColor">The color to use to draw the hotkey</param>
 		/// <param name="containerBounds">Specifies the screen-relative location and maximum container size.</param>
-		public void Draw (Rect bounds, Attribute normalColor, Attribute hotColor, Rect containerBounds = default)
+		/// <param name="fillRemaining">Determines if the bounds width will be used (default)or only the text width will be used.</param>
+		public void Draw (Rect bounds, Attribute normalColor, Attribute hotColor, Rect containerBounds = default, bool fillRemaining = true)
 		{
 			// With this check, we protect against subclasses with overrides of Text (like Button)
 			if (ustring.IsNullOrEmpty (text)) {
@@ -1244,7 +1245,7 @@ namespace Terminal.Gui {
 				var size = isVertical ? bounds.Height : bounds.Width;
 				var current = start;
 				var savedClip = Application.Driver?.Clip;
-				if (Application.Driver != null && containerBounds != default) {
+				if (Application.Driver != null) {
 					Application.Driver.Clip = containerBounds == default
 						? bounds
 						: new Rect (Math.Max (containerBounds.X, bounds.X),
@@ -1254,10 +1255,10 @@ namespace Terminal.Gui {
 				}
 
 				for (var idx = (isVertical ? start - y : start - x); current < start + size; idx++) {
-					if (idx < 0) {
+					if (!fillRemaining && idx < 0) {
 						current++;
 						continue;
-					} else if (idx > runes.Length - 1) {
+					} else if (!fillRemaining && idx > runes.Length - 1) {
 						break;
 					}
 					var rune = (Rune)' ';
@@ -1289,7 +1290,8 @@ namespace Terminal.Gui {
 					} else {
 						current += runeWidth;
 					}
-					if (!isVertical && idx + 1 < runes.Length && current + Rune.ColumnWidth (runes [idx + 1]) > start + size) {
+					var nextRuneWidth = idx + 1 > -1 && idx + 1 < runes.Length ? Rune.ColumnWidth (runes [idx + 1]) : 0;
+					if (!isVertical && idx + 1 < runes.Length && current + nextRuneWidth > start + size) {
 						break;
 					}
 				}

--- a/UnitTests/TextFormatterTests.cs
+++ b/UnitTests/TextFormatterTests.cs
@@ -3334,6 +3334,35 @@ e
 			Assert.Equal (new Rect (0, 0, 13, height + 2), pos);
 		}
 
+		[Fact, AutoInitShutdown]
+		public void Draw_Fill_Remaining ()
+		{
+			var view = new View ("A very long text behind the TextFormatter.");
+
+			var tf = new TextFormatter ();
+			tf.Text = "Hello";
+			tf.Size = new Size (10, 1);
+
+			Application.Top.Add (view);
+			Application.Begin (Application.Top);
+
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+A very long text behind the TextFormatter.
+", output);
+
+			tf.Draw (new Rect (0, 0, 10, 1), view.GetNormalColor (), view.ColorScheme.HotNormal, default, false);
+			Application.Top.Redraw (Application.Top.Bounds);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+Helloy long text behind the TextFormatter.
+", output);
+
+			tf.Draw (new Rect (0, 0, 10, 1), view.GetNormalColor (), view.ColorScheme.HotNormal, default);
+			Application.Top.Redraw (Application.Top.Bounds);
+			GraphViewTests.AssertDriverContentsWithFrameAre (@"
+Hello     g text behind the TextFormatter.
+", output);
+		}
+
 		[Fact]
 		public void GetTextWidth_Simple_And_Wide_Runes ()
 		{

--- a/UnitTests/TextFormatterTests.cs
+++ b/UnitTests/TextFormatterTests.cs
@@ -3337,29 +3337,42 @@ e
 		[Fact, AutoInitShutdown]
 		public void Draw_Fill_Remaining ()
 		{
-			var view = new View ("A very long text behind the TextFormatter.");
+			var view = new View ("This view needs to be cleared before rewritten.");
 
-			var tf = new TextFormatter ();
-			tf.Text = "Hello";
-			tf.Size = new Size (10, 1);
+			var tf1 = new TextFormatter ();
+			tf1.Text = "This TextFormatter (tf1) without fill will not be cleared on rewritten.";
+			var tf1Size = tf1.Size;
+
+			var tf2 = new TextFormatter ();
+			tf2.Text = "This TextFormatter (tf2) with fill will be cleared on rewritten.";
+			var tf2Size = tf2.Size;
 
 			Application.Top.Add (view);
 			Application.Begin (Application.Top);
 
+			tf1.Draw (new Rect (new Point (0, 1), tf1Size), view.GetNormalColor (), view.ColorScheme.HotNormal, default, false);
+
+			tf2.Draw (new Rect (new Point (0, 2), tf2Size), view.GetNormalColor (), view.ColorScheme.HotNormal);
+
 			GraphViewTests.AssertDriverContentsWithFrameAre (@"
-A very long text behind the TextFormatter.
+This view needs to be cleared before rewritten.                        
+This TextFormatter (tf1) without fill will not be cleared on rewritten.
+This TextFormatter (tf2) with fill will be cleared on rewritten.       
 ", output);
 
-			tf.Draw (new Rect (0, 0, 10, 1), view.GetNormalColor (), view.ColorScheme.HotNormal, default, false);
-			Application.Top.Redraw (Application.Top.Bounds);
-			GraphViewTests.AssertDriverContentsWithFrameAre (@"
-Helloy long text behind the TextFormatter.
-", output);
+			view.Text = "This view is rewritten.";
+			view.Redraw (view.Bounds);
 
-			tf.Draw (new Rect (0, 0, 10, 1), view.GetNormalColor (), view.ColorScheme.HotNormal);
-			Application.Top.Redraw (Application.Top.Bounds);
+			tf1.Text = "This TextFormatter (tf1) is rewritten.";
+			tf1.Draw (new Rect (new Point (0, 1), tf1Size), view.GetNormalColor (), view.ColorScheme.HotNormal, default, false);
+
+			tf2.Text = "This TextFormatter (tf2) is rewritten.";
+			tf2.Draw (new Rect (new Point (0, 2), tf2Size), view.GetNormalColor (), view.ColorScheme.HotNormal);
+
 			GraphViewTests.AssertDriverContentsWithFrameAre (@"
-Hello     g text behind the TextFormatter.
+This view is rewritten.                                                
+This TextFormatter (tf1) is rewritten.will not be cleared on rewritten.
+This TextFormatter (tf2) is rewritten.                                 
 ", output);
 		}
 

--- a/UnitTests/TextFormatterTests.cs
+++ b/UnitTests/TextFormatterTests.cs
@@ -3356,7 +3356,7 @@ A very long text behind the TextFormatter.
 Helloy long text behind the TextFormatter.
 ", output);
 
-			tf.Draw (new Rect (0, 0, 10, 1), view.GetNormalColor (), view.ColorScheme.HotNormal, default);
+			tf.Draw (new Rect (0, 0, 10, 1), view.GetNormalColor (), view.ColorScheme.HotNormal);
 			Application.Top.Redraw (Application.Top.Bounds);
 			GraphViewTests.AssertDriverContentsWithFrameAre (@"
 Hello     g text behind the TextFormatter.


### PR DESCRIPTION
Fixes #2002 - By default the `TextFormatter.Draw` method should fill the remaining view width spaces. This way any view can fill all the view width. If it's false only the text width will be draw.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
