### PR TITLE
Fixes #2222. RadioGroup first upper case and ProcessColdKey is not working well.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -3064,6 +3064,17 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
+		/// Determines the current <see cref="ColorScheme"/> based on the <see cref="Enabled"/> value.
+		/// </summary>
+		/// <returns><see cref="Terminal.Gui.ColorScheme.HotNormal"/> if <see cref="Enabled"/> is <see langword="true"/>
+		/// or <see cref="Terminal.Gui.ColorScheme.Disabled"/> if <see cref="Enabled"/> is <see langword="false"/>.
+		/// If it's overridden can return other values.</returns>
+		public virtual Attribute GetHotNormalColor ()
+		{
+			return Enabled ? ColorScheme.HotNormal : ColorScheme.Disabled;
+		}
+
+		/// <summary>
 		/// Get the top superview of a given <see cref="View"/>.
 		/// </summary>
 		/// <returns>The superview view.</returns>

--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -116,11 +116,17 @@ namespace Terminal.Gui {
 
 		void Watcher_Error (object sender, ErrorEventArgs e)
 		{
+			if (Application.MainLoop == null)
+				return;
+
 			Application.MainLoop.Invoke (() => Reload ());
 		}
 
 		void Watcher_Changed (object sender, FileSystemEventArgs e)
 		{
+			if (Application.MainLoop == null)
+				return;
+
 			Application.MainLoop.Invoke (() => Reload ());
 		}
 

--- a/UnitTests/RadioGroupTests.cs
+++ b/UnitTests/RadioGroupTests.cs
@@ -172,5 +172,20 @@ namespace Terminal.Gui.Views {
 			Assert.True (rg.ProcessKey (new KeyEvent (Key.Space, new KeyModifiers ())));
 			Assert.Equal (1, rg.SelectedItem);
 		}
+
+		[Fact]
+		public void ProcessColdKey_HotKey ()
+		{
+			var rg = new RadioGroup (new NStack.ustring [] { "Left", "Right", "Cen_tered", "Justified" });
+
+			Assert.True (rg.ProcessColdKey (new KeyEvent (Key.t, new KeyModifiers ())));
+			Assert.Equal (2, rg.SelectedItem);
+			Assert.True (rg.ProcessColdKey (new KeyEvent (Key.L, new KeyModifiers ())));
+			Assert.Equal (0, rg.SelectedItem);
+			Assert.True (rg.ProcessColdKey (new KeyEvent (Key.J, new KeyModifiers ())));
+			Assert.Equal (3, rg.SelectedItem);
+			Assert.True (rg.ProcessColdKey (new KeyEvent (Key.R, new KeyModifiers ())));
+			Assert.Equal (1, rg.SelectedItem);
+		}
 	}
 }

--- a/UnitTests/TextFormatterTests.cs
+++ b/UnitTests/TextFormatterTests.cs
@@ -4139,18 +4139,29 @@ This TextFormatter (tf2) is rewritten.
 		}
 
 		[Fact]
-		public void Ustring_Array_Is_Not_Equal_ToRunes_Array ()
+		public void Ustring_Array_Is_Not_Equal_ToRunes_Array_And_String_Array ()
 		{
-			ustring us = "New Test 你";
+			var text = "New Test 你";
+			ustring us = text;
+			string s = text;
 			Assert.Equal (10, us.RuneCount);
+			Assert.Equal (10, s.Length);
+			// The reason is ustring index is related to byte length and not rune length
+			Assert.Equal (12, us.Length);
 			Assert.NotEqual (20320, us [9]);
+			Assert.Equal (20320, s [9]);
 			Assert.Equal (228, us [9]);
 			Assert.Equal ("ä", ((Rune)us [9]).ToString ());
+			Assert.Equal ("你", s [9].ToString ());
 
+			// Rune array is equal to string array
 			var usToRunes = us.ToRunes ();
 			Assert.Equal (10, usToRunes.Length);
+			Assert.Equal (10, s.Length);
 			Assert.Equal (20320, (int)usToRunes [9]);
+			Assert.Equal (20320, s [9]);
 			Assert.Equal ("你", ((Rune)usToRunes [9]).ToString ());
+			Assert.Equal ("你", s [9].ToString ());
 		}
 	}
 }

--- a/UnitTests/TextFormatterTests.cs
+++ b/UnitTests/TextFormatterTests.cs
@@ -4137,5 +4137,20 @@ This TextFormatter (tf2) is rewritten.
 			text = $"First Line 界\nSecond Line 界\nThird Line 界\n";
 			Assert.Equal (14, TextFormatter.MaxWidthLine (text));
 		}
+
+		[Fact]
+		public void Ustring_Array_Is_Not_Equal_ToRunes_Array ()
+		{
+			ustring us = "New Test 你";
+			Assert.Equal (10, us.RuneCount);
+			Assert.NotEqual (20320, us [9]);
+			Assert.Equal (228, us [9]);
+			Assert.Equal ("ä", ((Rune)us [9]).ToString ());
+
+			var usToRunes = us.ToRunes ();
+			Assert.Equal (10, usToRunes.Length);
+			Assert.Equal (20320, (int)usToRunes [9]);
+			Assert.Equal ("你", ((Rune)usToRunes [9]).ToString ());
+		}
 	}
 }

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -4062,5 +4062,27 @@ This is a tes
 			Assert.False (view.IsKeyPress);
 			Assert.True (view.IsKeyUp);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void GetNormalColor_ColorScheme ()
+		{
+			var view = new View { ColorScheme = Colors.Base };
+
+			Assert.Equal (view.ColorScheme.Normal, view.GetNormalColor ());
+
+			view.Enabled = false;
+			Assert.Equal (view.ColorScheme.Disabled, view.GetNormalColor ());
+		}
+
+		[Fact, AutoInitShutdown]
+		public void GetHotNormalColor_ColorScheme ()
+		{
+			var view = new View { ColorScheme = Colors.Base };
+
+			Assert.Equal (view.ColorScheme.HotNormal, view.GetHotNormalColor ());
+
+			view.Enabled = false;
+			Assert.Equal (view.ColorScheme.Disabled, view.GetHotNormalColor ());
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2222 - Also added a new method to get the hot normal color depended if the view is enabled or not.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
