### PR TITLE
Fixes #2277. Changing TextField.Text does not clear text selection.

### DIFF
--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -298,6 +298,7 @@ namespace Terminal.Gui {
 					}
 					return;
 				}
+				ClearAllSelection ();
 				text = TextModel.ToRunes (newText.NewText);
 
 				if (!Secret && !historyText.IsFromHistory) {

--- a/UnitTests/TextFieldTests.cs
+++ b/UnitTests/TextFieldTests.cs
@@ -1296,5 +1296,32 @@ namespace Terminal.Gui.Views {
 			Assert.Equal ($"{text}A", tf.Text);
 			Assert.True (tf.IsDirty);
 		}
+
+		[InlineData ("a")] // Lower than selection
+		[InlineData ("aaaaaaaaaaa")] // Greater than selection
+		[InlineData ("aaaa")] // Equal than selection
+		[Theory]
+		public void TestSetTextAndMoveCursorToEnd_WhenExistingSelection (string newText)
+		{
+			var tf = new TextField ();
+			tf.Text = "fish";
+			tf.CursorPosition = tf.Text.Length;
+
+			tf.ProcessKey (new KeyEvent (Key.CursorLeft, new KeyModifiers ()));
+
+			tf.ProcessKey (new KeyEvent (Key.CursorLeft | Key.ShiftMask, new KeyModifiers { Shift = true }));
+			tf.ProcessKey (new KeyEvent (Key.CursorLeft | Key.ShiftMask, new KeyModifiers { Shift = true }));
+
+			Assert.Equal (1, tf.CursorPosition);
+			Assert.Equal (2, tf.SelectedLength);
+			Assert.Equal ("is", tf.SelectedText);
+
+			tf.Text = newText;
+			tf.CursorPosition = tf.Text.Length;
+
+			Assert.Equal (newText.Length, tf.CursorPosition);
+			Assert.Equal (0, tf.SelectedLength);
+			Assert.Null (tf.SelectedText);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2277 - The selected text is handled internally by the `TextField` and any change to the `Text` property must also clear the selected text.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
