### PR TITLE
Fixes 2193. Character Map scenario not showing the last range chars U+10fffx.

### DIFF
--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -109,7 +109,7 @@ namespace UICatalog.Scenarios {
 			ColorScheme = Colors.Dialog;
 			CanFocus = true;
 
-			ContentSize = new Size (CharMap.RowWidth, MaxCodePointVal / 16);
+			ContentSize = new Size (CharMap.RowWidth, MaxCodePointVal / 16 + 1);
 			ShowVerticalScrollIndicator = true;
 			ShowHorizontalScrollIndicator = false;
 			LayoutComplete += (args) => {
@@ -128,6 +128,8 @@ namespace UICatalog.Scenarios {
 			AddCommand (Command.ScrollDown, () => { ScrollDown (1); return true; });
 			AddCommand (Command.ScrollLeft, () => { ScrollLeft (1); return true; });
 			AddCommand (Command.ScrollRight, () => { ScrollRight (1); return true; });
+			AddCommand (Command.PageUp, () => ScrollUp (Bounds.Height - 1));
+			AddCommand (Command.PageDown, () => ScrollDown (Bounds.Height - 1));
 		}
 
 		private void CharMap_DrawContent (Rect viewport)


### PR DESCRIPTION
Fixes #2193 - Ensures that all items are all showed on navigation.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
