### PR TITLE
Fixes #2348. The Basic Colors scenario doesn't output the blue on white properly.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -1013,8 +1013,6 @@ namespace Terminal.Gui {
 				return Curses.COLOR_YELLOW | Curses.A_BOLD | Curses.COLOR_GRAY;
 			case Color.White:
 				return Curses.COLOR_WHITE | Curses.A_BOLD | Curses.COLOR_GRAY;
-			case Color.Invalid:
-				return Curses.COLOR_BLACK; 
 			}
 			throw new ArgumentException ("Invalid color code");
 		}

--- a/Terminal.Gui/Core/ConsoleDriver.cs
+++ b/Terminal.Gui/Core/ConsoleDriver.cs
@@ -15,7 +15,7 @@ namespace Terminal.Gui {
 	/// Colors that can be used to set the foreground and background colors in console applications.
 	/// </summary>
 	/// <remarks>
-	/// The <see cref="Color.Invalid"/> value indicates either no-color has been set or the color is invalid.
+	/// The <see cref="Attribute.HasValidColors"/> value indicates either no-color has been set or the color is invalid.
 	/// </remarks>
 	public enum Color {
 		/// <summary>
@@ -81,11 +81,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// The White color.
 		/// </summary>
-		White,
-		/// <summary>
-		/// Indicates an invalid or un-set color value. 
-		/// </summary>
-		Invalid = -1
+		White
 	}
 
 	/// <summary>
@@ -177,7 +173,7 @@ namespace Terminal.Gui {
 	public struct Attribute {
 		/// <summary>
 		/// The <see cref="ConsoleDriver"/>-specific color attribute value. If <see cref="Initialized"/> is <see langword="false"/> 
-		/// the value of this property is invalid (typcially because the Attribute was created before a driver was loaded)
+		/// the value of this property is invalid (typically because the Attribute was created before a driver was loaded)
 		/// and the attribute should be re-made (see <see cref="Make(Color, Color)"/>) before it is used.
 		/// </summary>
 		public int Value { get; }
@@ -199,8 +195,8 @@ namespace Terminal.Gui {
 		/// <param name="value">Value.</param>
 		public Attribute (int value)
 		{
-			Color foreground = Color.Invalid;
-			Color background = Color.Invalid;
+			Color foreground = default;
+			Color background = default;
 
 			Initialized = false;
 			if (Application.Driver != null) {
@@ -280,9 +276,9 @@ namespace Terminal.Gui {
 		{
 			if (Application.Driver == null) {
 				// Create the attribute, but show it's not been initialized
-				var a = new Attribute (-1, foreground, background);
-				a.Initialized = false;
-				return a;
+				return new Attribute (-1, foreground, background) {
+					Initialized = false
+				};
 			}
 			return Application.Driver.MakeAttribute (foreground, background);
 		}
@@ -299,10 +295,10 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// If <see langword="true"/> the attribute has been initialzed by a <see cref="ConsoleDriver"/> and 
+		/// If <see langword="true"/> the attribute has been initialized by a <see cref="ConsoleDriver"/> and 
 		/// thus has <see cref="Value"/> that is valid for that driver. If <see langword="false"/> the <see cref="Foreground"/>
-		/// and <see cref="Background"/> colors may have been set (see <see cref="Color.Invalid"/>) but
-		/// the attribute has not been mapped to a <see cref="ConsoleDriver"/> specific color value. 
+		/// and <see cref="Background"/> colors may have been set '-1' but
+		/// the attribute has not been mapped to a <see cref="ConsoleDriver"/> specific color value.
 		/// </summary>
 		/// <remarks>
 		/// Attributes that have not been initialized must eventually be initialized before being passed to a driver.
@@ -310,14 +306,10 @@ namespace Terminal.Gui {
 		public bool Initialized { get; internal set; }
 
 		/// <summary>
-		/// Returns <see langword="true"/> if the Atrribute is valid (both foreground and background have valid color values).
+		/// Returns <see langword="true"/> if the Attribute is valid (both foreground and background have valid color values).
 		/// </summary>
 		/// <returns></returns>
-		public bool HasValidColors {
-			get {
-				return Foreground != Color.Invalid && Background != Color.Invalid;
-			}
-		}
+		public bool HasValidColors { get => (int)Foreground > -1 && (int)Background != -1; }
 	}
 
 	/// <summary>
@@ -329,7 +321,7 @@ namespace Terminal.Gui {
 	/// See also: <see cref="Colors.ColorSchemes"/>.
 	/// </remarks>
 	public class ColorScheme : IEquatable<ColorScheme> {
-		Attribute _normal = new Attribute(Color.White, Color.Black);
+		Attribute _normal = new Attribute (Color.White, Color.Black);
 		Attribute _focus = new Attribute (Color.White, Color.Black);
 		Attribute _hotNormal = new Attribute (Color.White, Color.Black);
 		Attribute _hotFocus = new Attribute (Color.White, Color.Black);
@@ -520,13 +512,13 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Creates a new dictionary of new <see cref="ColorScheme"/> objects.
 		/// </summary>
-		public static Dictionary<string, ColorScheme> Create () 
+		public static Dictionary<string, ColorScheme> Create ()
 		{
 			// Use reflection to dynamically create the default set of ColorSchemes from the list defined 
 			// by the class. 
 			return typeof (Colors).GetProperties ()
 				.Where (p => p.PropertyType == typeof (ColorScheme))
-				.Select (p => new KeyValuePair<string, ColorScheme> (p.Name, new ColorScheme()))
+				.Select (p => new KeyValuePair<string, ColorScheme> (p.Name, new ColorScheme ()))
 				.ToDictionary (t => t.Key, t => t.Value, comparer: new SchemeNameComparerIgnoreCase ());
 		}
 
@@ -881,7 +873,7 @@ namespace Terminal.Gui {
 		/// The current attribute the driver is using. 
 		/// </summary>
 		public virtual Attribute CurrentAttribute {
-			get => currentAttribute; 
+			get => currentAttribute;
 			set {
 				if (!value.Initialized && value.HasValidColors && Application.Driver != null) {
 					CurrentAttribute = Application.Driver.MakeAttribute (value.Foreground, value.Background);
@@ -1463,13 +1455,13 @@ namespace Terminal.Gui {
 		public abstract Attribute MakeColor (Color foreground, Color background);
 
 		/// <summary>
-		/// Ensures all <see cref="Attribute"/>s in <see cref="Colors.ColorSchemes"/> are correclty 
-		/// initalized by the driver.
+		/// Ensures all <see cref="Attribute"/>s in <see cref="Colors.ColorSchemes"/> are correctly 
+		/// initialized by the driver.
 		/// </summary>
 		/// <param name="supportsColors">Flag indicating if colors are supported (not used).</param>
 		public void InitalizeColorSchemes (bool supportsColors = true)
 		{
-			// Ensure all Attributes are initlaized by the driver
+			// Ensure all Attributes are initialized by the driver
 			foreach (var s in Colors.ColorSchemes) {
 				s.Value.Initialize ();
 			}
@@ -1480,7 +1472,7 @@ namespace Terminal.Gui {
 
 
 			// Define the default color theme only if the user has not defined one.
-			
+
 			Colors.TopLevel.Normal = MakeColor (Color.BrightGreen, Color.Black);
 			Colors.TopLevel.Focus = MakeColor (Color.White, Color.Cyan);
 			Colors.TopLevel.HotNormal = MakeColor (Color.Brown, Color.Black);

--- a/Terminal.Gui/Core/ConsoleDriver.cs
+++ b/Terminal.Gui/Core/ConsoleDriver.cs
@@ -309,7 +309,7 @@ namespace Terminal.Gui {
 		/// Returns <see langword="true"/> if the Attribute is valid (both foreground and background have valid color values).
 		/// </summary>
 		/// <returns></returns>
-		public bool HasValidColors { get => (int)Foreground > -1 && (int)Background != -1; }
+		public bool HasValidColors { get => (int)Foreground > -1 && (int)Background > -1; }
 	}
 
 	/// <summary>

--- a/UICatalog/Scenarios/BasicColors.cs
+++ b/UICatalog/Scenarios/BasicColors.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Terminal.Gui;
+﻿using Terminal.Gui;
 
 namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "Basic Colors", Description: "Show all basic colors.")]
@@ -11,11 +10,10 @@ namespace UICatalog.Scenarios {
 			var vx = 30;
 			var x = 30;
 			var y = 14;
-			var colors = System.Enum.GetValues (typeof (Color)).Cast<Color> ().ToArray ();
+			var colors = System.Enum.GetValues (typeof (Color));
 
-			for (int i = 0; i < colors.Length; i++) {
-				Color bg = colors [i];
-				Attribute attr = new Attribute (bg, colors [colors.Length - 1 - i]);
+			foreach (Color bg in colors) {
+				Attribute attr = new Attribute (bg, colors.Length - 1 - bg);
 				var vl = new Label (bg.ToString (), TextDirection.TopBottom_LeftRight) {
 					X = vx,
 					Y = 0,

--- a/UICatalog/Scenarios/BasicColors.cs
+++ b/UICatalog/Scenarios/BasicColors.cs
@@ -1,4 +1,5 @@
-﻿using Terminal.Gui;
+﻿using System.Linq;
+using Terminal.Gui;
 
 namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "Basic Colors", Description: "Show all basic colors.")]
@@ -10,16 +11,18 @@ namespace UICatalog.Scenarios {
 			var vx = 30;
 			var x = 30;
 			var y = 14;
-			var colors = System.Enum.GetValues (typeof (Color));
+			var colors = System.Enum.GetValues (typeof (Color)).Cast<Color> ().ToArray ();
 
-			foreach (Color bg in colors) {
+			for (int i = 0; i < colors.Length; i++) {
+				Color bg = colors [i];
+				Attribute attr = new Attribute (bg, colors [colors.Length - 1 - i]);
 				var vl = new Label (bg.ToString (), TextDirection.TopBottom_LeftRight) {
 					X = vx,
 					Y = 0,
 					Width = 1,
 					Height = 13,
 					VerticalTextAlignment = VerticalTextAlignment.Bottom,
-					ColorScheme = new ColorScheme () { Normal = new Attribute (bg, colors.Length - 1 - bg) }
+					ColorScheme = new ColorScheme () { Normal = attr }
 				};
 				Win.Add (vl);
 				var hl = new Label (bg.ToString ()) {
@@ -28,7 +31,7 @@ namespace UICatalog.Scenarios {
 					Width = 13,
 					Height = 1,
 					TextAlignment = TextAlignment.Right,
-					ColorScheme = new ColorScheme () { Normal = new Attribute (bg, colors.Length - 1 - bg) }
+					ColorScheme = new ColorScheme () { Normal = attr }
 				};
 				Win.Add (hl);
 				vx++;

--- a/UnitTests/Drivers/AttributeTests.cs
+++ b/UnitTests/Drivers/AttributeTests.cs
@@ -218,13 +218,13 @@ namespace Terminal.Gui.DriverTests {
 			attr = new Attribute (Color.Red, Color.Green);
 			Assert.True (attr.HasValidColors);
 
-			attr = new Attribute (Color.Red, Color.Invalid);
+			attr = new Attribute (Color.Red, (Color)(-1));
 			Assert.False (attr.HasValidColors);
 
-			attr = new Attribute (Color.Invalid, Color.Green);
+			attr = new Attribute ((Color)(-1), Color.Green);
 			Assert.False (attr.HasValidColors);
 
-			attr = new Attribute (Color.Invalid, Color.Invalid);
+			attr = new Attribute ((Color)(-1), (Color)(-1));
 			Assert.False (attr.HasValidColors);
 		}
 	}

--- a/UnitTests/Drivers/ColorTests.cs
+++ b/UnitTests/Drivers/ColorTests.cs
@@ -44,5 +44,34 @@ namespace Terminal.Gui.DriverTests {
 			lbl.Redraw (lbl.Bounds);
 		}
 
+		[Fact]
+		public void TestAllColors ()
+		{
+			var colors = System.Enum.GetValues (typeof (Color));
+			Attribute [] attrs = new Attribute [colors.Length];
+
+			int idx = 0;
+			foreach (Color bg in colors) {
+				attrs [idx] = new Attribute (bg, colors.Length - 1 - bg);
+				idx++;
+			}
+			Assert.Equal (16, attrs.Length);
+			Assert.Equal (new Attribute (Color.Black, Color.White), attrs [0]);
+			Assert.Equal (new Attribute (Color.Blue, Color.BrightYellow), attrs [1]);
+			Assert.Equal (new Attribute (Color.Green, Color.BrightMagenta), attrs [2]);
+			Assert.Equal (new Attribute (Color.Cyan, Color.BrightRed), attrs [3]);
+			Assert.Equal (new Attribute (Color.Red, Color.BrightCyan), attrs [4]);
+			Assert.Equal (new Attribute (Color.Magenta, Color.BrightGreen), attrs [5]);
+			Assert.Equal (new Attribute (Color.Brown, Color.BrightBlue), attrs [6]);
+			Assert.Equal (new Attribute (Color.Gray, Color.DarkGray), attrs [7]);
+			Assert.Equal (new Attribute (Color.DarkGray, Color.Gray), attrs [8]);
+			Assert.Equal (new Attribute (Color.BrightBlue, Color.Brown), attrs [9]);
+			Assert.Equal (new Attribute (Color.BrightGreen, Color.Magenta), attrs [10]);
+			Assert.Equal (new Attribute (Color.BrightCyan, Color.Red), attrs [11]);
+			Assert.Equal (new Attribute (Color.BrightRed, Color.Cyan), attrs [12]);
+			Assert.Equal (new Attribute (Color.BrightMagenta, Color.Green), attrs [13]);
+			Assert.Equal (new Attribute (Color.BrightYellow, Color.Blue), attrs [14]);
+			Assert.Equal (new Attribute (Color.White, Color.Black), attrs [^1]);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2348 - After the adding of the `Color.Invalid` the calculation used doesn't work anymore. Converting to an array and changing from `foreach` to `for` statement fixed the issue.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
