### PR TITLE
Fixes #2162. BackgroundWorker Scenario broke

### DIFF
--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -816,7 +816,7 @@ namespace Terminal.Gui {
 		{
 			if (toplevel == null) {
 				throw new ArgumentNullException (nameof (toplevel));
-			} else if (toplevel.IsMdiContainer && MdiTop != null) {
+			} else if (toplevel.IsMdiContainer && MdiTop != toplevel && MdiTop != null) {
 				throw new InvalidOperationException ("Only one Mdi Container is allowed.");
 			}
 
@@ -1153,7 +1153,12 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Runs the application by calling <see cref="Run(Toplevel, Func{Exception, bool})"/> with a new instance of the specified <see cref="Toplevel"/>-derived class
+		/// Runs the application by calling <see cref="Run(Toplevel, Func{Exception, bool})"/> 
+		/// with a new instance of the specified <see cref="Toplevel"/>-derived class.
+		/// <para>
+		/// If <see cref="Init(ConsoleDriver, IMainLoopDriver)"/> has not arleady been called, this function will
+		/// call <see cref="Init(Func{Toplevel}, ConsoleDriver, IMainLoopDriver)"/>.
+		/// </para>
 		/// </summary>
 		public static void Run<T> (Func<Exception, bool> errorHandler = null) where T : Toplevel, new()
 		{

--- a/UICatalog/Scenarios/BackgroundWorkerCollection.cs
+++ b/UICatalog/Scenarios/BackgroundWorkerCollection.cs
@@ -12,22 +12,14 @@ namespace UICatalog.Scenarios {
 	[ScenarioCategory ("Dialogs")]
 	[ScenarioCategory ("Controls")]
 	public class BackgroundWorkerCollection : Scenario {
-		public override void Init (Toplevel top, ColorScheme colorScheme)
-		{
-			//Application.Init ();
-		}
-
 		public override void Run ()
 		{
-			// For Scenarios that want to use `Applciation.Run<T>` to create a new Toplevel, there are two choices:
-
-			// 1) Override `Scenario.Init` and do nothing in it.
-			// The call to `Application.Run<MdiMain>` in `Run` implies an `Application.Init()` call.
-			//
-			// 2) Just override `Run` but call `Application.Top.Dispose` then `Application.Shutdown ()`. This
-			// works around bug #520, ensuring the `Toplevel` created by `Init` gets Disposed.
-			//Application.Top.Dispose ();
-			//Application.Shutdown ();
+			// BUGBUG: work around Issue #520: Ensuring the `Toplevel` created by `Init` gets Disposed...
+			// For Scenarios that want to use `Applciation.Run<T>` to create a new Toplevel: 
+			// Override `Run` and call `Application.Top.Dispose` before calling `Application.Run<T>`.
+			if (Application.Top != null) {
+				Application.Top.Dispose ();
+			}
 
 			Application.Run<MdiMain> ();
 		}

--- a/UICatalog/Scenarios/BackgroundWorkerCollection.cs
+++ b/UICatalog/Scenarios/BackgroundWorkerCollection.cs
@@ -14,11 +14,21 @@ namespace UICatalog.Scenarios {
 	public class BackgroundWorkerCollection : Scenario {
 		public override void Init (Toplevel top, ColorScheme colorScheme)
 		{
-			// Do nothing as the call to `Application.Run<MdiMain>` in `Run` implies an `Application.Init()` call.
+			//Application.Init ();
 		}
 
 		public override void Run ()
 		{
+			// For Scenarios that want to use `Applciation.Run<T>` to create a new Toplevel, there are two choices:
+
+			// 1) Override `Scenario.Init` and do nothing in it.
+			// The call to `Application.Run<MdiMain>` in `Run` implies an `Application.Init()` call.
+			//
+			// 2) Just override `Run` but call `Application.Top.Dispose` then `Application.Shutdown ()`. This
+			// works around bug #520, ensuring the `Toplevel` created by `Init` gets Disposed.
+			//Application.Top.Dispose ();
+			//Application.Shutdown ();
+
 			Application.Run<MdiMain> ();
 		}
 

--- a/UICatalog/Scenarios/BackgroundWorkerCollection.cs
+++ b/UICatalog/Scenarios/BackgroundWorkerCollection.cs
@@ -14,15 +14,12 @@ namespace UICatalog.Scenarios {
 	public class BackgroundWorkerCollection : Scenario {
 		public override void Init (Toplevel top, ColorScheme colorScheme)
 		{
-			Application.Top.Dispose ();
-
-			Application.Run<MdiMain> ();
-
-			Application.Top.Dispose ();
+			// Do nothing as the call to `Application.Run<MdiMain>` in `Run` implies an `Application.Init()` call.
 		}
 
 		public override void Run ()
 		{
+			Application.Run<MdiMain> ();
 		}
 
 		class MdiMain : Toplevel {

--- a/UICatalog/Scenarios/Editor.cs
+++ b/UICatalog/Scenarios/Editor.cs
@@ -30,11 +30,12 @@ namespace UICatalog.Scenarios {
 		private TabView _tabView;
 		private MenuItem _miForceMinimumPosToZero;
 		private bool _forceMinimumPosToZero = true;
-		private readonly List<CultureInfo> _cultureInfos = Application.SupportedCultures;
+		private List<CultureInfo> _cultureInfos;
 
 		public override void Init (Toplevel top, ColorScheme colorScheme)
 		{
 			Application.Init ();
+			_cultureInfos = Application.SupportedCultures;
 			Top = top != null ? top : Application.Top;
 
 			Win = new Window (_fileName ?? "Untitled") {

--- a/UnitTests/MainLoopTests.cs
+++ b/UnitTests/MainLoopTests.cs
@@ -578,9 +578,9 @@ namespace Terminal.Gui.Core {
 			TextField tf = new ();
 			Application.Top.Add (tf);
 
-			const int numPasses = 10;
-			const int numIncrements = 10000;
-			const int pollMs = 20000;
+			const int numPasses = 5;
+			const int numIncrements = 5000;
+			const int pollMs = 10000;
 
 			var task = Task.Run (() => RunTest (r, tf, numPasses, numIncrements, pollMs));
 

--- a/UnitTests/ScenarioTests.cs
+++ b/UnitTests/ScenarioTests.cs
@@ -70,6 +70,12 @@ namespace UICatalog {
 				scenario.Setup ();
 				scenario.Run ();
 				Application.Shutdown ();
+#if DEBUG_IDISPOSABLE
+				foreach (var inst in Responder.Instances) {
+					Assert.True (inst.WasDisposed);
+				}
+				Responder.Instances.Clear ();
+#endif
 			}
 #if DEBUG_IDISPOSABLE
 			foreach (var inst in Responder.Instances) {

--- a/UnitTests/ScenarioTests.cs
+++ b/UnitTests/ScenarioTests.cs
@@ -64,7 +64,7 @@ namespace UICatalog {
 				Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 				// Close after a short period of time
-				var token = Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (200), closeCallback);
+				var token = Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), closeCallback);
 
 				scenario.Init (Application.Top, Colors.Base);
 				scenario.Setup ();


### PR DESCRIPTION
Fixes #2162 

Beyond fixing the `BackgroundWorkerCollection` scenario, this PR enhances the API docs for `Run<T> (Func<Exception, bool> errorHandler = null) where T : Toplevel, new()` to note that `Init` is not needed if it's not already been called.