### PR TITLE
Fixes #2216. MessageBox default width should be proportional for smaller screens.

### DIFF
--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -238,7 +238,10 @@ namespace Terminal.Gui {
 		static int QueryFull (bool useErrorColors, int width, int height, ustring title, ustring message,
 			int defaultButton = 0, Border border = null, params ustring [] buttons)
 		{
-			const int defaultWidth = 50;
+			int defaultWidth = 50;
+			if (defaultWidth > Application.Driver.Cols / 2) {
+				defaultWidth = (int)(Application.Driver.Cols * 0.60f);
+			}
 			int maxWidthLine = TextFormatter.MaxWidthLine (message);
 			if (maxWidthLine > Application.Driver.Cols) {
 				maxWidthLine = Application.Driver.Cols;

--- a/UnitTests/MessageBoxTests.cs
+++ b/UnitTests/MessageBoxTests.cs
@@ -30,11 +30,11 @@ namespace Terminal.Gui.Views {
 				} else if (iterations == 1) {
 					Application.Top.Redraw (Application.Top.Bounds);
 					TestHelpers.AssertDriverContentsWithFrameAre (@"
-               ┌ Title ─────────────────────────────────────────┐
-               │                    Message                     │
-               │                                                │
-               │                                                │
-               └────────────────────────────────────────────────┘
+                ┌ Title ───────────────────────────────────────┐
+                │                   Message                    │
+                │                                              │
+                │                                              │
+                └──────────────────────────────────────────────┘
 ", output);
 
 					Application.RequestStop ();


### PR DESCRIPTION
Fixes #2216 - Avoids `MessageBox` been bigger than the screen width if not necessary.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
