### PR TITLE
Fixes #2262 - Change Ctrl+Home/End to prevent horizontal navigation when FullRowSelect is on

### DIFF
--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -794,22 +794,28 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Moves or extends the selection to the first cell in the table (0,0)
+		/// Moves or extends the selection to the first cell in the table (0,0).
+		/// If <see cref="FullRowSelect"/> is enabled then selection instead moves
+		/// to (<see cref="SelectedColumn"/>,0) i.e. no horizontal scrolling.
 		/// </summary>
 		/// <param name="extend">true to extend the current selection (if any) instead of replacing</param>
 		public void ChangeSelectionToStartOfTable (bool extend)
 		{
-			SetSelection (0, 0, extend);
+			SetSelection (FullRowSelect ? SelectedColumn : 0, 0, extend);
 			Update ();
 		}
 
 		/// <summary>
-		/// Moves or extends the selection to the final cell in the table
+		/// Moves or extends the selection to the final cell in the table (nX,nY).
+		/// If <see cref="FullRowSelect"/> is enabled then selection instead moves
+		/// to (<see cref="SelectedColumn"/>,nY) i.e. no horizontal scrolling.
 		/// </summary>
 		/// <param name="extend">true to extend the current selection (if any) instead of replacing</param>
 		public void ChangeSelectionToEndOfTable(bool extend)
 		{
-			SetSelection (Table.Columns.Count - 1, Table.Rows.Count - 1, extend);
+			var finalColumn = Table.Columns.Count - 1;
+
+			SetSelection (FullRowSelect ? SelectedColumn : finalColumn, Table.Rows.Count - 1, extend);
 			Update ();
 		}
 

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -1312,6 +1312,54 @@ namespace Terminal.Gui.Views {
 			Assert.Equal (1, tableView.SelectedColumn);
 		}
 
+
+		[InlineData(true)]
+		[InlineData (false)]
+		[Theory, AutoInitShutdown]
+		public void TestMoveStartEnd_WithFullRowSelect(bool withFullRowSelect)
+		{
+			var tableView = GetTwoRowSixColumnTable ();
+			tableView.FullRowSelect = withFullRowSelect;
+
+			tableView.SelectedRow = 1;
+			tableView.SelectedColumn = 1;
+
+			tableView.ProcessKey (new KeyEvent 
+			{
+				Key = Key.Home  | Key.CtrlMask
+			});
+
+			if(withFullRowSelect)
+			{
+				// Should not be any horizontal movement when
+				// using navigate to Start/End and FullRowSelect
+				Assert.Equal (1, tableView.SelectedColumn);
+				Assert.Equal (0, tableView.SelectedRow);
+			}
+			else
+			{
+				Assert.Equal (0, tableView.SelectedColumn);
+				Assert.Equal (0, tableView.SelectedRow);
+			}
+
+			tableView.ProcessKey (new KeyEvent 
+			{
+				Key = Key.End  | Key.CtrlMask
+			});
+
+			if(withFullRowSelect)
+			{
+				Assert.Equal (1, tableView.SelectedColumn);
+				Assert.Equal (1, tableView.SelectedRow);
+			}
+			else
+			{
+				Assert.Equal (5, tableView.SelectedColumn);
+				Assert.Equal (1, tableView.SelectedRow);
+			}
+
+		}
+
 		[InlineData (true)]
 		[InlineData (false)]
 		[Theory, AutoInitShutdown]


### PR DESCRIPTION


Fixes #2262- Do not change SelectedColumn when scrolling to start/end of TableView when FullRowSelect is on

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
