### PR TITLE
Fixes #2045. TrySetClipboardData test must be enclosed with a lock.

### DIFF
--- a/UnitTests/ClipboardTests.cs
+++ b/UnitTests/ClipboardTests.cs
@@ -53,21 +53,23 @@ namespace Terminal.Gui.Core {
 		[AutoInitShutdown]
 		public void TrySetClipboardData_Sets_The_OS_Clipboard ()
 		{
-			var clipText = "Trying to set the OS clipboard.";
-			if (Clipboard.IsSupported) {
-				Assert.True (Clipboard.TrySetClipboardData (clipText));
-			} else {
-				Assert.False (Clipboard.TrySetClipboardData (clipText));
-			}
+			lock (Clipboard.Contents) {
+				var clipText = "Trying to set the OS clipboard.";
+				if (Clipboard.IsSupported) {
+					Assert.True (Clipboard.TrySetClipboardData (clipText));
+				} else {
+					Assert.False (Clipboard.TrySetClipboardData (clipText));
+				}
 
-			Application.Iteration += () => Application.RequestStop ();
+				Application.Iteration += () => Application.RequestStop ();
 
-			Application.Run ();
+				Application.Run ();
 
-			if (Clipboard.IsSupported) {
-				Assert.Equal (clipText, Clipboard.Contents);
-			} else {
-				Assert.NotEqual (clipText, Clipboard.Contents);
+				if (Clipboard.IsSupported) {
+					Assert.Equal (clipText, Clipboard.Contents);
+				} else {
+					Assert.NotEqual (clipText, Clipboard.Contents);
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #2045 - Avoids throw an error if Clipboard.Contents is already being used in another test.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
