### PR TITLE
Fixes #2053. I am still having this issue with v1.8.0 on windows/net6.0.

### DIFF
--- a/StandaloneExample/Program.cs
+++ b/StandaloneExample/Program.cs
@@ -5,6 +5,8 @@
 	using NStack;
 	using System.Text;
 	using Rune = System.Rune;
+	using System.Runtime.InteropServices;
+	using System.Diagnostics;
 
 	static class Demo {
 		class Box10x : View {
@@ -220,6 +222,19 @@
 				Width = Dim.Fill (),
 				Height = Dim.Fill () - 1
 			};
+
+			StringBuilder aboutMessage = new StringBuilder ();
+			aboutMessage.AppendLine (@"A comprehensive sample library for");
+			aboutMessage.AppendLine (@"");
+			aboutMessage.AppendLine (@"  _______                  _             _   _____       _  ");
+			aboutMessage.AppendLine (@" |__   __|                (_)           | | / ____|     (_) ");
+			aboutMessage.AppendLine (@"    | | ___ _ __ _ __ ___  _ _ __   __ _| || |  __ _   _ _  ");
+			aboutMessage.AppendLine (@"    | |/ _ \ '__| '_ ` _ \| | '_ \ / _` | || | |_ | | | | | ");
+			aboutMessage.AppendLine (@"    | |  __/ |  | | | | | | | | | | (_| | || |__| | |_| | | ");
+			aboutMessage.AppendLine (@"    |_|\___|_|  |_| |_| |_|_|_| |_|\__,_|_(_)_____|\__,_|_| ");
+			aboutMessage.AppendLine (@"");
+			aboutMessage.AppendLine (@"https://github.com/gui-cs/Terminal.Gui");
+
 			var menu = new MenuBar (new MenuBarItem [] {
 				new MenuBarItem ("_File", new MenuItem [] {
 					new MenuItem ("_New", "Creates new file", NewFile),
@@ -238,6 +253,12 @@
 				miScrollViewCheck = new MenuBarItem ("ScrollView", new MenuItem [] {
 					new MenuItem ("Box10x", "", () => ScrollViewCheck()) {CheckType = MenuItemCheckStyle.Radio, Checked = true },
 					new MenuItem ("Filler", "", () => ScrollViewCheck()) {CheckType = MenuItemCheckStyle.Radio }
+				}),
+					new MenuBarItem ("_Help", new MenuItem [] {
+					new MenuItem ("_gui.cs API Overview", "", () => OpenUrl ("https://gui-cs.github.io/Terminal.Gui/articles/overview.html"), null, null, Key.F1),
+					new MenuItem ("gui.cs _README", "", () => OpenUrl ("https://github.com/gui-cs/Terminal.Gui"), null, null, Key.F2),
+					new MenuItem ("_About...", "About UI Catalog",
+						() =>  MessageBox.Query ("About UI Catalog", aboutMessage.ToString(), "_Ok"), null, null, Key.CtrlMask | Key.A)
 				})
 			});
 
@@ -260,6 +281,33 @@
 			Application.Run ();
 
 			Application.Shutdown ();
+		}
+
+		private static void OpenUrl (string url)
+		{
+			try {
+				if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows)) {
+					url = url.Replace ("&", "^&");
+					Process.Start (new ProcessStartInfo ("cmd", $"/c start {url}") { CreateNoWindow = true });
+				} else if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux)) {
+					using (var process = new Process {
+						StartInfo = new ProcessStartInfo {
+							FileName = "xdg-open",
+							Arguments = url,
+							RedirectStandardError = true,
+							RedirectStandardOutput = true,
+							CreateNoWindow = true,
+							UseShellExecute = false
+						}
+					}) {
+						process.Start ();
+					}
+				} else if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
+					Process.Start ("open", url);
+				}
+			} catch {
+				throw;
+			}
 		}
 	}
 }

--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -248,9 +248,9 @@ namespace Terminal.Gui {
 			} else {
 				maxWidthLine = width;
 			}
-			int textWidth = TextFormatter.MaxWidth (message, maxWidthLine);
+			int textWidth = Math.Min (TextFormatter.MaxWidth (message, maxWidthLine), Application.Driver.Cols);
 			int textHeight = TextFormatter.MaxLines (message, textWidth); // message.Count (ustring.Make ('\n')) + 1;
-			int msgboxHeight = Math.Max (1, textHeight) + 4; // textHeight + (top + top padding + buttons + bottom)
+			int msgboxHeight = Math.Min (Math.Max (1, textHeight) + 4, Application.Driver.Rows); // textHeight + (top + top padding + buttons + bottom)
 
 			// Create button array for Dialog
 			int count = 0;
@@ -300,7 +300,7 @@ namespace Terminal.Gui {
 
 			if (width == 0 & height == 0) {
 				// Dynamically size Width
-				d.Width = Math.Max (maxWidthLine, Math.Max (title.ConsoleWidth, Math.Max (textWidth + 2, d.GetButtonsWidth ()))); // textWidth + (left + padding + padding + right)
+				d.Width = Math.Min (Math.Max (maxWidthLine, Math.Max (title.ConsoleWidth, Math.Max (textWidth + 2, d.GetButtonsWidth ()))), Application.Driver.Cols); // textWidth + (left + padding + padding + right)
 			}
 
 			// Setup actions

--- a/UnitTests/MessageBoxTests.cs
+++ b/UnitTests/MessageBoxTests.cs
@@ -154,5 +154,109 @@ namespace Terminal.Gui.Views {
 
 			Application.Run ();
 		}
+
+		[Fact, AutoInitShutdown]
+		public void MessageBox_With_A_Label_Without_Spaces ()
+		{
+			var iterations = -1;
+			Application.Begin (Application.Top);
+
+			Application.Iteration += () => {
+				iterations++;
+
+				if (iterations == 0) {
+					MessageBox.Query ("mywindow", new string ('f', 2000), "ok");
+
+					Application.RequestStop ();
+				} else if (iterations == 1) {
+					Application.Top.Redraw (Application.Top.Bounds);
+					GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌ mywindow ────────────────────────────────────────────────────────────────────┐
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
+│                                   [◦ ok ◦]                                   │
+└──────────────────────────────────────────────────────────────────────────────┘
+", output);
+
+					Application.RequestStop ();
+				}
+			};
+
+			Application.Run ();
+		}
+
+		[Fact, AutoInitShutdown]
+		public void MessageBox_With_A_Label_With_Spaces ()
+		{
+			var iterations = -1;
+			Application.Begin (Application.Top);
+
+			Application.Iteration += () => {
+				iterations++;
+
+				if (iterations == 0) {
+					var sb = new StringBuilder ();
+					for (int i = 0; i < 1000; i++)
+						sb.Append ("ff ");
+
+					MessageBox.Query ("mywindow", sb.ToString (), "ok");
+
+					Application.RequestStop ();
+				} else if (iterations == 1) {
+					Application.Top.Redraw (Application.Top.Bounds);
+					GraphViewTests.AssertDriverContentsWithFrameAre (@"
+┌ mywindow ────────────────────────────────────────────────────────────────────┐
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
+│                                   [◦ ok ◦]                                   │
+└──────────────────────────────────────────────────────────────────────────────┘
+", output);
+
+					Application.RequestStop ();
+				}
+			};
+
+			Application.Run ();
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2053 - I copied the Help menu from the `UICatalog` and pasted into the `StandaloneExample` net6.0 project which use the 1.8.0 nuget package to prove `MessageBox` text wrapping is working fine. The problem was the dialog size was exceeding the console size.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

![imagem](https://user-images.githubusercontent.com/13117724/191562663-af7e4213-d9fd-4410-baa1-c4a39bc95fa6.png)
