### PR TITLE
Fixes #2081. Clipboard unit tests sometimes fail with WSL.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -1500,6 +1500,7 @@ namespace Terminal.Gui {
 				}
 			}) {
 				powershell.Start ();
+				powershell.WaitForExit ();
 				if (!powershell.DoubleWaitForExit ()) {
 					var timeoutError = $@"Process timed out. Command line: bash {powershell.StartInfo.Arguments}.
 							Output: {powershell.StandardOutput.ReadToEnd ()}

--- a/Terminal.Gui/Core/Clipboard/ClipboardBase.cs
+++ b/Terminal.Gui/Core/Clipboard/ClipboardBase.cs
@@ -92,7 +92,8 @@ namespace Terminal.Gui {
 			try {
 				SetClipboardDataImpl (text);
 				return true;
-			} catch (Exception) {
+			} catch (Exception ex) {
+				System.Diagnostics.Debug.WriteLine ($"TrySetClipboardData: {ex.Message}");
 				return false;
 			}
 		}

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\dotnet-core.yml = .github\workflows\dotnet-core.yml
 		.github\workflows\publish.yml = .github\workflows\publish.yml
 		README.md = README.md
+		testenvironments.json = testenvironments.json
 	EndProjectSection
 EndProject
 Global

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -1,0 +1,15 @@
+{
+	"version": "1",
+	"environments": [
+		{
+			"name": "WSL-Ubuntu",
+			"type": "wsl",
+			"wslDistribution": "Ubuntu"
+		},
+		{
+			"name": "WSL-Debian",
+			"type": "wsl",
+			"wslDistribution": "Debian"
+		}
+	]
+}


### PR DESCRIPTION
Fixes #2081 - I also included a json configuration file to allowing debugging unit tests on Linux with the VS 2022.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
