### PR TITLE
Fixes #2071. DrawContentComplete event is never called from the base if it's overridden.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1548,6 +1548,7 @@ namespace Terminal.Gui {
 								};
 								view.OnDrawContent (rect);
 								view.Redraw (rect);
+								view.OnDrawContentComplete (rect);
 							}
 						}
 						view.NeedDisplay = Rect.Empty;

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -3892,5 +3892,23 @@ This is a tes
 This is a tes
 ", output);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void DrawContentComplete_Event_Is_Always_Called ()
+		{
+			var viewCalled = false;
+			var tvCalled = false;
+
+			var view = new View ("View") { Width = 10, Height = 10 };
+			view.DrawContentComplete += (e) => viewCalled = true;
+			var tv = new TextView () { Y = 11, Width = 10, Height = 10 };
+			tv.DrawContentComplete += (e) => tvCalled = true;
+
+			Application.Top.Add (view, tv);
+			Application.Begin (Application.Top);
+
+			Assert.True (viewCalled);
+			Assert.True (tvCalled);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2071 - The `DrawContentComplete` event is also needed be called from the views that overridden the Redraw method to do some action after drawn.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
