### PR TITLE
Fixes #2008 - attempt to unwrap `ConsoleKey.Packet` in WindowsDriver

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1244,6 +1244,9 @@ namespace Terminal.Gui {
 				keyModifiers.Scrolllock = scrolllock;
 
 			var ConsoleKeyInfo = new ConsoleKeyInfo (keyEvent.UnicodeChar, (ConsoleKey)keyEvent.wVirtualKeyCode, shift, alt, control);
+
+			ConsoleKeyInfo = RemapPacketKey(ConsoleKeyInfo);
+
 			return new WindowsConsole.ConsoleKeyInfoEx (ConsoleKeyInfo, capslock, numlock);
 		}
 
@@ -1756,6 +1759,40 @@ namespace Terminal.Gui {
 
 		public override void CookMouse ()
 		{
+		}
+
+
+		/// <summary>
+		/// Handles case when the 'key' providied is ConsoleKey.Packet by
+		/// returning a new <see cref="ConsoleKeyInfo"/> where key is remapped
+		/// by parsing the Unicode char data of the <see cref="ConsoleKeyInfo"/>
+		/// </summary>
+		internal static ConsoleKeyInfo RemapPacketKey (ConsoleKeyInfo original)
+		{
+			// If the key struck was virtual
+			if(original.Key == ConsoleKey.Packet)
+			{
+				// Try to parse the unicode key e.g. 'A' into a value in ConsoleKey
+				// so that other parts of the program consider it as a regular button
+				// press
+				ConsoleKey remappedkey;
+				if(Enum.TryParse<ConsoleKey>(
+					// have to turn e.g. 'a' to something parseable as
+					// an enum value (i.e. Upper it)
+					original.KeyChar.ToString().ToUpper(), 
+					out remappedkey))
+				{
+					return new ConsoleKeyInfo(
+						original.KeyChar,
+						remappedkey,
+						original.Modifiers.HasFlag(ConsoleModifiers.Shift),
+						original.Modifiers.HasFlag(ConsoleModifiers.Alt),
+						original.Modifiers.HasFlag(ConsoleModifiers.Control)
+					);
+				}
+			}
+
+			return original;
 		}
 		#endregion
 	}


### PR DESCRIPTION
Fixes #2008 - When using some remoting technologies some keyboard input is supplied as `ConsoleKey.Packet`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [ x I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
