### PR TITLE
Fixes #2017. Sometimes I get fails with the TestAddManyTimeouts unit test.

### DIFF
--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -1301,7 +1301,7 @@ namespace Terminal.Gui.Core {
 					var myi = i;
 
 					Task.Run (() => {
-						Task.Delay (100).Wait ();
+						Thread.Sleep (100);
 
 						// each thread registers lots of 1s timeouts
 						for (int j = 0; j < numberOfTimeoutsPerThread; j++) {
@@ -1318,7 +1318,7 @@ namespace Terminal.Gui.Core {
 						if (myi == 0) {
 
 							// let the timeouts run for a bit
-							Task.Delay (5000).Wait ();
+							Thread.Sleep (5000);
 
 							// then tell the application to quit
 							Application.MainLoop.Invoke (() => Application.RequestStop ());


### PR DESCRIPTION
Fixes #2017 - Changed from `Task.Delay` to `Thread.Sleep` to block the thread.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
