### PR TITLE
Fixes #2069. Enable KeyDown and KeyUp events to be canceled (like KeyPress)

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -370,12 +370,14 @@ namespace Terminal.Gui {
 			return keyMod != Key.Null ? keyMod | key : key;
 		}
 
+		Action<KeyEvent> keyDownHandler;
 		Action<KeyEvent> keyHandler;
 		Action<KeyEvent> keyUpHandler;
 		private CursorVisibility savedCursorVisibility;
 
 		public override void PrepareToRun (MainLoop mainLoop, Action<KeyEvent> keyHandler, Action<KeyEvent> keyDownHandler, Action<KeyEvent> keyUpHandler, Action<MouseEvent> mouseHandler)
 		{
+			this.keyDownHandler = keyDownHandler;
 			this.keyHandler = keyHandler;
 			this.keyUpHandler = keyUpHandler;
 
@@ -400,6 +402,7 @@ namespace Terminal.Gui {
 				keyModifiers.Ctrl = true;
 			}
 
+			keyDownHandler (new KeyEvent (map, keyModifiers));
 			keyHandler (new KeyEvent (map, keyModifiers));
 			keyUpHandler (new KeyEvent (map, keyModifiers));
 		}

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -388,18 +388,22 @@ namespace Terminal.Gui {
 		void ProcessInput (ConsoleKeyInfo consoleKey)
 		{
 			keyModifiers = new KeyModifiers ();
-			var map = MapKey (consoleKey);
-			if (map == (Key)0xffffffff)
-				return;
-
-			if (consoleKey.Modifiers.HasFlag (ConsoleModifiers.Alt)) {
-				keyModifiers.Alt = true;
-			}
 			if (consoleKey.Modifiers.HasFlag (ConsoleModifiers.Shift)) {
 				keyModifiers.Shift = true;
 			}
+			if (consoleKey.Modifiers.HasFlag (ConsoleModifiers.Alt)) {
+				keyModifiers.Alt = true;
+			}
 			if (consoleKey.Modifiers.HasFlag (ConsoleModifiers.Control)) {
 				keyModifiers.Ctrl = true;
+			}
+			var map = MapKey (consoleKey);
+			if (map == (Key)0xffffffff) {
+				if ((consoleKey.Modifiers & (ConsoleModifiers.Shift | ConsoleModifiers.Alt | ConsoleModifiers.Control)) != 0) {
+					keyDownHandler (new KeyEvent (map, keyModifiers));
+					keyUpHandler (new KeyEvent (map, keyModifiers));
+				}
+				return;
 			}
 
 			keyDownHandler (new KeyEvent (map, keyModifiers));

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1932,8 +1932,14 @@ namespace Terminal.Gui {
 			if (args.Handled) {
 				return true;
 			}
-			if (Focused?.Enabled == true && Focused?.OnKeyDown (keyEvent) == true) {
-				return true;
+			if (Focused?.Enabled == true) {
+				Focused.KeyDown?.Invoke (args);
+				if (args.Handled) {
+					return true;
+				}
+				if (Focused?.OnKeyDown (keyEvent) == true) {
+					return true;
+				}
 			}
 
 			return false;
@@ -1956,8 +1962,14 @@ namespace Terminal.Gui {
 			if (args.Handled) {
 				return true;
 			}
-			if (Focused?.Enabled == true && Focused?.OnKeyUp (keyEvent) == true) {
-				return true;
+			if (Focused?.Enabled == true) {
+				Focused.KeyUp?.Invoke (args);
+				if (args.Handled) {
+					return true;
+				}
+				if (Focused?.OnKeyUp (keyEvent) == true) {
+					return true;
+				}
 			}
 
 			return false;

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -3914,40 +3914,50 @@ This is a tes
 		[Fact, AutoInitShutdown]
 		public void KeyDown_And_KeyUp_Events_Must_Called_Before_OnKeyDown_And_OnKeyUp ()
 		{
+			var keyDown = false;
+			var keyPress = false;
+			var keyUp = false;
+
 			var view = new DerivedView ();
 			view.KeyDown += (e) => {
 				Assert.Equal (Key.a, e.KeyEvent.Key);
+				Assert.False (keyDown);
 				Assert.False (view.IsKeyDown);
 				e.Handled = true;
+				keyDown = true;
 			};
 			view.KeyPress += (e) => {
 				Assert.Equal (Key.a, e.KeyEvent.Key);
+				Assert.False (keyPress);
 				Assert.False (view.IsKeyPress);
 				e.Handled = true;
+				keyPress = true;
 			};
 			view.KeyUp += (e) => {
 				Assert.Equal (Key.a, e.KeyEvent.Key);
+				Assert.False (keyUp);
 				Assert.False (view.IsKeyUp);
 				e.Handled = true;
-			};
-
-			var iterations = -1;
-
-			Application.Iteration += () => {
-				iterations++;
-				if (iterations == 0) {
-					Console.MockKeyPresses.Push (new ConsoleKeyInfo ('a', ConsoleKey.A, false, false, false));
-				} else if (iterations == 1) {
-					Application.RequestStop ();
-				}
+				keyUp = true;
 			};
 
 			Application.Top.Add (view);
+
+			Console.MockKeyPresses.Push (new ConsoleKeyInfo ('a', ConsoleKey.A, false, false, false));
+
+			Application.Iteration += () => Application.RequestStop ();
 
 			Assert.True (view.CanFocus);
 
 			Application.Run ();
 			Application.Shutdown ();
+
+			Assert.True (keyDown);
+			Assert.True (keyPress);
+			Assert.True (keyUp);
+			Assert.False (view.IsKeyDown);
+			Assert.False (view.IsKeyPress);
+			Assert.False (view.IsKeyUp);
 		}
 
 		public class DerivedView : View {
@@ -3963,20 +3973,72 @@ This is a tes
 			public override bool OnKeyDown (KeyEvent keyEvent)
 			{
 				IsKeyDown = true;
-				return base.OnKeyDown (keyEvent);
+				return true;
 			}
 
 			public override bool ProcessKey (KeyEvent keyEvent)
 			{
 				IsKeyPress = true;
-				return base.ProcessKey (keyEvent);
+				return true;
 			}
 
 			public override bool OnKeyUp (KeyEvent keyEvent)
 			{
 				IsKeyUp = true;
-				return base.OnKeyUp (keyEvent);
+				return true;
 			}
+		}
+
+		[Theory, AutoInitShutdown]
+		[InlineData (true, false, false)]
+		[InlineData (true, true, false)]
+		[InlineData (true, true, true)]
+		public void KeyDown_And_KeyUp_Events_With_Only_Key_Modifiers (bool shift, bool alt, bool control)
+		{
+			var keyDown = false;
+			var keyPress = false;
+			var keyUp = false;
+
+			var view = new DerivedView ();
+			view.KeyDown += (e) => {
+				Assert.Equal (-1, e.KeyEvent.KeyValue);
+				Assert.Equal (shift, e.KeyEvent.IsShift);
+				Assert.Equal (alt, e.KeyEvent.IsAlt);
+				Assert.Equal (control, e.KeyEvent.IsCtrl);
+				Assert.False (keyDown);
+				Assert.False (view.IsKeyDown);
+				keyDown = true;
+			};
+			view.KeyPress += (e) => {
+				keyPress = true;
+			};
+			view.KeyUp += (e) => {
+				Assert.Equal (-1, e.KeyEvent.KeyValue);
+				Assert.Equal (shift, e.KeyEvent.IsShift);
+				Assert.Equal (alt, e.KeyEvent.IsAlt);
+				Assert.Equal (control, e.KeyEvent.IsCtrl);
+				Assert.False (keyUp);
+				Assert.False (view.IsKeyUp);
+				keyUp = true;
+			};
+
+			Application.Top.Add (view);
+
+			Console.MockKeyPresses.Push (new ConsoleKeyInfo ('\0', (ConsoleKey)'\0', shift, alt, control));
+
+			Application.Iteration += () => Application.RequestStop ();
+
+			Assert.True (view.CanFocus);
+
+			Application.Run ();
+			Application.Shutdown ();
+
+			Assert.True (keyDown);
+			Assert.False (keyPress);
+			Assert.True (keyUp);
+			Assert.True (view.IsKeyDown);
+			Assert.False (view.IsKeyPress);
+			Assert.True (view.IsKeyUp);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2069 - Now it's possible to cancel any key on the `KeyDown` and `KeyUp` events, like `KeyPress` event does.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
