### PR TITLE
Fixes #2006. ProgressBarStyles isn't disposing the _fractionTimer on quitting if running.

### DIFF
--- a/UICatalog/Scenarios/ProgressBarStyles.cs
+++ b/UICatalog/Scenarios/ProgressBarStyles.cs
@@ -135,11 +135,15 @@ namespace UICatalog.Scenarios {
 
 			void Top_Unloaded ()
 			{
+				if (_fractionTimer != null) {
+					_fractionTimer.Dispose ();
+					_fractionTimer = null;
+				}
 				if (_pulseTimer != null) {
 					_pulseTimer.Dispose ();
 					_pulseTimer = null;
-					Top.Unloaded -= Top_Unloaded;
 				}
+				Top.Unloaded -= Top_Unloaded;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #2006 - Only the `_pulseTimer` was disposing. This fix avoids throwing an exception at quitting if it's running.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
