### PR TITLE
Fixes #2175 Hide cursor when entering GraphView and TabRowView

### DIFF
--- a/Terminal.Gui/Views/GraphView.cs
+++ b/Terminal.Gui/Views/GraphView.cs
@@ -240,7 +240,13 @@ namespace Terminal.Gui {
 				);
 		}
 
-
+		/// <inheritdoc/>
+		/// <remarks>Also ensures that cursor is invisible after entering the <see cref="GraphView"/>.</remarks>
+		public override bool OnEnter (View view)
+		{
+			Driver.SetCursorVisibility (CursorVisibility.Invisible);
+			return base.OnEnter (view);
+		}
 
 		/// <inheritdoc/>
 		public override bool ProcessKey (KeyEvent keyEvent)

--- a/Terminal.Gui/Views/TabView.cs
+++ b/Terminal.Gui/Views/TabView.cs
@@ -493,6 +493,12 @@ namespace Terminal.Gui {
 
 			}
 
+			public override bool OnEnter (View view)
+			{
+				Driver.SetCursorVisibility (CursorVisibility.Invisible);
+				return base.OnEnter (view);
+			}
+
 			public override void Redraw (Rect bounds)
 			{
 				base.Redraw (bounds);

--- a/Terminal.Gui/Views/TabView.cs
+++ b/Terminal.Gui/Views/TabView.cs
@@ -466,33 +466,6 @@ namespace Terminal.Gui {
 				Width = Dim.Fill ();
 			}
 
-			/// <summary>
-			/// Positions the cursor at the start of the currently selected tab
-			/// </summary>
-			public override void PositionCursor ()
-			{
-				base.PositionCursor ();
-
-				var selected = host.CalculateViewport (Bounds).FirstOrDefault (t => Equals (host.SelectedTab, t.Tab));
-
-				if (selected == null) {
-					return;
-				}
-
-				int y;
-
-				if (host.Style.TabsOnBottom) {
-					y = 1;
-				} else {
-					y = host.Style.ShowTopLine ? 1 : 0;
-				}
-
-				Move (selected.X, y);
-
-
-
-			}
-
 			public override bool OnEnter (View view)
 			{
 				Driver.SetCursorVisibility (CursorVisibility.Invisible);


### PR DESCRIPTION
Fixes #2175 - Explicitly hides cursor when entering tabs and `GraphView`

_`TabRowView` is a private sub view of `TabView`: the actual tabs themselves._

Also deleted `public override void PositionCursor ()` in `TabRowView` since we are now hiding it explicitly.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
