### PR TITLE
Fixes #2039. Surrounding the Clipboard.Contents with a lock keyword.

### DIFF
--- a/UnitTests/ClipboardTests.cs
+++ b/UnitTests/ClipboardTests.cs
@@ -79,110 +79,112 @@ namespace Terminal.Gui.Core {
 			var exit = false;
 			var getClipText = "";
 
-			Application.Iteration += () => {
-				if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows)) {
-					// using (Process clipExe = new Process {
-					// 	StartInfo = new ProcessStartInfo {
-					// 		RedirectStandardInput = true,
-					// 		FileName = "clip"
-					// 	}
-					// }) {
-					// 	clipExe.Start ();
-					// 	clipExe.StandardInput.Write (clipText);
-					// 	clipExe.StandardInput.Close ();
-					// 	var result = clipExe.WaitForExit (500);
-					// 	if (result) {
-					// 		clipExe.WaitForExit ();
-					// 	}
-					// }
+			lock (Clipboard.Contents) {
+				Application.Iteration += () => {
+					if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows)) {
+						// using (Process clipExe = new Process {
+						// 	StartInfo = new ProcessStartInfo {
+						// 		RedirectStandardInput = true,
+						// 		FileName = "clip"
+						// 	}
+						// }) {
+						// 	clipExe.Start ();
+						// 	clipExe.StandardInput.Write (clipText);
+						// 	clipExe.StandardInput.Close ();
+						// 	var result = clipExe.WaitForExit (500);
+						// 	if (result) {
+						// 		clipExe.WaitForExit ();
+						// 	}
+						// }
 
-					using (Process pwsh = new Process {
-						StartInfo = new ProcessStartInfo {
-							FileName = "powershell",
-							Arguments = $"-command \"Set-Clipboard -Value \\\"{clipText}\\\"\""
-						}
-					}) {
-						pwsh.Start ();
-						pwsh.WaitForExit ();
-					}
-					getClipText = Clipboard.Contents.ToString ();
-
-				} else if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
-					using (Process copy = new Process {
-						StartInfo = new ProcessStartInfo {
-							RedirectStandardInput = true,
-							FileName = "pbcopy"
-						}
-					}) {
-						copy.Start ();
-						copy.StandardInput.Write (clipText);
-						copy.StandardInput.Close ();
-						copy.WaitForExit ();
-					}
-					getClipText = Clipboard.Contents.ToString ();
-
-				} else if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux)) {
-					if (Is_WSL_Platform ()) {
-						try {
-							using (Process bash = new Process {
-								StartInfo = new ProcessStartInfo {
-									FileName = "powershell.exe",
-									Arguments = $"-noprofile -command \"Set-Clipboard -Value \\\"{clipText}\\\"\""
-								}
-							}) {
-								bash.Start ();
-								bash.WaitForExit ();
+						using (Process pwsh = new Process {
+							StartInfo = new ProcessStartInfo {
+								FileName = "powershell",
+								Arguments = $"-command \"Set-Clipboard -Value \\\"{clipText}\\\"\""
 							}
+						}) {
+							pwsh.Start ();
+							pwsh.WaitForExit ();
+						}
+						getClipText = Clipboard.Contents.ToString ();
 
-							//using (Process clipExe = new Process {
-							//	StartInfo = new ProcessStartInfo {
-							//		RedirectStandardInput = true,
-							//		FileName = "clip.exe"
-							//	}
-							//}) {
-							//	clipExe.Start ();
-							//	clipExe.StandardInput.Write (clipText);
-							//	clipExe.StandardInput.Close ();
-							//	clipExe.WaitForExit ();
-							//	//var result = clipExe.WaitForExit (500);
-							//	//if (result) {
-							//	//	clipExe.WaitForExit ();
-							//	//}
-							//}
-						} catch {
-							exit = true;
+					} else if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
+						using (Process copy = new Process {
+							StartInfo = new ProcessStartInfo {
+								RedirectStandardInput = true,
+								FileName = "pbcopy"
+							}
+						}) {
+							copy.Start ();
+							copy.StandardInput.Write (clipText);
+							copy.StandardInput.Close ();
+							copy.WaitForExit ();
+						}
+						getClipText = Clipboard.Contents.ToString ();
+
+					} else if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux)) {
+						if (Is_WSL_Platform ()) {
+							try {
+								using (Process bash = new Process {
+									StartInfo = new ProcessStartInfo {
+										FileName = "powershell.exe",
+										Arguments = $"-noprofile -command \"Set-Clipboard -Value \\\"{clipText}\\\"\""
+									}
+								}) {
+									bash.Start ();
+									bash.WaitForExit ();
+								}
+
+								//using (Process clipExe = new Process {
+								//	StartInfo = new ProcessStartInfo {
+								//		RedirectStandardInput = true,
+								//		FileName = "clip.exe"
+								//	}
+								//}) {
+								//	clipExe.Start ();
+								//	clipExe.StandardInput.Write (clipText);
+								//	clipExe.StandardInput.Close ();
+								//	clipExe.WaitForExit ();
+								//	//var result = clipExe.WaitForExit (500);
+								//	//if (result) {
+								//	//	clipExe.WaitForExit ();
+								//	//}
+								//}
+							} catch {
+								exit = true;
+							}
+							if (!exit) {
+								getClipText = Clipboard.Contents.ToString ();
+							}
+							Application.RequestStop ();
+							return;
+						}
+						if (exit = xclipExists () == false) {
+							// xclip doesn't exist then exit.
+							Application.RequestStop ();
+							return;
+						}
+
+						using (Process bash = new Process {
+							StartInfo = new ProcessStartInfo {
+								FileName = "bash",
+								Arguments = $"-c \"xclip -sel clip -i\"",
+								RedirectStandardInput = true,
+							}
+						}) {
+							bash.Start ();
+							bash.StandardInput.Write (clipText);
+							bash.StandardInput.Close ();
+							bash.WaitForExit ();
 						}
 						if (!exit) {
 							getClipText = Clipboard.Contents.ToString ();
 						}
-						Application.RequestStop ();
-						return;
-					}
-					if (exit = xclipExists () == false) {
-						// xclip doesn't exist then exit.
-						Application.RequestStop ();
-						return;
 					}
 
-					using (Process bash = new Process {
-						StartInfo = new ProcessStartInfo {
-							FileName = "bash",
-							Arguments = $"-c \"xclip -sel clip -i\"",
-							RedirectStandardInput = true,
-						}
-					}) {
-						bash.Start ();
-						bash.StandardInput.Write (clipText);
-						bash.StandardInput.Close ();
-						bash.WaitForExit ();
-					}
-					if (!exit) {
-						getClipText = Clipboard.Contents.ToString ();
-					}
-				}
-
-				Application.RequestStop ();
-			};
+					Application.RequestStop ();
+				};
+			}
 
 			Application.Run ();
 


### PR DESCRIPTION
Fixes #2039 - Include a terse summary of the change or which issue is fixed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
