### PR TITLE
Fixes #2041. Check if the folder 'docs' exists before removing in build.ps1.

### DIFF
--- a/docfx/build.ps1
+++ b/docfx/build.ps1
@@ -2,7 +2,10 @@
 
 dotnet build --configuration Release ../Terminal.sln
 
-rm ../docs -Recurse -Force
+$Folder = '..\docs'
+if(Test-Path -Path $Folder){
+	rm ../docs -Recurse -Force
+}
 
 $env:DOCFX_SOURCE_BRANCH_NAME="main"
 


### PR DESCRIPTION
Fixes #2041 - Avoids thrown an error if the folder doesn't yet exists.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
