### PR TITLE
Fixes #2061.  WindowsDriver - On 'MouseMoved', at least `ReportMousePosition` flag must be returned.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1123,11 +1123,9 @@ namespace Terminal.Gui {
 				}
 
 			} else if (mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved) {
+				mouseFlag = MouseFlags.ReportMousePosition;
 				if (mouseEvent.MousePosition.X != pointMove.X || mouseEvent.MousePosition.Y != pointMove.Y) {
-					mouseFlag = MouseFlags.ReportMousePosition;
 					pointMove = new Point (mouseEvent.MousePosition.X, mouseEvent.MousePosition.Y);
-				} else {
-					mouseFlag = 0;
 				}
 			} else if (mouseEvent.ButtonState == 0 && mouseEvent.EventFlags == 0) {
 				mouseFlag = 0;


### PR DESCRIPTION
Fixes #2061 - On a `MouseMoved` event at least a `ReportMousePosition` flag must be returned. The only action is only set the `pointMove` field to the correct value if needed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
