### PR TITLE
Fixes 2343 - LineCanvas not respecting X and Y of clip bounds

### DIFF
--- a/Terminal.Gui/Core/Graphs/LineCanvas.cs
+++ b/Terminal.Gui/Core/Graphs/LineCanvas.cs
@@ -65,7 +65,7 @@ namespace Terminal.Gui.Graphs {
 				for (int x = 0; x < inArea.Width; x++) {
 
 					var intersects = lines
-						.Select (l => l.Intersects (x, y))
+						.Select (l => l.Intersects (inArea.X + x, inArea.Y + y))
 						.Where (i => i != null)
 						.ToArray ();
 

--- a/Terminal.Gui/Core/Graphs/LineCanvas.cs
+++ b/Terminal.Gui/Core/Graphs/LineCanvas.cs
@@ -79,15 +79,20 @@ namespace Terminal.Gui.Graphs {
 		}
 
 		/// <summary>
-		/// Draws all the lines that lie within the <paramref name="bounds"/> onto
-		/// the <paramref name="view"/> client area.  This method should be called from
+		/// Draws all the lines that lie within the <paramref name="sourceRect"/> onto
+		/// the <paramref name="view"/> client area at given <paramref name="drawOffset"/>.
+		///  This method should be called from
 		/// <see cref="View.Redraw(Rect)"/>.
 		/// </summary>
 		/// <param name="view"></param>
-		/// <param name="bounds"></param>
-		public void Draw (View view, Rect bounds)
+		/// <param name="sourceRect">The area of the canvas to draw.</param>
+		/// <param name="drawOffset">The point within the client area of 
+		/// <paramref name="view"/> to draw at.</param>
+		public void Draw (View view, Rect sourceRect, Point? drawOffset = null)
 		{
-			var runes = GenerateImage (bounds);
+			var offset = drawOffset ?? Point.Empty;
+
+			var runes = GenerateImage (sourceRect);
 
 			var runeRows = runes.GetLength (0);
 			var runeCols = runes.GetLength (1);
@@ -97,7 +102,7 @@ namespace Terminal.Gui.Graphs {
 					var rune = runes [y, x];
 
 					if (rune.HasValue) {
-						view.AddRune (bounds.X + x, bounds.Y + y, rune.Value);
+						view.AddRune (offset.X + x, offset.Y + y, rune.Value);
 					}
 				}
 			}

--- a/Terminal.Gui/Core/Graphs/LineCanvas.cs
+++ b/Terminal.Gui/Core/Graphs/LineCanvas.cs
@@ -89,12 +89,15 @@ namespace Terminal.Gui.Graphs {
 		{
 			var runes = GenerateImage (bounds);
 
-			for (int y = bounds.Y; y < bounds.Height; y++) {
-				for (int x = bounds.X; x < bounds.Width; x++) {
+			var runeRows = runes.GetLength (0);
+			var runeCols = runes.GetLength (1);
+
+			for (int y = 0; y < runeRows; y++) {
+				for (int x = 0; x < runeCols; x++) {
 					var rune = runes [y, x];
 
 					if (rune.HasValue) {
-						view.AddRune (x, y, rune.Value);
+						view.AddRune (bounds.X + x, bounds.Y + y, rune.Value);
 					}
 				}
 			}

--- a/Terminal.Gui/Core/Graphs/LineCanvas.cs
+++ b/Terminal.Gui/Core/Graphs/LineCanvas.cs
@@ -11,10 +11,10 @@ namespace Terminal.Gui.Graphs {
 	/// </summary>
 	public class LineCanvas {
 
-		
+
 		private List<StraightLine> lines = new List<StraightLine> ();
 
-		Dictionary<IntersectionRuneType, IntersectionRuneResolver> runeResolvers = new Dictionary<IntersectionRuneType, IntersectionRuneResolver> { 
+		Dictionary<IntersectionRuneType, IntersectionRuneResolver> runeResolvers = new Dictionary<IntersectionRuneType, IntersectionRuneResolver> {
 			{IntersectionRuneType.ULCorner,new ULIntersectionRuneResolver()},
 			{IntersectionRuneType.URCorner,new URIntersectionRuneResolver()},
 			{IntersectionRuneType.LLCorner,new LLIntersectionRuneResolver()},
@@ -100,15 +100,14 @@ namespace Terminal.Gui.Graphs {
 			}
 		}
 
-		private abstract class IntersectionRuneResolver
-		{
+		private abstract class IntersectionRuneResolver {
 			readonly Rune round;
 			readonly Rune doubleH;
 			readonly Rune doubleV;
 			readonly Rune doubleBoth;
 			readonly Rune normal;
 
-			public IntersectionRuneResolver(Rune round, Rune doubleH, Rune doubleV, Rune doubleBoth, Rune normal)
+			public IntersectionRuneResolver (Rune round, Rune doubleH, Rune doubleV, Rune doubleBoth, Rune normal)
 			{
 				this.round = round;
 				this.doubleH = doubleH;
@@ -121,17 +120,15 @@ namespace Terminal.Gui.Graphs {
 			{
 				var useRounded = intersects.Any (i => i.Line.Style == BorderStyle.Rounded && i.Line.Length != 0);
 
-				bool doubleHorizontal = intersects.Any(l=>l.Line.Orientation == Orientation.Horizontal && l.Line.Style == BorderStyle.Double);
-				bool doubleVertical = intersects.Any(l=>l.Line.Orientation == Orientation.Vertical && l.Line.Style == BorderStyle.Double);
+				bool doubleHorizontal = intersects.Any (l => l.Line.Orientation == Orientation.Horizontal && l.Line.Style == BorderStyle.Double);
+				bool doubleVertical = intersects.Any (l => l.Line.Orientation == Orientation.Vertical && l.Line.Style == BorderStyle.Double);
 
 
-				if(doubleHorizontal)
-				{
-						return doubleVertical ? doubleBoth : doubleH;
+				if (doubleHorizontal) {
+					return doubleVertical ? doubleBoth : doubleH;
 				}
-				
-				if(doubleVertical)
-				{
+
+				if (doubleVertical) {
 					return doubleV;
 				}
 
@@ -139,75 +136,71 @@ namespace Terminal.Gui.Graphs {
 			}
 		}
 
-		private class ULIntersectionRuneResolver : IntersectionRuneResolver 
-		{
-			public ULIntersectionRuneResolver() :
-				base('╭','╒','╓','╔','┌')
+		private class ULIntersectionRuneResolver : IntersectionRuneResolver {
+			public ULIntersectionRuneResolver () :
+				base ('╭', '╒', '╓', '╔', '┌')
 			{
-				
-			}
-		}
-		private class URIntersectionRuneResolver : IntersectionRuneResolver 
-		{
 
-			public URIntersectionRuneResolver() :
-				base('╮','╕','╖','╗','┐')
-			{
-				
 			}
 		}
-		private class LLIntersectionRuneResolver : IntersectionRuneResolver 
-		{
+		private class URIntersectionRuneResolver : IntersectionRuneResolver {
 
-			public LLIntersectionRuneResolver() :
-				base('╰','╘','╙','╚','└')
+			public URIntersectionRuneResolver () :
+				base ('╮', '╕', '╖', '╗', '┐')
 			{
-				
+
 			}
 		}
-		private class LRIntersectionRuneResolver : IntersectionRuneResolver 
-		{
-			public LRIntersectionRuneResolver() :
-				base('╯','╛','╜','╝','┘')
+		private class LLIntersectionRuneResolver : IntersectionRuneResolver {
+
+			public LLIntersectionRuneResolver () :
+				base ('╰', '╘', '╙', '╚', '└')
 			{
-				
+
+			}
+		}
+		private class LRIntersectionRuneResolver : IntersectionRuneResolver {
+			public LRIntersectionRuneResolver () :
+				base ('╯', '╛', '╜', '╝', '┘')
+			{
+
 			}
 		}
 
-		private class TopTeeIntersectionRuneResolver : IntersectionRuneResolver 
-		{
-			public TopTeeIntersectionRuneResolver():
-				base('┬','╤','╥','╦','┬'){
-					
-				}
+		private class TopTeeIntersectionRuneResolver : IntersectionRuneResolver {
+			public TopTeeIntersectionRuneResolver () :
+				base ('┬', '╤', '╥', '╦', '┬')
+			{
+
+			}
 		}
-		private class LeftTeeIntersectionRuneResolver : IntersectionRuneResolver 
-		{
-			public LeftTeeIntersectionRuneResolver():
-				base('├','╞','╟','╠','├'){
-					
-				}
+		private class LeftTeeIntersectionRuneResolver : IntersectionRuneResolver {
+			public LeftTeeIntersectionRuneResolver () :
+				base ('├', '╞', '╟', '╠', '├')
+			{
+
+			}
 		}
-		private class RightTeeIntersectionRuneResolver : IntersectionRuneResolver 
-		{
-			public RightTeeIntersectionRuneResolver():
-				base('┤','╡','╢','╣','┤'){
-					
-				}
+		private class RightTeeIntersectionRuneResolver : IntersectionRuneResolver {
+			public RightTeeIntersectionRuneResolver () :
+				base ('┤', '╡', '╢', '╣', '┤')
+			{
+
+			}
 		}
-		private class BottomTeeIntersectionRuneResolver : IntersectionRuneResolver 
-		{
-			public BottomTeeIntersectionRuneResolver():
-				base('┴','╧','╨','╩','┴'){
-					
-				}
+		private class BottomTeeIntersectionRuneResolver : IntersectionRuneResolver {
+			public BottomTeeIntersectionRuneResolver () :
+				base ('┴', '╧', '╨', '╩', '┴')
+			{
+
+			}
 		}
-		private class CrosshairIntersectionRuneResolver : IntersectionRuneResolver 
-		{
-			public CrosshairIntersectionRuneResolver():
-				base('┼','╪','╫','╬','┼'){
-					
-				}
+		private class CrosshairIntersectionRuneResolver : IntersectionRuneResolver {
+			public CrosshairIntersectionRuneResolver () :
+				base ('┼', '╪', '╫', '╬', '┼')
+			{
+
+			}
 		}
 
 		private Rune? GetRuneForIntersects (ConsoleDriver driver, IntersectionDefinition [] intersects)
@@ -217,7 +210,7 @@ namespace Terminal.Gui.Graphs {
 
 			var runeType = GetRuneTypeForIntersects (intersects);
 
-			if(runeResolvers.ContainsKey (runeType)) {
+			if (runeResolvers.ContainsKey (runeType)) {
 				return runeResolvers [runeType].GetRuneForIntersects (driver, intersects);
 			}
 
@@ -228,13 +221,13 @@ namespace Terminal.Gui.Graphs {
 			// TODO: maybe make these resolvers to for simplicity?
 			// or for dotted lines later on or that kind of thing?
 			switch (runeType) {
-			case IntersectionRuneType.None: 
+			case IntersectionRuneType.None:
 				return null;
-			case IntersectionRuneType.Dot: 
+			case IntersectionRuneType.Dot:
 				return (Rune)'.';
-			case IntersectionRuneType.HLine: 
+			case IntersectionRuneType.HLine:
 				return useDouble ? driver.HDLine : driver.HLine;
-			case IntersectionRuneType.VLine: 
+			case IntersectionRuneType.VLine:
 				return useDouble ? driver.VDLine : driver.VLine;
 			default: throw new Exception ("Could not find resolver or switch case for " + nameof (runeType) + ":" + runeType);
 			}
@@ -243,7 +236,7 @@ namespace Terminal.Gui.Graphs {
 
 		private IntersectionRuneType GetRuneTypeForIntersects (IntersectionDefinition [] intersects)
 		{
-			if(intersects.All(i=>i.Line.Length == 0)) {
+			if (intersects.All (i => i.Line.Length == 0)) {
 				return IntersectionRuneType.Dot;
 			}
 

--- a/UICatalog/Scenarios/LineDrawing.cs
+++ b/UICatalog/Scenarios/LineDrawing.cs
@@ -71,7 +71,12 @@ namespace UICatalog.Scenarios {
 				base.Redraw (bounds);
 
 				Driver.SetAttribute (new Terminal.Gui.Attribute (Color.DarkGray, ColorScheme.Normal.Background));
-				grid.Draw (this, bounds);
+				
+				
+				foreach(var p in grid.GenerateImage(bounds))
+				{
+					this.AddRune(p.Key.X,p.Key.Y,p.Value);
+				}
 
 				foreach (var swatch in swatches) {
 					Driver.SetAttribute (new Terminal.Gui.Attribute (swatch.Value, ColorScheme.Normal.Background));
@@ -151,7 +156,13 @@ namespace UICatalog.Scenarios {
 				foreach (var kvp in colorLayers) {
 
 					Driver.SetAttribute (new Terminal.Gui.Attribute (kvp.Key, ColorScheme.Normal.Background));
-					canvases [kvp.Value].Draw (this, bounds);
+
+					var canvas = canvases [kvp.Value];
+
+					foreach(var p in canvas.GenerateImage(bounds))
+					{
+						this.AddRune(p.Key.X,p.Key.Y,p.Value);
+					}
 				}
 			}
 			public override bool OnMouseEvent (MouseEvent mouseEvent)

--- a/UnitTests/Core/LineCanvasTests.cs
+++ b/UnitTests/Core/LineCanvasTests.cs
@@ -1,4 +1,7 @@
-﻿using Terminal.Gui.Graphs;
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Terminal.Gui.Graphs;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -129,6 +132,7 @@ namespace Terminal.Gui.CoreTests {
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		
 		}
+
 		[Fact,AutoInitShutdown]
 		public void TestLineCanvas_Window ()
 		{
@@ -279,6 +283,52 @@ namespace Terminal.Gui.CoreTests {
 ";
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
+
+
+		[Theory, AutoInitShutdown]
+		[InlineData(0,0,@"
+═══
+══
+═══")]
+		[InlineData (1, 0,@"
+══
+═
+══")]
+		[InlineData (2, 0,@"
+═
+
+═")]
+		[InlineData (0, 1,@"
+══
+═══")]
+		[InlineData (0, 2,@"
+═══")]
+		public void TestLineCanvasRenderOffset_NoOffset (int xOffset,int yOffset, string expect)
+		{
+			var canvas = new LineCanvas ();
+			canvas.AddLine (new Point (0, 0), 2, Orientation.Horizontal, BorderStyle.Double);
+			canvas.AddLine (new Point (0, 1), 1, Orientation.Horizontal, BorderStyle.Double);
+			canvas.AddLine (new Point (0, 2), 2, Orientation.Horizontal, BorderStyle.Double);
+
+			var bmp = canvas.GenerateImage (new Rect (xOffset, yOffset, 3, 3));
+			var actual = BmpToString (bmp);
+			Assert.Equal (expect.TrimStart (), actual);
+
+		}
+
+		private string BmpToString (System.Rune? [,] bmp)
+		{
+			var sb = new StringBuilder ();
+			for (int y = 0; y < bmp.GetLength (1); y++) {
+				for (int x = 0; x < bmp.GetLength (0); x++) {
+					sb.Append (bmp [y, x]);
+				}
+				sb.AppendLine ();
+			}
+
+			return sb.ToString ().TrimEnd ();
+		}
+
 
 		private View GetCanvas (out LineCanvas canvas)
 		{

--- a/UnitTests/Core/LineCanvasTests.cs
+++ b/UnitTests/Core/LineCanvasTests.cs
@@ -312,50 +312,6 @@ namespace Terminal.Gui.CoreTests {
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
 
-		[Theory, AutoInitShutdown]
-		[InlineData (0, 0, @"
-═══
-══
-═══")]
-		[InlineData (1, 0, @"
-══
-═
-══")]
-		[InlineData (2, 0, @"
-═
-
-═")]
-		[InlineData (0, 1, @"
-══
-═══")]
-		[InlineData (0, 2, @"
-═══")]
-		public void TestLineCanvasRenderOffset_NoOffset (int xOffset, int yOffset, string expect)
-		{
-			var canvas = new LineCanvas ();
-			canvas.AddLine (new Point (0, 0), 2, Orientation.Horizontal, BorderStyle.Double);
-			canvas.AddLine (new Point (0, 1), 1, Orientation.Horizontal, BorderStyle.Double);
-			canvas.AddLine (new Point (0, 2), 2, Orientation.Horizontal, BorderStyle.Double);
-
-			var bmp = canvas.GenerateImage (new Rect (xOffset, yOffset, 3, 3));
-			var actual = BmpToString (bmp);
-			Assert.Equal (expect.TrimStart (), actual);
-
-		}
-
-		private string BmpToString (System.Rune? [,] bmp)
-		{
-			var sb = new StringBuilder ();
-			for (int y = 0; y < bmp.GetLength (1); y++) {
-				for (int x = 0; x < bmp.GetLength (0); x++) {
-					sb.Append (bmp [y, x]);
-				}
-				sb.AppendLine ();
-			}
-
-			return sb.ToString ().TrimEnd ();
-		}
-
 
 		/// <summary>
 		/// Creates a new <see cref="View"/> into which a <see cref="LineCanvas"/> is rendered
@@ -374,7 +330,15 @@ namespace Terminal.Gui.CoreTests {
 			};
 
 			var canvasCopy = canvas = new LineCanvas ();
-			v.DrawContentComplete += (r) => canvasCopy.Draw (v, v.Bounds, new Point(offsetX,offsetY));
+			v.DrawContentComplete += (r) => {
+					foreach(var p in canvasCopy.GenerateImage(v.Bounds))
+					{
+						v.AddRune(
+							offsetX + p.Key.X,
+							offsetY + p.Key.Y,
+							p.Value);
+					}
+				};
 
 			return v;
 		}

--- a/UnitTests/Core/LineCanvasTests.cs
+++ b/UnitTests/Core/LineCanvasTests.cs
@@ -284,6 +284,35 @@ namespace Terminal.Gui.CoreTests {
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
 
+		[Fact, AutoInitShutdown]
+		public void TestLineCanvas_PositiveLocation ()
+		{
+			var x = 1;
+			var y = 1;
+			var v = GetCanvas (out var canvas, x, y);
+
+			// outer box
+			canvas.AddLine (new Point (x, y), 9, Orientation.Horizontal, BorderStyle.Single);
+			canvas.AddLine (new Point (x + 9, y + 0), 4, Orientation.Vertical, BorderStyle.Single);
+			canvas.AddLine (new Point (x + 9, y + 4), -9, Orientation.Horizontal, BorderStyle.Single);
+			canvas.AddLine (new Point (x + 0, y + 4), -4, Orientation.Vertical, BorderStyle.Single);
+
+
+			canvas.AddLine (new Point (x + 5, y + 0), 4, Orientation.Vertical, BorderStyle.Single);
+			canvas.AddLine (new Point (x + 0, y + 2), 9, Orientation.Horizontal, BorderStyle.Single);
+
+			v.Redraw (v.Bounds);
+
+			string looksLike =
+@"    
+
+ ┌────┬───┐
+ │    │   │
+ ├────┼───┤
+ │    │   │
+ └────┴───┘";
+			TestHelpers.AssertDriverContentsAre (looksLike, output);
+		}
 
 		[Theory, AutoInitShutdown]
 		[InlineData (0, 0, @"
@@ -330,12 +359,20 @@ namespace Terminal.Gui.CoreTests {
 		}
 
 
-		private View GetCanvas (out LineCanvas canvas)
+		/// <summary>
+		/// Creates a new <see cref="View"/> into which a <see cref="LineCanvas"/> is rendered
+		/// at <see cref="View.DrawContentComplete"/> time.
+		/// </summary>
+		/// <param name="canvas">The <see cref="LineCanvas"/> you can draw into.</param>
+		/// <param name="offsetX">How far to offset the <see cref="View.Bounds"/> in X</param>
+		/// <param name="offsetX">How far to offset the <see cref="View.Bounds"/> in Y</param>
+		/// <returns></returns>
+		private View GetCanvas (out LineCanvas canvas, int offsetX = 0, int offsetY = 0)
 		{
 			var v = new View {
 				Width = 10,
 				Height = 5,
-				Bounds = new Rect (0, 0, 10, 5)
+				Bounds = new Rect (offsetX, offsetY, 10, 5)
 			};
 
 			var canvasCopy = canvas = new LineCanvas ();

--- a/UnitTests/Core/LineCanvasTests.cs
+++ b/UnitTests/Core/LineCanvasTests.cs
@@ -60,7 +60,7 @@ namespace Terminal.Gui.CoreTests {
 		}
 
 		[InlineData (BorderStyle.Single)]
-		[InlineData(BorderStyle.Rounded)]
+		[InlineData (BorderStyle.Rounded)]
 		[Theory, AutoInitShutdown]
 		public void TestLineCanvas_Vertical (BorderStyle style)
 		{
@@ -96,7 +96,7 @@ namespace Terminal.Gui.CoreTests {
 		/// Not when they terminate adjacent to one another.
 		/// </summary>
 		[Fact, AutoInitShutdown]
-		public void TestLineCanvas_Corner_NoOverlap()
+		public void TestLineCanvas_Corner_NoOverlap ()
 		{
 			var v = GetCanvas (out var canvas);
 			canvas.AddLine (new Point (0, 0), 1, Orientation.Horizontal, BorderStyle.Single);
@@ -130,14 +130,14 @@ namespace Terminal.Gui.CoreTests {
 │
 │";
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
-		
+
 		}
 
-		[Fact,AutoInitShutdown]
+		[Fact, AutoInitShutdown]
 		public void TestLineCanvas_Window ()
 		{
 			var v = GetCanvas (out var canvas);
-			
+
 			// outer box
 			canvas.AddLine (new Point (0, 0), 9, Orientation.Horizontal, BorderStyle.Single);
 			canvas.AddLine (new Point (9, 0), 4, Orientation.Vertical, BorderStyle.Single);
@@ -172,10 +172,10 @@ namespace Terminal.Gui.CoreTests {
 
 			// outer box
 			canvas.AddLine (new Point (0, 0), 9, Orientation.Horizontal, BorderStyle.Rounded);
-			
+
 			// BorderStyle.Single is ignored because corner overlaps with the above line which is Rounded
 			// this results in a rounded corner being used.
-			canvas.AddLine (new Point (9, 0), 4, Orientation.Vertical, BorderStyle.Single); 
+			canvas.AddLine (new Point (9, 0), 4, Orientation.Vertical, BorderStyle.Single);
 			canvas.AddLine (new Point (9, 4), -9, Orientation.Horizontal, BorderStyle.Rounded);
 			canvas.AddLine (new Point (0, 4), -4, Orientation.Vertical, BorderStyle.Single);
 
@@ -224,8 +224,8 @@ namespace Terminal.Gui.CoreTests {
 
 
 		[Theory, AutoInitShutdown]
-		[InlineData(BorderStyle.Single)]
-		[InlineData(BorderStyle.Rounded)]
+		[InlineData (BorderStyle.Single)]
+		[InlineData (BorderStyle.Rounded)]
 		public void TestLineCanvas_Window_DoubleTop_SingleSides (BorderStyle thinStyle)
 		{
 			var v = GetCanvas (out var canvas);
@@ -237,7 +237,7 @@ namespace Terminal.Gui.CoreTests {
 			canvas.AddLine (new Point (0, 4), -4, Orientation.Vertical, thinStyle);
 
 
-			canvas.AddLine (new Point (5, 0), 4, Orientation.Vertical,thinStyle);
+			canvas.AddLine (new Point (5, 0), 4, Orientation.Vertical, thinStyle);
 			canvas.AddLine (new Point (0, 2), 9, Orientation.Horizontal, BorderStyle.Double);
 
 			v.Redraw (v.Bounds);
@@ -254,8 +254,8 @@ namespace Terminal.Gui.CoreTests {
 		}
 
 		[Theory, AutoInitShutdown]
-		[InlineData(BorderStyle.Single)]
-		[InlineData(BorderStyle.Rounded)]
+		[InlineData (BorderStyle.Single)]
+		[InlineData (BorderStyle.Rounded)]
 		public void TestLineCanvas_Window_SingleTop_DoubleSides (BorderStyle thinStyle)
 		{
 			var v = GetCanvas (out var canvas);
@@ -263,8 +263,8 @@ namespace Terminal.Gui.CoreTests {
 			// outer box
 			canvas.AddLine (new Point (0, 0), 9, Orientation.Horizontal, thinStyle);
 			canvas.AddLine (new Point (9, 0), 4, Orientation.Vertical, BorderStyle.Double);
-			canvas.AddLine (new Point (9, 4), -9, Orientation.Horizontal,thinStyle);
-			canvas.AddLine (new Point (0, 4), -4, Orientation.Vertical,  BorderStyle.Double);
+			canvas.AddLine (new Point (9, 4), -9, Orientation.Horizontal, thinStyle);
+			canvas.AddLine (new Point (0, 4), -4, Orientation.Vertical, BorderStyle.Double);
 
 
 			canvas.AddLine (new Point (5, 0), 4, Orientation.Vertical, BorderStyle.Double);
@@ -286,24 +286,24 @@ namespace Terminal.Gui.CoreTests {
 
 
 		[Theory, AutoInitShutdown]
-		[InlineData(0,0,@"
+		[InlineData (0, 0, @"
 ═══
 ══
 ═══")]
-		[InlineData (1, 0,@"
+		[InlineData (1, 0, @"
 ══
 ═
 ══")]
-		[InlineData (2, 0,@"
+		[InlineData (2, 0, @"
 ═
 
 ═")]
-		[InlineData (0, 1,@"
+		[InlineData (0, 1, @"
 ══
 ═══")]
-		[InlineData (0, 2,@"
+		[InlineData (0, 2, @"
 ═══")]
-		public void TestLineCanvasRenderOffset_NoOffset (int xOffset,int yOffset, string expect)
+		public void TestLineCanvasRenderOffset_NoOffset (int xOffset, int yOffset, string expect)
 		{
 			var canvas = new LineCanvas ();
 			canvas.AddLine (new Point (0, 0), 2, Orientation.Horizontal, BorderStyle.Double);
@@ -338,8 +338,8 @@ namespace Terminal.Gui.CoreTests {
 				Bounds = new Rect (0, 0, 10, 5)
 			};
 
-			var canvasCopy = canvas =  new LineCanvas ();
-			v.DrawContentComplete += (r)=> canvasCopy.Draw (v, v.Bounds);
+			var canvasCopy = canvas = new LineCanvas ();
+			v.DrawContentComplete += (r) => canvasCopy.Draw (v, v.Bounds);
 
 			return v;
 		}

--- a/UnitTests/Core/LineCanvasTests.cs
+++ b/UnitTests/Core/LineCanvasTests.cs
@@ -285,32 +285,30 @@ namespace Terminal.Gui.CoreTests {
 		}
 
 		[Fact, AutoInitShutdown]
-		public void TestLineCanvas_PositiveLocation ()
+		public void TestLineCanvas_LeaveMargin_Top1_Left1 ()
 		{
-			var x = 1;
-			var y = 1;
-			var v = GetCanvas (out var canvas, x, y);
+			// Draw at 1,1 within client area of View (i.e. leave a top and left margin of 1)
+			var v = GetCanvas (out var canvas, 1, 1);
 
 			// outer box
-			canvas.AddLine (new Point (x, y), 9, Orientation.Horizontal, BorderStyle.Single);
-			canvas.AddLine (new Point (x + 9, y + 0), 4, Orientation.Vertical, BorderStyle.Single);
-			canvas.AddLine (new Point (x + 9, y + 4), -9, Orientation.Horizontal, BorderStyle.Single);
-			canvas.AddLine (new Point (x + 0, y + 4), -4, Orientation.Vertical, BorderStyle.Single);
+			canvas.AddLine (new Point (0, 0), 8, Orientation.Horizontal, BorderStyle.Single);
+			canvas.AddLine (new Point (8, 0), 3, Orientation.Vertical, BorderStyle.Single);
+			canvas.AddLine (new Point (8, 3), -8, Orientation.Horizontal, BorderStyle.Single);
+			canvas.AddLine (new Point (0, 3), -3, Orientation.Vertical, BorderStyle.Single);
 
 
-			canvas.AddLine (new Point (x + 5, y + 0), 4, Orientation.Vertical, BorderStyle.Single);
-			canvas.AddLine (new Point (x + 0, y + 2), 9, Orientation.Horizontal, BorderStyle.Single);
+			canvas.AddLine (new Point (5, 0), 3, Orientation.Vertical, BorderStyle.Single);
+			canvas.AddLine (new Point (0, 2), 8, Orientation.Horizontal, BorderStyle.Single);
 
 			v.Redraw (v.Bounds);
 
 			string looksLike =
-@"    
-
- ┌────┬───┐
- │    │   │
- ├────┼───┤
- │    │   │
- └────┴───┘";
+@"
+ ┌────┬──┐
+ │    │  │
+ ├────┼──┤
+ └────┴──┘
+";
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
 
@@ -364,19 +362,19 @@ namespace Terminal.Gui.CoreTests {
 		/// at <see cref="View.DrawContentComplete"/> time.
 		/// </summary>
 		/// <param name="canvas">The <see cref="LineCanvas"/> you can draw into.</param>
-		/// <param name="offsetX">How far to offset the <see cref="View.Bounds"/> in X</param>
-		/// <param name="offsetX">How far to offset the <see cref="View.Bounds"/> in Y</param>
+		/// <param name="offsetX">How far to offset drawing in X</param>
+		/// <param name="offsetY">How far to offset drawing in Y</param>
 		/// <returns></returns>
 		private View GetCanvas (out LineCanvas canvas, int offsetX = 0, int offsetY = 0)
 		{
 			var v = new View {
 				Width = 10,
 				Height = 5,
-				Bounds = new Rect (offsetX, offsetY, 10, 5)
+				Bounds = new Rect (0, 0, 10, 5)
 			};
 
 			var canvasCopy = canvas = new LineCanvas ();
-			v.DrawContentComplete += (r) => canvasCopy.Draw (v, v.Bounds);
+			v.DrawContentComplete += (r) => canvasCopy.Draw (v, v.Bounds, new Point(offsetX,offsetY));
 
 			return v;
 		}


### PR DESCRIPTION
Fixes #2343 - `GenerateImage` no longer assumes clip area starts at 0,0

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
