### PR TITLE
Fixes #2213. ContextMenu.IsShow is wrongly inheriting previous value on a new instance.

### DIFF
--- a/Terminal.Gui/Views/ContextMenu.cs
+++ b/Terminal.Gui/Views/ContextMenu.cs
@@ -52,7 +52,10 @@ namespace Terminal.Gui {
 		public ContextMenu (int x, int y, MenuBarItem menuItems)
 		{
 			if (IsShow) {
-				Hide ();
+				if (menuBar.SuperView != null) {
+					Hide ();
+				}
+				IsShow = false;
 			}
 			MenuItems = menuItems;
 			Position = new Point (x, y);
@@ -126,7 +129,7 @@ namespace Terminal.Gui {
 			} else if (ForceMinimumPosToZero && position.Y < 0) {
 				position.Y = 0;
 			}
-			
+
 			menuBar = new MenuBar (new [] { MenuItems }) {
 				X = position.X,
 				Y = position.Y,


### PR DESCRIPTION
Fixes #2213 - If superview is null the previous instance was already destroyed then reset the `IsShow` to false.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
