### PR TITLE
Fixes #2165 - ListView: OnSelectedChanged is called when it didn't actually change (again)

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -728,7 +728,6 @@ namespace Terminal.Gui {
 
 			if (lastSelectedItem == -1) {
 				EnsuresVisibilitySelectedItem ();
-				OnSelectedChanged ();
 			}
 
 			return base.OnEnter (view);

--- a/UnitTests/ComboBoxTests.cs
+++ b/UnitTests/ComboBoxTests.cs
@@ -826,9 +826,9 @@ Three ", output);
 
 			TestHelpers.AssertDriverColorsAre (@"
 000000
-00000
-22222
-22222", attributes);
+222222
+222222
+222222", attributes);
 
 			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
 			Assert.Equal ("", selected);
@@ -838,9 +838,9 @@ Three ", output);
 			cb.Redraw (cb.Bounds);
 			TestHelpers.AssertDriverColorsAre (@"
 000000
-22222
-00000
-22222", attributes);
+222222
+000002
+222222", attributes);
 
 			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
 			Assert.Equal ("", selected);
@@ -850,9 +850,9 @@ Three ", output);
 			cb.Redraw (cb.Bounds);
 			TestHelpers.AssertDriverColorsAre (@"
 000000
-22222
-22222
-00000", attributes);
+222222
+222222
+000002", attributes);
 
 			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
 			Assert.Equal ("Three", selected);
@@ -868,9 +868,9 @@ Three ", output);
 			cb.Redraw (cb.Bounds);
 			TestHelpers.AssertDriverColorsAre (@"
 000000
-22222
-22222
-00000", attributes);
+222222
+222222
+000002", attributes);
 
 			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorUp, new KeyModifiers ())));
 			Assert.Equal ("Three", selected);
@@ -880,9 +880,9 @@ Three ", output);
 			cb.Redraw (cb.Bounds);
 			TestHelpers.AssertDriverColorsAre (@"
 000000
-22222
-00000
-11111", attributes);
+222222
+000002
+111112", attributes);
 
 			Assert.True (cb.Subviews [1].ProcessKey (new KeyEvent (Key.CursorUp, new KeyModifiers ())));
 			Assert.Equal ("Three", selected);
@@ -892,9 +892,9 @@ Three ", output);
 			cb.Redraw (cb.Bounds);
 			TestHelpers.AssertDriverColorsAre (@"
 000000
-00000
-22222
-11111", attributes);
+000002
+222222
+111112", attributes);
 
 			Assert.True (cb.ProcessKey (new KeyEvent (Key.F4, new KeyModifiers ())));
 			Assert.Equal ("Three", selected);


### PR DESCRIPTION
Fixes #2136 and #2140 

Reapplied fixes from 26eabdda6c178329d8cd391e1b0200383b4a1e06 which where somehow reverted from #2152 
