### PR TITLE
Fixes #2064. Make `Application.MouseGrabView` public; allow views who use it some control

### DIFF
--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -581,7 +581,22 @@ namespace Terminal.Gui {
 			return top;
 		}
 
-		internal static View mouseGrabView;
+		static View mouseGrabView;
+
+		/// <summary>
+		/// The view that grabbed the mouse, to where will be routed all the mouse events.
+		/// </summary>
+		public static View MouseGrabView => mouseGrabView;
+
+		/// <summary>
+		/// Event to be invoked when a view grab the mouse.
+		/// </summary>
+		public static event Action<View> GrabbedMouse;
+
+		/// <summary>
+		/// Event to be invoked when a view ungrab the mouse.
+		/// </summary>
+		public static event Action<View> UnGrabbedMouse;
 
 		/// <summary>
 		/// Grabs the mouse, forcing all mouse events to be routed to the specified view until UngrabMouse is called.
@@ -592,6 +607,7 @@ namespace Terminal.Gui {
 		{
 			if (view == null)
 				return;
+			OnGrabbedMouse (view);
 			mouseGrabView = view;
 			Driver.UncookMouse ();
 		}
@@ -601,8 +617,25 @@ namespace Terminal.Gui {
 		/// </summary>
 		public static void UngrabMouse ()
 		{
+			if (mouseGrabView == null)
+				return;
+			OnUnGrabbedMouse (mouseGrabView);
 			mouseGrabView = null;
 			Driver.CookMouse ();
+		}
+
+		static void OnGrabbedMouse (View view)
+		{
+			if (view == null)
+				return;
+			GrabbedMouse?.Invoke (view);
+		}
+
+		static void OnUnGrabbedMouse (View view)
+		{
+			if (view == null)
+				return;
+			UnGrabbedMouse?.Invoke (view);
 		}
 
 		/// <summary>
@@ -656,7 +689,7 @@ namespace Terminal.Gui {
 					lastMouseOwnerView?.OnMouseLeave (me);
 				}
 				// System.Diagnostics.Debug.WriteLine ($"{nme.Flags};{nme.X};{nme.Y};{mouseGrabView}");
-				if (mouseGrabView != null && mouseGrabView.OnMouseEvent (nme)) {
+				if (mouseGrabView?.OnMouseEvent (nme) == true) {
 					return;
 				}
 			}

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -1816,7 +1816,7 @@ namespace Terminal.Gui {
 
 		internal bool HandleGrabView (MouseEvent me, View current)
 		{
-			if (Application.mouseGrabView != null) {
+			if (Application.MouseGrabView != null) {
 				if (me.View is MenuBar || me.View is Menu) {
 					var mbar = GetMouseGrabViewInstance (me.View);
 					if (mbar != null) {
@@ -1890,7 +1890,7 @@ namespace Terminal.Gui {
 			//if (!(me.View is MenuBar) && !(me.View is Menu) && me.Flags != MouseFlags.Button1Pressed))
 			//	return false;
 
-			//if (Application.mouseGrabView != null) {
+			//if (Application.MouseGrabView != null) {
 			//	if (me.View is MenuBar || me.View is Menu) {
 			//		me.X -= me.OfX;
 			//		me.Y -= me.OfY;
@@ -1905,8 +1905,8 @@ namespace Terminal.Gui {
 			//	return true;
 			//}
 
-			//if (Application.mouseGrabView != null) {
-			//	if (Application.mouseGrabView == me.View && me.View == current) {
+			//if (Application.MouseGrabView != null) {
+			//	if (Application.MouseGrabView == me.View && me.View == current) {
 			//		me.X -= me.OfX;
 			//		me.Y -= me.OfY;
 			//	} else if (me.View != current && me.View is MenuBar && me.View is Menu) {
@@ -1927,7 +1927,7 @@ namespace Terminal.Gui {
 
 		MenuBar GetMouseGrabViewInstance (View view)
 		{
-			if (view == null || Application.mouseGrabView == null) {
+			if (view == null || Application.MouseGrabView == null) {
 				return null;
 			}
 
@@ -1938,7 +1938,7 @@ namespace Terminal.Gui {
 				hostView = ((Menu)view).host;
 			}
 
-			var grabView = Application.mouseGrabView;
+			var grabView = Application.MouseGrabView;
 			MenuBar hostGrabView = null;
 			if (grabView is MenuBar) {
 				hostGrabView = (MenuBar)grabView;

--- a/Terminal.Gui/Views/ScrollBarView.cs
+++ b/Terminal.Gui/Views/ScrollBarView.cs
@@ -357,7 +357,7 @@ namespace Terminal.Gui {
 				} else if (otherScrollBarView != null && otherScrollBarView.contentBottomRightCorner != null) {
 					otherScrollBarView.contentBottomRightCorner.Visible = false;
 				}
-				if (Application.mouseGrabView != null && Application.mouseGrabView == this) {
+				if (Application.MouseGrabView != null && Application.MouseGrabView == this) {
 					Application.UngrabMouse ();
 				}
 			} else if (contentBottomRightCorner != null) {
@@ -638,9 +638,9 @@ namespace Terminal.Gui {
 			var pos = Position;
 
 			if (me.Flags != MouseFlags.Button1Released
-				&& (Application.mouseGrabView == null || Application.mouseGrabView != this)) {
+				&& (Application.MouseGrabView == null || Application.MouseGrabView != this)) {
 				Application.GrabMouse (this);
-			} else if (me.Flags == MouseFlags.Button1Released && Application.mouseGrabView != null && Application.mouseGrabView == this) {
+			} else if (me.Flags == MouseFlags.Button1Released && Application.MouseGrabView != null && Application.MouseGrabView == this) {
 				lastLocation = -1;
 				Application.UngrabMouse ();
 				return true;

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -227,7 +227,7 @@ namespace Terminal.Gui {
 
 		void View_MouseLeave (MouseEventArgs e)
 		{
-			if (Application.mouseGrabView != null && Application.mouseGrabView != vertical && Application.mouseGrabView != horizontal) {
+			if (Application.MouseGrabView != null && Application.MouseGrabView != vertical && Application.MouseGrabView != horizontal) {
 				Application.UngrabMouse ();
 			}
 		}

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -249,9 +249,9 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override bool OnLeave (View view)
 		{
-			if (Application.mouseGrabView != null && Application.mouseGrabView == this)
+			if (Application.MouseGrabView != null && Application.MouseGrabView == this)
 				Application.UngrabMouse ();
-			//if (SelectedLength != 0 && !(Application.mouseGrabView is MenuBar))
+			//if (SelectedLength != 0 && !(Application.MouseGrabView is MenuBar))
 			//	ClearAllSelection ();
 
 			return base.OnLeave (view);
@@ -1049,7 +1049,7 @@ namespace Terminal.Gui {
 				int x = PositionCursor (ev);
 				isButtonReleased = false;
 				PrepareSelection (x);
-				if (Application.mouseGrabView == null) {
+				if (Application.MouseGrabView == null) {
 					Application.GrabMouse (this);
 				}
 			} else if (ev.Flags == MouseFlags.Button1Released) {

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -4328,7 +4328,7 @@ namespace Terminal.Gui {
 				}
 				lastWasKill = false;
 				columnTrack = currentColumn;
-				if (Application.mouseGrabView == null) {
+				if (Application.MouseGrabView == null) {
 					Application.GrabMouse (this);
 				}
 			} else if (ev.Flags.HasFlag (MouseFlags.Button1Released)) {
@@ -4407,7 +4407,7 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override bool OnLeave (View view)
 		{
-			if (Application.mouseGrabView != null && Application.mouseGrabView == this) {
+			if (Application.MouseGrabView != null && Application.MouseGrabView == this) {
 				Application.UngrabMouse ();
 			}
 

--- a/UnitTests/ContextMenuTests.cs
+++ b/UnitTests/ContextMenuTests.cs
@@ -519,38 +519,38 @@ namespace Terminal.Gui.Core {
 
 			Application.Top.Add (menu);
 
-			Assert.Null (Application.mouseGrabView);
+			Assert.Null (Application.MouseGrabView);
 
 			cm.Show ();
 			Assert.True (ContextMenu.IsShow);
-			Assert.Equal (cm.MenuBar, Application.mouseGrabView);
+			Assert.Equal (cm.MenuBar, Application.MouseGrabView);
 			Assert.False (menu.IsMenuOpen);
 			Assert.True (menu.ProcessHotKey (new KeyEvent (Key.F9, new KeyModifiers ())));
 			Assert.False (ContextMenu.IsShow);
-			Assert.Equal (menu, Application.mouseGrabView);
+			Assert.Equal (menu, Application.MouseGrabView);
 			Assert.True (menu.IsMenuOpen);
 
 			cm.Show ();
 			Assert.True (ContextMenu.IsShow);
-			Assert.Equal (cm.MenuBar, Application.mouseGrabView);
+			Assert.Equal (cm.MenuBar, Application.MouseGrabView);
 			Assert.False (menu.IsMenuOpen);
 			Assert.False (menu.OnKeyDown (new KeyEvent (Key.Null, new KeyModifiers () { Alt = true })));
 			Assert.True (menu.OnKeyUp (new KeyEvent (Key.Null, new KeyModifiers () { Alt = true })));
 			Assert.False (ContextMenu.IsShow);
-			Assert.Equal (menu, Application.mouseGrabView);
+			Assert.Equal (menu, Application.MouseGrabView);
 			Assert.True (menu.IsMenuOpen);
 
 			cm.Show ();
 			Assert.True (ContextMenu.IsShow);
-			Assert.Equal (cm.MenuBar, Application.mouseGrabView);
+			Assert.Equal (cm.MenuBar, Application.MouseGrabView);
 			Assert.False (menu.IsMenuOpen);
 			Assert.False (menu.MouseEvent (new MouseEvent () { X = 1, Flags = MouseFlags.ReportMousePosition, View = menu }));
 			Assert.True (ContextMenu.IsShow);
-			Assert.Equal (cm.MenuBar, Application.mouseGrabView);
+			Assert.Equal (cm.MenuBar, Application.MouseGrabView);
 			Assert.False (menu.IsMenuOpen);
 			Assert.True (menu.MouseEvent (new MouseEvent () { X = 1, Flags = MouseFlags.Button1Clicked, View = menu }));
 			Assert.False (ContextMenu.IsShow);
-			Assert.Equal (menu, Application.mouseGrabView);
+			Assert.Equal (menu, Application.MouseGrabView);
 			Assert.True (menu.IsMenuOpen);
 		}
 

--- a/UnitTests/ScrollBarViewTests.cs
+++ b/UnitTests/ScrollBarViewTests.cs
@@ -947,7 +947,7 @@ This is a test
 					Flags = MouseFlags.Button1Clicked
 				});
 
-			Assert.Null (Application.mouseGrabView);
+			Assert.Null (Application.MouseGrabView);
 			Assert.True (clicked);
 
 			clicked = false;
@@ -974,7 +974,7 @@ This is a test
 					Flags = MouseFlags.Button1Clicked
 				});
 
-			Assert.Null (Application.mouseGrabView);
+			Assert.Null (Application.MouseGrabView);
 			Assert.True (clicked);
 			Assert.Equal (5, sbv.Size);
 			Assert.False (sbv.ShowScrollIndicator);


### PR DESCRIPTION
Fixes #2064 - This is useful for a grabbed view that is being grabbed to another view to be notified and thus taking some necessary action.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
