### PR TITLE
Fixes #2296.  `Attribute.Make` works even if a driver isn't loaded

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -160,10 +160,11 @@ namespace Terminal.Gui {
 
 		public override void UpdateScreen () => window.redrawwin ();
 
-		Attribute currentAttribute;
+		Attribute currentAttribute = new Attribute (Color.White, Color.Black);
 
 		public override void SetAttribute (Attribute c)
 		{
+			base.SetAttribute (c);
 			currentAttribute = c;
 			Curses.attrset (currentAttribute);
 		}
@@ -201,6 +202,7 @@ namespace Terminal.Gui {
 
 		public override void SetColors (ConsoleColor foreground, ConsoleColor background)
 		{
+			// BUGBUG: This code is never called ?? See Issue #2300
 			int f = (short)foreground;
 			int b = (short)background;
 			var v = colorPairs [f, b];
@@ -218,6 +220,7 @@ namespace Terminal.Gui {
 		Dictionary<int, int> rawPairs = new Dictionary<int, int> ();
 		public override void SetColors (short foreColorId, short backgroundColorId)
 		{
+			// BUGBUG: This code is never called ?? See Issue #2300
 			int key = ((ushort)foreColorId << 16) | (ushort)backgroundColorId;
 			if (!rawPairs.TryGetValue (key, out var v)) {
 				v = MakeColor (foreColorId, backgroundColorId);

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -208,11 +208,9 @@ namespace Terminal.Gui {
 			rows = FakeConsole.WindowHeight = FakeConsole.BufferHeight = FakeConsole.HEIGHT;
 			FakeConsole.Clear ();
 			ResizeScreen ();
-			UpdateOffScreen ();
-
+			// Call CreateColors before UpdateOffScreen as it references Colors
 			CreateColors ();
-
-			//MockConsole.Clear ();
+			UpdateOffScreen ();
 		}
 
 		public override Attribute MakeAttribute (Color fore, Color back)
@@ -283,9 +281,10 @@ namespace Terminal.Gui {
 			UpdateCursor ();
 		}
 
-		Attribute currentAttribute;
+		Attribute currentAttribute = new Attribute (Color.White, Color.Black);
 		public override void SetAttribute (Attribute c)
 		{
+			base.SetAttribute (c);
 			currentAttribute = c;
 		}
 

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -1613,9 +1613,11 @@ namespace Terminal.Gui {
 		{
 		}
 
-		Attribute currentAttribute;
+		Attribute currentAttribute = new Attribute (Color.White, Color.Black);
+
 		public override void SetAttribute (Attribute c)
 		{
+			base.SetAttribute (c);
 			currentAttribute = c;
 		}
 

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1568,10 +1568,11 @@ namespace Terminal.Gui {
 				AddRune (rune);
 		}
 
-		Attribute currentAttribute;
+		Attribute currentAttribute = new Attribute (Color.White, Color.Black);
 
 		public override void SetAttribute (Attribute c)
 		{
+			base.SetAttribute (c);
 			currentAttribute = c;
 		}
 

--- a/UnitTests/Drivers/AttributeTests.cs
+++ b/UnitTests/Drivers/AttributeTests.cs
@@ -85,7 +85,34 @@ namespace Terminal.Gui.DriverTests {
 		}
 
 		[Fact]
-		public void Make_SetsNotInitialized_IfNotInit ()
+		public void Implicit_Assign_NoDriver ()
+		{
+
+			var attr = new Attribute ();
+
+			var fg = new Color ();
+			fg = Color.Red;
+
+			var bg = new Color ();
+			bg = Color.Blue;
+
+			// Test conversion to int
+			attr = new Attribute (fg, bg);
+			int value_implicit = (int)attr.Value;
+			Assert.False (attr.Initialized);
+
+			Assert.Equal (-1, value_implicit);
+			Assert.False (attr.Initialized);
+
+			// Test conversion from int
+			attr = -1;
+			Assert.Equal (-1, attr.Value);
+			Assert.False (attr.Initialized);
+
+		}
+
+		[Fact]
+		public void Make_SetsNotInitialized_NoDriver ()
 		{
 			var fg = new Color ();
 			fg = Color.Red;
@@ -95,7 +122,7 @@ namespace Terminal.Gui.DriverTests {
 
 			var a = Attribute.Make (fg, bg);
 
-			Assert.False (a.IsInitialized);
+			Assert.False (a.Initialized);
 		}
 
 		[Fact]
@@ -111,8 +138,8 @@ namespace Terminal.Gui.DriverTests {
 			var bg = new Color ();
 			bg = Color.Blue;
 
-			var attr =  Attribute.Make (fg, bg);
-			Assert.True (attr.IsInitialized);
+			var attr = Attribute.Make (fg, bg);
+			Assert.True (attr.Initialized);
 			Assert.Equal (fg, attr.Foreground);
 			Assert.Equal (bg, attr.Background);
 
@@ -121,7 +148,23 @@ namespace Terminal.Gui.DriverTests {
 		}
 
 		[Fact]
-		public void Get_Asserts_IfNotInit ()
+		public void Make_Creates_NoDriver ()
+		{
+
+			var fg = new Color ();
+			fg = Color.Red;
+
+			var bg = new Color ();
+			bg = Color.Blue;
+
+			var attr = Attribute.Make (fg, bg);
+			Assert.False (attr.Initialized);
+			Assert.Equal (fg, attr.Foreground);
+			Assert.Equal (bg, attr.Background);
+		}
+
+		[Fact]
+		public void Get_Asserts_NoDriver ()
 		{
 			Assert.Throws<InvalidOperationException> (() => Attribute.Get ());
 		}
@@ -164,6 +207,25 @@ namespace Terminal.Gui.DriverTests {
 
 			Assert.Equal (Color.Red, fg);
 			Assert.Equal (Color.Green, bg);
+		}
+
+		[Fact]
+		public void IsValid_Tests ()
+		{
+			var attr = new Attribute ();
+			Assert.True (attr.HasValidColors);
+
+			attr = new Attribute (Color.Red, Color.Green);
+			Assert.True (attr.HasValidColors);
+
+			attr = new Attribute (Color.Red, Color.Invalid);
+			Assert.False (attr.HasValidColors);
+
+			attr = new Attribute (Color.Invalid, Color.Green);
+			Assert.False (attr.HasValidColors);
+
+			attr = new Attribute (Color.Invalid, Color.Invalid);
+			Assert.False (attr.HasValidColors);
 		}
 	}
 }

--- a/UnitTests/Drivers/AttributeTests.cs
+++ b/UnitTests/Drivers/AttributeTests.cs
@@ -85,7 +85,7 @@ namespace Terminal.Gui.DriverTests {
 		}
 
 		[Fact]
-		public void Make_Asserts_IfNotInit ()
+		public void Make_SetsNotInitialized_IfNotInit ()
 		{
 			var fg = new Color ();
 			fg = Color.Red;
@@ -93,7 +93,9 @@ namespace Terminal.Gui.DriverTests {
 			var bg = new Color ();
 			bg = Color.Blue;
 
-			Assert.Throws<InvalidOperationException> (() => Attribute.Make (fg, bg));
+			var a = Attribute.Make (fg, bg);
+
+			Assert.False (a.IsInitialized);
 		}
 
 		[Fact]
@@ -110,7 +112,7 @@ namespace Terminal.Gui.DriverTests {
 			bg = Color.Blue;
 
 			var attr =  Attribute.Make (fg, bg);
-
+			Assert.True (attr.IsInitialized);
 			Assert.Equal (fg, attr.Foreground);
 			Assert.Equal (bg, attr.Background);
 

--- a/UnitTests/Drivers/ColorTests.cs
+++ b/UnitTests/Drivers/ColorTests.cs
@@ -35,5 +35,14 @@ namespace Terminal.Gui.DriverTests {
 			Application.Shutdown ();
 		}
 
+		[Fact, AutoInitShutdown]
+		public void ColorScheme_New ()
+		{
+			var scheme = new ColorScheme ();
+			var lbl = new Label ();
+			lbl.ColorScheme = scheme;
+			lbl.Redraw (lbl.Bounds);
+		}
+
 	}
 }

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -1601,8 +1601,8 @@ Y
 					// Calling the Text constructor.
 					lbl = new Label (text);
 				}
-				lbl.ColorScheme = new ColorScheme ();
-				lbl.Redraw (lbl.Bounds);
+				Application.Top.Add (lbl);
+				Application.Top.Redraw (Application.Top.Bounds);
 
 				// should have the initial text
 				Assert.Equal ('t', driver.Contents [0, 0, 0]);


### PR DESCRIPTION
Fixes #2296

- Adds a `Invalid` constant to the `Color` enum - this is in prep for Configuration Manager where there is a need to know if a Color has been set or not
- Adds an `HasValidColors` property to `Attribute` that is false if either of the foreground/background colors is `Invalid`
- Changes the `set` semantics of `ColorScheme` such that if an `Attribute` being set is `Invalid`, it does nothing (the alternative was to throw an exception, but this would break existing code that passes around un-initialized `Attributes`; a NOP does no harm).
- Adds an `Initialized` property to `Attribute` that indicates if the `Attribute` was initialized by a drive or not.
- Adds unit tests for the above changes
- Outputs debug spew in `ConsoleDriver` if un-initilaized `Attributes` are passed to `SetAttribute`
- Changes all `ConsoleDriver`s to initialize `currentAttribute` with a  valid attribute 

Note there's a lot of code (esp in Unit Tests) that create new instances of `ColorScheme` and then do things without actually setting any valid values. Previously this all worked because none of these tests are actually inspecting Attributes. 