### PR TITLE
Fixes #2265 - Keyboard input doesn't work in UnixMainLoop when Idle function is registered

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -176,16 +176,15 @@ namespace Terminal.Gui {
 		{
 			UpdatePollMap ();
 
-			if (CheckTimers (wait, out var pollTimeout)) {
-				return true;
-			}
+			bool checkTimersResult = CheckTimers (wait, out var pollTimeout);
 
 			var n = poll (pollmap, (uint)pollmap.Length, pollTimeout);
 
 			if (n == KEY_RESIZE) {
 				winChanged = true;
 			}
-			return n >= KEY_RESIZE || CheckTimers (wait, out pollTimeout);
+
+			return checkTimersResult || n >= KEY_RESIZE;
 		}
 
 		bool CheckTimers (bool wait, out int pollTimeout)


### PR DESCRIPTION
Fixes #2265 - Keyboard input doesn't work in UnixMainLoop when Idle function is registered

When running in WSL Ubuntu, I was unable to process input. The issue was that when there's an idle function registered with the main loop, UnixMainLoop doesn't ever call poll. Without the poll call, pollmap doesn't get updated and the input callback doesn't get called. Change this so that it calls poll every loop iteration, even if there's an idle function.
