### PR TITLE
Fixes #2298 - Adds TabView.TabClicked event

### DIFF
--- a/Terminal.Gui/Views/TabView.cs
+++ b/Terminal.Gui/Views/TabView.cs
@@ -679,7 +679,7 @@ namespace Terminal.Gui {
 					me.Flags.HasFlag (MouseFlags.Button2Clicked) ||
 					me.Flags.HasFlag (MouseFlags.Button3Clicked);
 
-				if (hit != null && isClick) {
+				if (isClick) {
 					host.OnTabClicked (new TabMouseEventArgs (hit, me));
 
 					// user canceled click
@@ -777,9 +777,11 @@ namespace Terminal.Gui {
 		public class TabMouseEventArgs : EventArgs {
 
 			/// <summary>
-			/// Gets the <see cref="TabView.Tab"/> that the mouse was over when the <see cref="MouseEvent"/>
-			/// occurred.
+			/// Gets the <see cref="TabView.Tab"/> (if any) that the mouse
+			/// was over when the <see cref="MouseEvent"/> occurred.
 			/// </summary>
+			/// <remarks>This will be null if the click is after last tab
+			/// or before first.</remarks>
 			public Tab Tab { get; }
 
 			/// <summary>

--- a/Terminal.Gui/Views/TabView.cs
+++ b/Terminal.Gui/Views/TabView.cs
@@ -53,6 +53,14 @@ namespace Terminal.Gui {
 		/// </summary>
 		public event EventHandler<TabChangedEventArgs> SelectedTabChanged;
 
+
+		/// <summary>
+		/// Event fired when a <see cref="TabView.Tab"/> is clicked.  Can be used to cancel navigation,
+		/// show context menu (e.g. on right click) etc.
+		/// </summary>
+		public event EventHandler<TabMouseEventArgs> TabClicked;
+
+
 		/// <summary>
 		/// The currently selected member of <see cref="Tabs"/> chosen by the user
 		/// </summary>
@@ -665,6 +673,22 @@ namespace Terminal.Gui {
 
 			public override bool MouseEvent (MouseEvent me)
 			{
+				var hit = ScreenToTab (me.X, me.Y);
+
+				bool isClick = me.Flags.HasFlag (MouseFlags.Button1Clicked) ||
+					me.Flags.HasFlag (MouseFlags.Button2Clicked) ||
+					me.Flags.HasFlag (MouseFlags.Button3Clicked);
+
+				if (hit != null && isClick) {
+					host.OnTabClicked (new TabMouseEventArgs (hit, me));
+
+					// user canceled click
+					if (me.Handled) {
+						return true;
+					}
+				}
+
+
 				if (!me.Flags.HasFlag (MouseFlags.Button1Clicked) &&
 				!me.Flags.HasFlag (MouseFlags.Button1DoubleClicked) &&
 				!me.Flags.HasFlag (MouseFlags.Button1TripleClicked))
@@ -689,7 +713,7 @@ namespace Terminal.Gui {
 						return true;
 					}
 
-					var hit = ScreenToTab (me.X, me.Y);
+
 					if (hit != null) {
 						host.SelectedTab = hit;
 						SetNeedsDisplay ();
@@ -738,6 +762,43 @@ namespace Terminal.Gui {
 			}
 		}
 
+		/// <summary>
+		/// Raises the <see cref="TabClicked"/> event.
+		/// </summary>
+		/// <param name="tabMouseEventArgs"></param>
+		protected virtual private void OnTabClicked (TabMouseEventArgs tabMouseEventArgs)
+		{
+			TabClicked?.Invoke (this, tabMouseEventArgs);
+		}
+
+		/// <summary>
+		/// Describes a mouse event over a specific <see cref="TabView.Tab"/> in a <see cref="TabView"/>.
+		/// </summary>
+		public class TabMouseEventArgs : EventArgs {
+
+			/// <summary>
+			/// Gets the <see cref="TabView.Tab"/> that the mouse was over when the <see cref="MouseEvent"/>
+			/// occurred.
+			/// </summary>
+			public Tab Tab { get; }
+
+			/// <summary>
+			/// Gets the actual mouse event.  Use <see cref="MouseEvent.Handled"/> to cancel this event
+			/// and perform custom behavior (e.g. show a context menu).
+			/// </summary>
+			public MouseEvent MouseEvent { get; }
+
+			/// <summary>
+			/// Creates a new instance of the <see cref="TabMouseEventArgs"/> class.
+			/// </summary>
+			/// <param name="tab"><see cref="TabView.Tab"/> that the mouse was over when the event occurred.</param>
+			/// <param name="mouseEvent">The mouse activity being reported</param>
+			public TabMouseEventArgs (Tab tab, MouseEvent mouseEvent)
+			{
+				Tab = tab;
+				MouseEvent = mouseEvent;
+			}
+		}
 
 		/// <summary>
 		/// A single tab in a <see cref="TabView"/>

--- a/UICatalog/Scenarios/Notepad.cs
+++ b/UICatalog/Scenarios/Notepad.cs
@@ -38,6 +38,8 @@ namespace UICatalog.Scenarios {
 				Height = Dim.Fill (1),
 			};
 
+			tabView.TabClicked += TabView_TabClicked;
+
 			tabView.Style.ShowBorder = true;
 			tabView.ApplyStyleChanges ();
 
@@ -63,6 +65,19 @@ namespace UICatalog.Scenarios {
 			New ();
 		}
 
+		private void TabView_TabClicked (object sender, TabView.TabMouseEventArgs e)
+		{
+			var contextMenu = new ContextMenu (e.MouseEvent.X + 1, e.MouseEvent.Y + 1,
+				new MenuBarItem (new MenuItem [] {
+					new MenuItem ($"Save", "", () => Save(e.Tab)),
+					new MenuItem ($"Close", "", () => Close(e.Tab)),
+				})
+			);
+
+			contextMenu.Show ();
+			e.MouseEvent.Handled = true;
+		}
+
 		private void New ()
 		{
 			Open ("", null, $"new {numbeOfNewTabs++}");
@@ -70,7 +85,11 @@ namespace UICatalog.Scenarios {
 
 		private void Close ()
 		{
-			var tab = tabView.SelectedTab as OpenedFile;
+			Close (tabView.SelectedTab);
+		}
+		private void Close (TabView.Tab tabToClose)
+		{
+			var tab = tabToClose as OpenedFile;
 
 			if (tab == null) {
 				return;
@@ -156,9 +175,13 @@ namespace UICatalog.Scenarios {
 			};
 		}
 
-		public void Save ()
+		public void Save()
 		{
-			var tab = tabView.SelectedTab as OpenedFile;
+			Save (tabView.SelectedTab);
+		}
+		public void Save (TabView.Tab tabToSave )
+		{
+			var tab = tabToSave as OpenedFile;
 
 			if (tab == null) {
 				return;

--- a/UICatalog/Scenarios/Notepad.cs
+++ b/UICatalog/Scenarios/Notepad.cs
@@ -67,12 +67,27 @@ namespace UICatalog.Scenarios {
 
 		private void TabView_TabClicked (object sender, TabView.TabMouseEventArgs e)
 		{
-			var contextMenu = new ContextMenu (e.MouseEvent.X + 1, e.MouseEvent.Y + 1,
-				new MenuBarItem (new MenuItem [] {
+			// we are only interested in right clicks
+			if(!e.MouseEvent.Flags.HasFlag(MouseFlags.Button3Clicked)) {
+				return;
+			}
+
+			MenuBarItem items;
+
+			if (e.Tab == null) {
+				items = new MenuBarItem (new MenuItem [] {
+					new MenuItem ($"Open", "", () => Open()),
+				});
+
+			} else {
+				items = new MenuBarItem (new MenuItem [] {
 					new MenuItem ($"Save", "", () => Save(e.Tab)),
 					new MenuItem ($"Close", "", () => Close(e.Tab)),
-				})
-			);
+				});
+			}
+
+
+			var contextMenu = new ContextMenu (e.MouseEvent.X + 1, e.MouseEvent.Y + 1, items);
 
 			contextMenu.Show ();
 			e.MouseEvent.Handled = true;
@@ -175,11 +190,11 @@ namespace UICatalog.Scenarios {
 			};
 		}
 
-		public void Save()
+		public void Save ()
 		{
 			Save (tabView.SelectedTab);
 		}
-		public void Save (TabView.Tab tabToSave )
+		public void Save (TabView.Tab tabToSave)
 		{
 			var tab = tabToSave as OpenedFile;
 

--- a/UnitTests/Views/TabViewTests.cs
+++ b/UnitTests/Views/TabViewTests.cs
@@ -839,6 +839,17 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal(tab1, clicked);
 			Assert.Equal(tab2, tv.SelectedTab);
 
+
+			tabRow.MouseEvent (new MouseEvent {
+				X = 10,
+				Y = 1,
+				Flags = MouseFlags.Button1Clicked
+			});
+
+			// Clicking beyond last tab should raise event with null Tab
+			Assert.Null (clicked);
+			Assert.Equal (tab2, tv.SelectedTab);
+
 		}
 
 		private void InitFakeDriver ()


### PR DESCRIPTION
Fixes #2298 - Adds TabClicked event

![tabview-right-click](https://user-images.githubusercontent.com/31306100/213789531-f9650e77-98ae-4142-9825-dacf57104a21.gif)

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
