### PR TITLE
Fixes #2078: Enable collection initializer syntax for View

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -111,7 +111,7 @@ namespace Terminal.Gui {
 	///    frames for the vies that use <see cref="LayoutStyle.Computed"/>.
 	/// </para>
 	/// </remarks>
-	public partial class View : Responder, ISupportInitializeNotification {
+	public partial class View : Responder, IEnumerable, ISupportInitializeNotification {
 
 		internal enum Direction {
 			Forward,
@@ -3039,5 +3039,7 @@ namespace Terminal.Gui {
 
 			return top;
 		}
+
+		IEnumerator IEnumerable.GetEnumerator () => Subviews.GetEnumerator ();
 	}
 }

--- a/UnitTests/ScrollBarViewTests.cs
+++ b/UnitTests/ScrollBarViewTests.cs
@@ -282,8 +282,12 @@ namespace Terminal.Gui.Views {
 			AddHandlers ();
 
 			Assert.NotNull (_scrollBar.OtherScrollBarView);
-			Assert.NotEqual (_scrollBar, _scrollBar.OtherScrollBarView);
-			Assert.Equal (_scrollBar.OtherScrollBarView.OtherScrollBarView, _scrollBar);
+			Assert.NotSame (_scrollBar, _scrollBar.OtherScrollBarView);
+			Assert.False (_scrollBar == _scrollBar.OtherScrollBarView);
+			Assert.True (_scrollBar != _scrollBar.OtherScrollBarView);
+			Assert.Same (_scrollBar.OtherScrollBarView.OtherScrollBarView, _scrollBar);
+			Assert.True (_scrollBar.OtherScrollBarView.OtherScrollBarView == _scrollBar);
+			Assert.False (_scrollBar.OtherScrollBarView.OtherScrollBarView != _scrollBar);
 		}
 
 		[Fact]

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -117,6 +117,20 @@ namespace Terminal.Gui.Core {
 		}
 
 		[Fact]
+		public void New_CollectionInitialized ()
+		{
+			var view = new View {
+				new View {
+					new View()
+				},
+				new View()
+			};
+
+			Assert.Equal (2, view.Subviews.Count);
+			Assert.Equal (1, view.Subviews [0].Subviews.Count);
+		}
+
+		[Fact]
 		public void New_Methods_Return_False ()
 		{
 			var r = new View ();


### PR DESCRIPTION
Adds the missing IEnumerable interface implementation so that collection initializers can be used to more declaratively create view structures.

Fixes #2078