### PR TITLE
TreeView - (redo) Adds option to highlight only the model text of selected node 

### DIFF
--- a/Terminal.Gui/Core/Trees/Branch.cs
+++ b/Terminal.Gui/Core/Trees/Branch.cs
@@ -121,7 +121,7 @@ namespace Terminal.Gui.Trees {
 				Attribute color = symbolColor;
 
 				if (tree.Style.ColorExpandSymbol) {
-					color = isSelected ? tree.ColorScheme.HotFocus : tree.ColorScheme.HotNormal;
+					color = isSelected ? (tree.Style.HighlightModelTextOnly ? colorScheme.HotNormal : tree.ColorScheme.HotFocus) : tree.ColorScheme.HotNormal;
 				} else {
 					color = symbolColor;
 				}

--- a/Terminal.Gui/Core/Trees/Branch.cs
+++ b/Terminal.Gui/Core/Trees/Branch.cs
@@ -90,7 +90,8 @@ namespace Terminal.Gui.Trees {
 		{
 			// true if the current line of the tree is the selected one and control has focus
 			bool isSelected = tree.IsSelected (Model);
-			Attribute textColor = isSelected ? (tree.HasFocus ? colorScheme.HotFocus : colorScheme.HotNormal) : colorScheme.Normal;
+
+			Attribute textColor = isSelected ? (tree.HasFocus ? colorScheme.Focus : colorScheme.HotNormal) : colorScheme.Normal;
 			Attribute symbolColor = tree.Style.HighlightModelTextOnly ? colorScheme.Normal : textColor;
 
 			// Everything on line before the expansion run and branch text

--- a/Terminal.Gui/Core/Trees/Branch.cs
+++ b/Terminal.Gui/Core/Trees/Branch.cs
@@ -121,7 +121,11 @@ namespace Terminal.Gui.Trees {
 				Attribute color = symbolColor;
 
 				if (tree.Style.ColorExpandSymbol) {
-					color = isSelected ? (tree.Style.HighlightModelTextOnly ? colorScheme.HotNormal : tree.ColorScheme.HotFocus) : tree.ColorScheme.HotNormal;
+					if (isSelected) {
+						color = tree.Style.HighlightModelTextOnly ? colorScheme.HotNormal : (tree.HasFocus ? tree.ColorScheme.HotFocus : tree.ColorScheme.HotNormal);
+					} else {
+						color = tree.ColorScheme.HotNormal;
+					}
 				} else {
 					color = symbolColor;
 				}
@@ -416,7 +420,7 @@ namespace Terminal.Gui.Trees {
 		/// Expands the current branch and all children branches.
 		/// </summary>
 		internal void ExpandAll ()
-			{
+		{
 			Expand ();
 
 			if (ChildBranches != null) {

--- a/Terminal.Gui/Core/Trees/Branch.cs
+++ b/Terminal.Gui/Core/Trees/Branch.cs
@@ -5,23 +5,23 @@ using System.Linq;
 namespace Terminal.Gui.Trees {
 	class Branch<T> where T : class {
 		/// <summary>
-		/// True if the branch is expanded to reveal child branches
+		/// True if the branch is expanded to reveal child branches.
 		/// </summary>
 		public bool IsExpanded { get; set; }
 
 		/// <summary>
-		/// The users object that is being displayed by this branch of the tree
+		/// The users object that is being displayed by this branch of the tree.
 		/// </summary>
 		public T Model { get; private set; }
 
 		/// <summary>
-		/// The depth of the current branch.  Depth of 0 indicates root level branches
+		/// The depth of the current branch.  Depth of 0 indicates root level branches.
 		/// </summary>
 		public int Depth { get; private set; } = 0;
 
 		/// <summary>
 		/// The children of the current branch.  This is null until the first call to 
-		/// <see cref="FetchChildren"/> to avoid enumerating the entire underlying hierarchy
+		/// <see cref="FetchChildren"/> to avoid enumerating the entire underlying hierarchy.
 		/// </summary>
 		public Dictionary<T, Branch<T>> ChildBranches { get; set; }
 
@@ -34,12 +34,12 @@ namespace Terminal.Gui.Trees {
 
 		/// <summary>
 		/// Declares a new branch of <paramref name="tree"/> in which the users object 
-		/// <paramref name="model"/> is presented
+		/// <paramref name="model"/> is presented.
 		/// </summary>
-		/// <param name="tree">The UI control in which the branch resides</param>
+		/// <param name="tree">The UI control in which the branch resides.</param>
 		/// <param name="parentBranchIfAny">Pass null for root level branches, otherwise
-		/// pass the parent</param>
-		/// <param name="model">The user's object that should be displayed</param>
+		/// pass the parent.</param>
+		/// <param name="model">The user's object that should be displayed.</param>
 		public Branch (TreeView<T> tree, Branch<T> parentBranchIfAny, T model)
 		{
 			this.tree = tree;
@@ -53,7 +53,7 @@ namespace Terminal.Gui.Trees {
 
 
 		/// <summary>
-		/// Fetch the children of this branch. This method populates <see cref="ChildBranches"/>
+		/// Fetch the children of this branch. This method populates <see cref="ChildBranches"/>.
 		/// </summary>
 		public virtual void FetchChildren ()
 		{
@@ -80,7 +80,7 @@ namespace Terminal.Gui.Trees {
 		}
 
 		/// <summary>
-		/// Renders the current <see cref="Model"/> on the specified line <paramref name="y"/>
+		/// Renders the current <see cref="Model"/> on the specified line <paramref name="y"/>.
 		/// </summary>
 		/// <param name="driver"></param>
 		/// <param name="colorScheme"></param>
@@ -89,10 +89,9 @@ namespace Terminal.Gui.Trees {
 		public virtual void Draw (ConsoleDriver driver, ColorScheme colorScheme, int y, int availableWidth)
 		{
 			// true if the current line of the tree is the selected one and control has focus
-			bool isSelected = tree.IsSelected (Model);// && tree.HasFocus;
-			Attribute lineColor = isSelected ? (tree.HasFocus ? colorScheme.HotFocus : colorScheme.HotNormal) : colorScheme.Normal ;
-
-			driver.SetAttribute (lineColor);
+			bool isSelected = tree.IsSelected (Model);
+			Attribute textColor = isSelected ? (tree.HasFocus ? colorScheme.HotFocus : colorScheme.HotNormal) : colorScheme.Normal;
+			Attribute symbolColor = tree.Style.HighlightModelTextOnly ? colorScheme.Normal : textColor;
 
 			// Everything on line before the expansion run and branch text
 			Rune [] prefix = GetLinePrefix (driver).ToArray ();
@@ -104,7 +103,8 @@ namespace Terminal.Gui.Trees {
 			// if we have scrolled to the right then bits of the prefix will have dispeared off the screen
 			int toSkip = tree.ScrollOffsetHorizontal;
 
-			// Draw the line prefix (all paralell lanes or whitespace and an expand/collapse/leaf symbol)
+			driver.SetAttribute (symbolColor);
+			// Draw the line prefix (all parallel lanes or whitespace and an expand/collapse/leaf symbol)
 			foreach (Rune r in prefix) {
 
 				if (toSkip > 0) {
@@ -117,12 +117,12 @@ namespace Terminal.Gui.Trees {
 
 			// pick color for expanded symbol
 			if (tree.Style.ColorExpandSymbol || tree.Style.InvertExpandSymbolColors) {
-				Attribute color;
+				Attribute color = symbolColor;
 
 				if (tree.Style.ColorExpandSymbol) {
 					color = isSelected ? tree.ColorScheme.HotFocus : tree.ColorScheme.HotNormal;
 				} else {
-					color = lineColor;
+					color = symbolColor;
 				}
 
 				if (tree.Style.InvertExpandSymbolColors) {
@@ -162,16 +162,14 @@ namespace Terminal.Gui.Trees {
 
 			// default behaviour is for model to use the color scheme
 			// of the tree view
-			var modelColor = lineColor;
+			var modelColor = textColor;
 
 			// if custom color delegate invoke it
-			if(tree.ColorGetter != null)
-			{
-				var modelScheme = tree.ColorGetter(Model);
+			if (tree.ColorGetter != null) {
+				var modelScheme = tree.ColorGetter (Model);
 
 				// if custom color scheme is defined for this Model
-				if(modelScheme != null)
-				{
+				if (modelScheme != null) {
 					// use it
 					modelColor = isSelected ? modelScheme.Focus : modelScheme.Normal;
 				}
@@ -179,24 +177,23 @@ namespace Terminal.Gui.Trees {
 
 			driver.SetAttribute (modelColor);
 			driver.AddStr (lineBody);
-			driver.SetAttribute (lineColor);
 
 			if (availableWidth > 0) {
+				driver.SetAttribute (symbolColor);
 				driver.AddStr (new string (' ', availableWidth));
 			}
-
 			driver.SetAttribute (colorScheme.Normal);
 		}
 
 		/// <summary>
 		/// Gets all characters to render prior to the current branches line.  This includes indentation
-		/// whitespace and any tree branches (if enabled)
+		/// whitespace and any tree branches (if enabled).
 		/// </summary>
 		/// <param name="driver"></param>
 		/// <returns></returns>
 		private IEnumerable<Rune> GetLinePrefix (ConsoleDriver driver)
 		{
-			// If not showing line branches or this is a root object
+			// If not showing line branches or this is a root object.
 			if (!tree.Style.ShowBranchLines) {
 				for (int i = 0; i < Depth; i++) {
 					yield return new Rune (' ');
@@ -224,7 +221,7 @@ namespace Terminal.Gui.Trees {
 		}
 
 		/// <summary>
-		/// Returns all parents starting with the immediate parent and ending at the root
+		/// Returns all parents starting with the immediate parent and ending at the root.
 		/// </summary>
 		/// <returns></returns>
 		private IEnumerable<Branch<T>> GetParentBranches ()
@@ -240,7 +237,7 @@ namespace Terminal.Gui.Trees {
 		/// <summary>
 		/// Returns an appropriate symbol for displaying next to the string representation of 
 		/// the <see cref="Model"/> object to indicate whether it <see cref="IsExpanded"/> or
-		/// not (or it is a leaf)
+		/// not (or it is a leaf).
 		/// </summary>
 		/// <param name="driver"></param>
 		/// <returns></returns>
@@ -261,7 +258,7 @@ namespace Terminal.Gui.Trees {
 
 		/// <summary>
 		/// Returns true if the current branch can be expanded according to 
-		/// the <see cref="TreeBuilder{T}"/> or cached children already fetched
+		/// the <see cref="TreeBuilder{T}"/> or cached children already fetched.
 		/// </summary>
 		/// <returns></returns>
 		public bool CanExpand ()
@@ -283,7 +280,7 @@ namespace Terminal.Gui.Trees {
 		}
 
 		/// <summary>
-		/// Expands the current branch if possible
+		/// Expands the current branch if possible.
 		/// </summary>
 		public void Expand ()
 		{
@@ -297,7 +294,7 @@ namespace Terminal.Gui.Trees {
 		}
 
 		/// <summary>
-		/// Marks the branch as collapsed (<see cref="IsExpanded"/> false)
+		/// Marks the branch as collapsed (<see cref="IsExpanded"/> false).
 		/// </summary>
 		public void Collapse ()
 		{
@@ -305,10 +302,10 @@ namespace Terminal.Gui.Trees {
 		}
 
 		/// <summary>
-		/// Refreshes cached knowledge in this branch e.g. what children an object has
+		/// Refreshes cached knowledge in this branch e.g. what children an object has.
 		/// </summary>
 		/// <param name="startAtTop">True to also refresh all <see cref="Parent"/> 
-		/// branches (starting with the root)</param>
+		/// branches (starting with the root).</param>
 		public void Refresh (bool startAtTop)
 		{
 			// if we must go up and refresh from the top down
@@ -351,7 +348,7 @@ namespace Terminal.Gui.Trees {
 		}
 
 		/// <summary>
-		/// Calls <see cref="Refresh(bool)"/> on the current branch and all expanded children
+		/// Calls <see cref="Refresh(bool)"/> on the current branch and all expanded children.
 		/// </summary>
 		internal void Rebuild ()
 		{
@@ -375,7 +372,7 @@ namespace Terminal.Gui.Trees {
 
 		/// <summary>
 		/// Returns true if this branch has parents and it is the last node of it's parents 
-		/// branches (or last root of the tree)
+		/// branches (or last root of the tree).
 		/// </summary>
 		/// <returns></returns>
 		private bool IsLast ()
@@ -389,7 +386,7 @@ namespace Terminal.Gui.Trees {
 
 		/// <summary>
 		/// Returns true if the given x offset on the branch line is the +/- symbol.  Returns 
-		/// false if not showing expansion symbols or leaf node etc
+		/// false if not showing expansion symbols or leaf node etc.
 		/// </summary>
 		/// <param name="driver"></param>
 		/// <param name="x"></param>
@@ -415,7 +412,7 @@ namespace Terminal.Gui.Trees {
 		}
 
 		/// <summary>
-		/// Expands the current branch and all children branches
+		/// Expands the current branch and all children branches.
 		/// </summary>
 		internal void ExpandAll ()
 			{
@@ -430,7 +427,7 @@ namespace Terminal.Gui.Trees {
 
 		/// <summary>
 		/// Collapses the current branch and all children branches (even though those branches are 
-		/// no longer visible they retain collapse/expansion state)
+		/// no longer visible they retain collapse/expansion state).
 		/// </summary>
 		internal void CollapseAll ()
 		{

--- a/Terminal.Gui/Core/Trees/TreeStyle.cs
+++ b/Terminal.Gui/Core/Trees/TreeStyle.cs
@@ -2,46 +2,51 @@
 
 namespace Terminal.Gui.Trees {
 	/// <summary>
-	/// Defines rendering options that affect how the tree is displayed
+	/// Defines rendering options that affect how the tree is displayed.
 	/// </summary>
 	public class TreeStyle {
 
 		/// <summary>
-		/// True to render vertical lines under expanded nodes to show which node belongs to which 
-		/// parent.  False to use only whitespace
+		/// <see langword="true"/> to render vertical lines under expanded nodes to show which node belongs to which 
+		/// parent. <see langword="false"/> to use only whitespace.
 		/// </summary>
 		/// <value></value>
 		public bool ShowBranchLines { get; set; } = true;
 
 		/// <summary>
-		/// Symbol to use for branch nodes that can be expanded to indicate this to the user.  
-		/// Defaults to '+'. Set to null to hide
+		/// Symbol to use for branch nodes that can be expanded to indicate this to the user. 
+		/// Defaults to '+'. Set to null to hide.
 		/// </summary>
 		public Rune? ExpandableSymbol { get; set; } = '+';
 
 		/// <summary>
 		/// Symbol to use for branch nodes that can be collapsed (are currently expanded).
-		/// Defaults to '-'.  Set to null to hide
+		/// Defaults to '-'. Set to null to hide.
 		/// </summary>
 		public Rune? CollapseableSymbol { get; set; } = '-';
 
 		/// <summary>
-		/// Set to true to highlight expand/collapse symbols in hot key color
+		/// Set to <see langword="true"/> to highlight expand/collapse symbols in hot key color.
 		/// </summary>
 		public bool ColorExpandSymbol { get; set; }
 
 		/// <summary>
-		/// Invert console colours used to render the expand symbol
+		/// Invert console colours used to render the expand symbol.
 		/// </summary>
 		public bool InvertExpandSymbolColors { get; set; }
 
 		/// <summary>
-		/// True to leave the last row of the control free for overwritting (e.g. by a scrollbar)
-		/// When True scrolling will be triggered on the second last row of the control rather than
+		/// <see langword="true"/> to leave the last row of the control free for overwritting (e.g. by a scrollbar)
+		/// When <see langword="true"/> scrolling will be triggered on the second last row of the control rather than.
 		/// the last.
 		/// </summary>
 		/// <value></value>
 		public bool LeaveLastRow { get; set; }
 
+		/// <summary>
+		/// Set to <see langword="true"/> to cause the selected item to be rendered with only the <see cref="Branch{T}.Model"/> text
+		/// to be highlighted. If <see langword="false"/> (the default), the entire row will be highlighted.
+		/// </summary>
+		public bool HighlightModelTextOnly { get; set; } = false;
 	}
 }

--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -689,8 +689,10 @@ namespace Terminal.Gui {
 		/// </summary>
 		public void ScrollDown ()
 		{
-			ScrollOffsetVertical++;
-			SetNeedsDisplay ();
+			if (ScrollOffsetVertical <= ContentHeight - 2) {
+				ScrollOffsetVertical++;
+				SetNeedsDisplay ();
+			}
 		}
 
 		/// <summary>
@@ -698,8 +700,10 @@ namespace Terminal.Gui {
 		/// </summary>
 		public void ScrollUp ()
 		{
-			ScrollOffsetVertical--;
-			SetNeedsDisplay ();
+			if (scrollOffsetVertical > 0) {
+				ScrollOffsetVertical--;
+				SetNeedsDisplay ();
+			}
 		}
 
 		/// <summary>

--- a/UICatalog/Scenarios/ClassExplorer.cs
+++ b/UICatalog/Scenarios/ClassExplorer.cs
@@ -53,6 +53,8 @@ namespace UICatalog.Scenarios {
 			}
 		}
 
+		MenuItem highlightModelTextOnly;
+
 		public override void Setup ()
 		{
 			Win.Title = this.GetName ();
@@ -63,15 +65,20 @@ namespace UICatalog.Scenarios {
 			var menu = new MenuBar (new MenuBarItem [] {
 				new MenuBarItem ("_File", new MenuItem [] {
 					new MenuItem ("_Quit", "", () => Quit()),
-				})
-				,
+				}),
 				new MenuBarItem ("_View", new MenuItem [] {
 					miShowPrivate = new MenuItem ("_Include Private", "", () => ShowPrivate()){
 						Checked = false,
 						CheckType = MenuItemCheckStyle.Checked
 					},
-				new MenuItem ("_Expand All", "", () => treeView.ExpandAll()),
-				new MenuItem ("_Collapse All", "", () => treeView.CollapseAll()) }),
+					new MenuItem ("_Expand All", "", () => treeView.ExpandAll()),
+					new MenuItem ("_Collapse All", "", () => treeView.CollapseAll())
+				}),
+				new MenuBarItem ("_Style", new MenuItem [] {
+					highlightModelTextOnly = new MenuItem ("_Highlight Model Text Only", "", () => OnCheckHighlightModelTextOnly()) {
+						CheckType = MenuItemCheckStyle.Checked
+					},
+				}) 
 			});
 			Top.Add (menu);
 
@@ -81,7 +88,6 @@ namespace UICatalog.Scenarios {
 				Width = Dim.Percent (50),
 				Height = Dim.Fill (),
 			};
-
 
 			treeView.AddObjects (AppDomain.CurrentDomain.GetAssemblies ());
 			treeView.AspectGetter = GetRepresentation;
@@ -98,6 +104,13 @@ namespace UICatalog.Scenarios {
 			};
 
 			Win.Add (textView);
+		}
+
+		private void OnCheckHighlightModelTextOnly ()
+		{
+			treeView.Style.HighlightModelTextOnly = !treeView.Style.HighlightModelTextOnly;
+			highlightModelTextOnly.Checked = treeView.Style.HighlightModelTextOnly;
+			treeView.SetNeedsDisplay ();
 		}
 
 		private void ShowPrivate ()

--- a/UICatalog/Scenarios/CollectionNavigatorTester.cs
+++ b/UICatalog/Scenarios/CollectionNavigatorTester.cs
@@ -138,7 +138,6 @@ namespace UICatalog.Scenarios {
 				Height = Dim.Fill (),
 				AllowsMarking = false,
 				AllowsMultipleSelection = false,
-				ColorScheme = Colors.TopLevel
 			};
 			Top.Add (_listView);
 
@@ -158,7 +157,7 @@ namespace UICatalog.Scenarios {
 				TextAlignment = TextAlignment.Centered,
 				X = Pos.Right (_listView) + 2,
 				Y = 1, // for menu
-				Width = Dim.Percent (50),
+				Width = Dim.Percent	 (50),
 				Height = 1,
 			};
 			Top.Add (label);
@@ -167,9 +166,9 @@ namespace UICatalog.Scenarios {
 				X = Pos.Right (_listView) + 1,
 				Y = Pos.Bottom (label),
 				Width = Dim.Fill (),
-				Height = Dim.Fill (),
-				ColorScheme = Colors.TopLevel
+				Height = Dim.Fill ()
 			};
+			_treeView.Style.HighlightModelTextOnly = true;
 			Top.Add (_treeView);
 
 			var root = new TreeNode ("IsLetterOrDigit examples");

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -78,14 +78,13 @@ namespace UICatalog.Scenarios {
 			};
 
 			detailsFrame = new DetailsFrame () {
-				X = Pos.Right (treeViewFiles) + 1,
+				X = Pos.Right (treeViewFiles),
 				Y = 0,
 				Width = Dim.Fill (),
 				Height = Dim.Fill (),
 			};
 
 			Win.Add (detailsFrame);
-			treeViewFiles.ObjectActivated += TreeViewFiles_ObjectActivated;
 			treeViewFiles.MouseClick += TreeViewFiles_MouseClick;
 			treeViewFiles.KeyPress += TreeViewFiles_KeyPress;
 			treeViewFiles.SelectionChanged += TreeViewFiles_SelectionChanged;
@@ -160,23 +159,12 @@ namespace UICatalog.Scenarios {
 
 		class DetailsFrame : FrameView {
 			private FileSystemInfo fileInfo;
-			TextView details = new TextView () {
-				X = 1,
-				Y = 0,
-				Width = Dim.Fill (),
-				Height = Dim.Fill (),
-				ColorScheme = Colors.Base,
-				WordWrap = true,
-				ReadOnly = true
-			};
 
 			public DetailsFrame ()
 			{
 				Title = "Details";
-				ColorScheme = Colors.Dialog;
 				Visible = true;
 				CanFocus = true;				
-				Add (details);
 			}
 
 			public FileSystemInfo FileInfo {
@@ -186,20 +174,20 @@ namespace UICatalog.Scenarios {
 					if (fileInfo is FileInfo f) {
 						Title = $"File: {f.Name}";
 						sb = new System.Text.StringBuilder ();
-						sb.AppendLine ($"Path: {f.DirectoryName}");
-						sb.AppendLine ($"Size: {f.Length:N0} bytes");
-						sb.AppendLine ($"Modified: {f.LastWriteTime}");
-						sb.AppendLine ($"Created: {f.CreationTime}");
+						sb.AppendLine ($"Path:\n {f.FullName}\n");
+						sb.AppendLine ($"Size:\n {f.Length:N0} bytes\n");
+						sb.AppendLine ($"Modified:\n {f.LastWriteTime}\n");
+						sb.AppendLine ($"Created:\n {f.CreationTime}");
 					}
 
 					if (fileInfo is DirectoryInfo dir) {
 						Title = $"Directory: {dir.Name}";
 						sb = new System.Text.StringBuilder ();
-						sb.AppendLine ($"Path: {dir?.FullName}");
-						sb.AppendLine ($"Modified: {dir.LastWriteTime}");
-						sb.AppendLine ($"Created: {dir.CreationTime}");
+						sb.AppendLine ($"Path:\n {dir?.FullName}\n");
+						sb.AppendLine ($"Modified:\n {dir.LastWriteTime}\n");
+						sb.AppendLine ($"Created:\n {dir.CreationTime}\n");
 					}
-					details.Text = sb.ToString ();
+					Text = sb.ToString ();
 				}
 			}
 		}
@@ -207,25 +195,6 @@ namespace UICatalog.Scenarios {
 		private void ShowPropertiesOf (FileSystemInfo fileSystemInfo)
 		{
 			detailsFrame.FileInfo = fileSystemInfo;
-			//if (fileSystemInfo is FileInfo f) {
-			//	System.Text.StringBuilder sb = new System.Text.StringBuilder ();
-			//	sb.AppendLine ($"Path:{f.DirectoryName}");
-			//	sb.AppendLine ($"Size:{f.Length:N0} bytes");
-			//	sb.AppendLine ($"Modified:{f.LastWriteTime}");
-			//	sb.AppendLine ($"Created:{f.CreationTime}");
-
-			//	MessageBox.Query (f.Name, sb.ToString (), "Close");
-			//}
-
-			//if (fileSystemInfo is DirectoryInfo dir) {
-
-			//	System.Text.StringBuilder sb = new System.Text.StringBuilder ();
-			//	sb.AppendLine ($"Path:{dir.Parent?.FullName}");
-			//	sb.AppendLine ($"Modified:{dir.LastWriteTime}");
-			//	sb.AppendLine ($"Created:{dir.CreationTime}");
-
-			//	MessageBox.Query (dir.Name, sb.ToString (), "Close");
-			//}
 		}
 
 		private void SetupScrollBar ()
@@ -276,11 +245,6 @@ namespace UICatalog.Scenarios {
 			treeViewFiles.AspectGetter = FileSystemAspectGetter;
 
 			treeViewFiles.AddObjects (DriveInfo.GetDrives ().Select (d => d.RootDirectory));
-		}
-
-		private void TreeViewFiles_ObjectActivated (ObjectActivatedEventArgs<FileSystemInfo> obj)
-		{
-			ShowPropertiesOf (obj.ActivatedObject);
 		}
 
 		private void ShowLines ()


### PR DESCRIPTION
This PR:

- Adds new `Style` named `HighlightModelTextOnly` - false by default
- Updates `Class Explorer` Scenario to have a menu for testing new Style
- Updates `TreeViewFileSystem` Scenario to have a menu for testing new Style
- Updates `CollectionNavigator` Scenario to use the new style
- Fixes #2151 

See: https://github.com/gui-cs/Terminal.Gui/pull/2155
See: https://github.com/gui-cs/Terminal.Gui/discussions/2154

![IE6jb7x 1](https://user-images.githubusercontent.com/585482/199630545-f4e83157-aab0-4f7d-b4fe-a495ed19a763.gif)

