### PR TITLE
Fixes #2073. Can no longer nest Application.MainLoop.Invoke.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -395,10 +395,7 @@ namespace Terminal.Gui {
 				};
 
 				if ((mouseFlag & MouseFlags.ReportMousePosition) == 0) {
-					Application.MainLoop.AddIdle (() => {
-						Task.Run (async () => await ProcessContinuousButtonPressedAsync (mouseFlag));
-						return false;
-					});
+					Application.MainLoop.Invoke (async () => await ProcessContinuousButtonPressedAsync (mouseFlag));
 				}
 
 

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -1500,6 +1500,7 @@ namespace Terminal.Gui {
 				}
 			}) {
 				powershell.Start ();
+				powershell.WaitForExit ();
 				if (!powershell.DoubleWaitForExit ()) {
 					var timeoutError = $@"Process timed out. Command line: bash {powershell.StartInfo.Arguments}.
 							Output: {powershell.StandardOutput.ReadToEnd ()}

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -713,10 +713,7 @@ namespace Terminal.Gui {
 			//System.Diagnostics.Debug.WriteLine ($"ButtonState: {mouseEvent.ButtonState} X: {mouseEvent.Position.X} Y: {mouseEvent.Position.Y}");
 
 			if (isButtonDoubleClicked) {
-				Application.MainLoop.AddIdle (() => {
-					Task.Run (async () => await ProcessButtonDoubleClickedAsync ());
-					return false;
-				});
+				Application.MainLoop.Invoke (async () => await ProcessButtonDoubleClickedAsync ());
 			}
 
 			if ((buttonState & MouseButtonState.Button1Pressed) != 0
@@ -782,12 +779,9 @@ namespace Terminal.Gui {
 				isButtonClicked = false;
 				isButtonDoubleClicked = true;
 				ProcessButtonDoubleClicked (mouseEvent);
-				Application.MainLoop.AddIdle (() => {
-					Task.Run (async () => {
-						await Task.Delay (600);
-						isButtonDoubleClicked = false;
-					});
-					return false;
+				Application.MainLoop.Invoke (async () => {
+					await Task.Delay (600);
+					isButtonDoubleClicked = false;
 				});
 				inputReady.Set ();
 				return;
@@ -829,12 +823,9 @@ namespace Terminal.Gui {
 				|| (buttonState & MouseButtonState.Button3Released) != 0)) {
 				isButtonClicked = true;
 				ProcessButtonClicked (mouseEvent);
-				Application.MainLoop.AddIdle (() => {
-					Task.Run (async () => {
-						await Task.Delay (300);
-						isButtonClicked = false;
-					});
-					return false;
+				Application.MainLoop.Invoke (async () => {
+					await Task.Delay (300);
+					isButtonClicked = false;
 				});
 				inputReady.Set ();
 				return;
@@ -852,10 +843,7 @@ namespace Terminal.Gui {
 					};
 				}
 				if ((buttonState & MouseButtonState.ReportMousePosition) == 0) {
-					Application.MainLoop.AddIdle (() => {
-						Task.Run (async () => await ProcessContinuousButtonPressedAsync ());
-						return false;
-					});
+					Application.MainLoop.Invoke (async () => await ProcessContinuousButtonPressedAsync ());
 				}
 			}
 
@@ -951,7 +939,7 @@ namespace Terminal.Gui {
 				if (view == null) {
 					break;
 				}
-				if (isButtonPressed && (lastMouseEvent.ButtonState & MouseButtonState.ReportMousePosition) == 0) {
+				if (isButtonPressed) {
 					inputResultQueue.Enqueue (new InputResult () {
 						EventType = EventType.Mouse,
 						MouseEvent = lastMouseEvent

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -914,10 +914,7 @@ namespace Terminal.Gui {
 			//	$"X:{mouseEvent.MousePosition.X};Y:{mouseEvent.MousePosition.Y};ButtonState:{mouseEvent.ButtonState};EventFlags:{mouseEvent.EventFlags}");
 
 			if (isButtonDoubleClicked || isOneFingerDoubleClicked) {
-				Application.MainLoop.AddIdle (() => {
-					Task.Run (async () => await ProcessButtonDoubleClickedAsync ());
-					return false;
-				});
+				Application.MainLoop.Invoke (async () => await ProcessButtonDoubleClickedAsync ());
 			}
 
 			// The ButtonState member of the MouseEvent structure has bit corresponding to each mouse button.
@@ -1025,10 +1022,7 @@ namespace Terminal.Gui {
 				isButtonPressed = true;
 
 				if ((mouseFlag & MouseFlags.ReportMousePosition) == 0) {
-					Application.MainLoop.AddIdle (() => {
-						Task.Run (async () => await ProcessContinuousButtonPressedAsync (mouseFlag));
-						return false;
-					});
+					Application.MainLoop.Invoke (async () => await ProcessContinuousButtonPressedAsync (mouseFlag));
 				}
 
 			} else if (lastMouseButtonPressed != null && mouseEvent.EventFlags == 0

--- a/Terminal.Gui/Core/Clipboard/ClipboardBase.cs
+++ b/Terminal.Gui/Core/Clipboard/ClipboardBase.cs
@@ -92,7 +92,8 @@ namespace Terminal.Gui {
 			try {
 				SetClipboardDataImpl (text);
 				return true;
-			} catch (Exception) {
+			} catch (Exception ex) {
+				System.Diagnostics.Debug.WriteLine ($"TrySetClipboardData: {ex.Message}");
 				return false;
 			}
 		}

--- a/Terminal.Gui/Core/ShortcutHelper.cs
+++ b/Terminal.Gui/Core/ShortcutHelper.cs
@@ -244,7 +244,8 @@ namespace Terminal.Gui {
 		public static bool FindAndOpenByShortcut (KeyEvent kb, View view = null)
 		{
 			if (view == null) {
-				return false;			}
+				return false;
+			}
 
 			var key = kb.KeyValue;
 			var keys = GetModifiersKey (kb);
@@ -252,12 +253,7 @@ namespace Terminal.Gui {
 			foreach (var v in view.Subviews) {
 				if (v.Shortcut != Key.Null && v.Shortcut == (Key)key) {
 					var action = v.ShortcutAction;
-					if (action != null) {
-						Application.MainLoop.AddIdle (() => {
-							action ();
-							return false;
-						});
-					}
+					Application.MainLoop.Invoke (() => action?.Invoke ());
 					return true;
 				}
 				if (FindAndOpenByShortcut (kb, v)) {

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -577,10 +577,7 @@ namespace Terminal.Gui {
 			host.CloseAllMenus ();
 			Application.Refresh ();
 
-			Application.MainLoop.AddIdle (() => {
-				action ();
-				return false;
-			});
+			Application.MainLoop.Invoke (() => action?.Invoke ());
 		}
 
 		public override bool OnLeave (View view)
@@ -1089,10 +1086,7 @@ namespace Terminal.Gui {
 			CloseAllMenus ();
 			Application.Refresh ();
 
-			Application.MainLoop.AddIdle (() => {
-				action ();
-				return false;
-			});
+			Application.MainLoop.Invoke (() => action?.Invoke ());
 		}
 
 		/// <summary>
@@ -1635,12 +1629,7 @@ namespace Terminal.Gui {
 				}
 				if ((!(mi is MenuBarItem mbiTopLevel) || mbiTopLevel.IsTopLevel) && mi.Shortcut != Key.Null && mi.Shortcut == (Key)key) {
 					var action = mi.Action;
-					if (action != null) {
-						Application.MainLoop.AddIdle (() => {
-							action ();
-							return false;
-						});
-					}
+					Application.MainLoop.Invoke (() => action?.Invoke ());
 					return true;
 				}
 				if (mi is MenuBarItem menuBarItem && !menuBarItem.IsTopLevel && FindAndOpenMenuByShortcut (kb, menuBarItem.Children)) {

--- a/Terminal.Gui/Views/StatusBar.cs
+++ b/Terminal.Gui/Views/StatusBar.cs
@@ -222,10 +222,7 @@ namespace Terminal.Gui {
 			if (action == null)
 				return;
 
-			Application.MainLoop.AddIdle (() => {
-				action ();
-				return false;
-			});
+			Application.MainLoop.Invoke (() => action?.Invoke ());
 		}
 
 		/// <inheritdoc/>

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\dotnet-core.yml = .github\workflows\dotnet-core.yml
 		.github\workflows\publish.yml = .github\workflows\publish.yml
 		README.md = README.md
+		testenvironments.json = testenvironments.json
 	EndProjectSection
 EndProject
 Global

--- a/UnitTests/ToplevelTests.cs
+++ b/UnitTests/ToplevelTests.cs
@@ -33,9 +33,10 @@ namespace Terminal.Gui.Core {
 		[AutoInitShutdown]
 		public void Application_Top_EnsureVisibleBounds_To_Driver_Rows_And_Cols ()
 		{
-			var iterations = 0;
+			var iterations = -1;
 
 			Application.Iteration += () => {
+				iterations++;
 				if (iterations == 0) {
 					Assert.False (Application.Top.AutoSize);
 					Assert.Equal ("Top1", Application.Top.Text);
@@ -78,7 +79,6 @@ namespace Terminal.Gui.Core {
 
 					Application.Top.ProcessHotKey (new KeyEvent (Key.CtrlMask | Key.Q, new KeyModifiers ()));
 				}
-				iterations++;
 			};
 
 			Application.Run (Top1 ());

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -1,0 +1,15 @@
+{
+	"version": "1",
+	"environments": [
+		{
+			"name": "WSL-Ubuntu",
+			"type": "wsl",
+			"wslDistribution": "Ubuntu"
+		},
+		{
+			"name": "WSL-Debian",
+			"type": "wsl",
+			"wslDistribution": "Debian"
+		}
+	]
+}


### PR DESCRIPTION
Fixes #2073 - View action must be called without using the `Application.MainLoop.Invoke` to avoid been blocked by the idle handlers..

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
