### PR TITLE
Fixes #2354. View.Redraw doesn't clear itself and PositionCursor doesn't ensure focus when a prior view was disabled.

### DIFF
--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -908,6 +908,12 @@ namespace Terminal.Gui {
 		{
 			if (!IsMdiContainer) {
 				base.PositionCursor ();
+				if (Focused == null) {
+					EnsureFocus ();
+					if (Focused == null) {
+						Driver.SetCursorVisibility (CursorVisibility.Invisible);
+					}
+				}
 				return;
 			}
 
@@ -920,6 +926,9 @@ namespace Terminal.Gui {
 				}
 			}
 			base.PositionCursor ();
+			if (Focused == null) {
+				Driver.SetCursorVisibility (CursorVisibility.Invisible);
+			}
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1510,11 +1510,7 @@ namespace Terminal.Gui {
 			var clipRect = new Rect (Point.Empty, frame.Size);
 
 			if (ColorScheme != null) {
-				if (!IgnoreHasFocusPropertyOnRedraw) {
-					Driver.SetAttribute (HasFocus ? GetFocusColor () : GetNormalColor ());
-				} else {
-					Driver.SetAttribute (GetNormalColor ());
-				}
+				Driver.SetAttribute (HasFocus ? GetFocusColor () : GetNormalColor ());
 			}
 
 			if (!IgnoreBorderPropertyOnRedraw && Border != null) {
@@ -2701,15 +2697,6 @@ namespace Terminal.Gui {
 		/// itself).
 		/// </summary>
 		public virtual bool IgnoreBorderPropertyOnRedraw { get; set; }
-
-		/// <summary>
-		/// Get or sets whether the view will use <see cref="Terminal.Gui.View.HasFocus"/> 
-		/// to set the <see cref="Terminal.Gui.ColorScheme.Focus"/> color if it's focused.
-		/// If <see langword="false"/> (the default), <see cref="View.Redraw(Rect)"/> will call <see cref="GetFocusColor"/>
-		/// or the <see cref="GetNormalColor"/> method.
-		/// If <see langword="true"/> only the <see cref="GetNormalColor"/> will be called.
-		/// </summary>
-		public virtual bool IgnoreHasFocusPropertyOnRedraw { get; set; }
 
 		/// <summary>
 		/// Pretty prints the View

--- a/UnitTests/TopLevels/ToplevelTests.cs
+++ b/UnitTests/TopLevels/ToplevelTests.cs
@@ -1011,5 +1011,25 @@ namespace Terminal.Gui.TopLevelTests {
 			Assert.True (isEnter);
 			Assert.False (isLeave);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void PositionCursor_SetCursorVisibility_To_Invisible_If_Focused_Is_Null ()
+		{
+			var tf = new TextField ("test") { Width = 5 };
+			var view = new View () { Width = 10, Height = 10 };
+			view.Add (tf);
+			Application.Top.Add (view);
+			Application.Begin (Application.Top);
+
+			Assert.True (tf.HasFocus);
+			Application.Driver.GetCursorVisibility (out CursorVisibility cursor);
+			Assert.Equal (CursorVisibility.Default, cursor);
+
+			view.Enabled = false;
+			Assert.False (tf.HasFocus);
+			Application.Refresh ();
+			Application.Driver.GetCursorVisibility (out cursor);
+			Assert.Equal (CursorVisibility.Invisible, cursor);
+		}
 	}
 }

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -4517,7 +4517,6 @@ At 0,0
 			Application.Top.Add (view);
 			Application.Begin (Application.Top);
 
-			Assert.False (view.IgnoreHasFocusPropertyOnRedraw);
 			Assert.False (view.CanFocus);
 			Assert.False (view.HasFocus);
 
@@ -4537,7 +4536,6 @@ At 0,0
 0000000", attributes);
 
 			view.CanFocus = true;
-			Assert.False (view.IgnoreHasFocusPropertyOnRedraw);
 			Assert.True (view.CanFocus);
 			view.SetFocus ();
 			Assert.True (view.HasFocus);
@@ -4549,20 +4547,6 @@ At 0,0
 0222220
 0222220
 0222220
-0000000", attributes);
-
-			view.IgnoreHasFocusPropertyOnRedraw = true;
-			Application.Refresh ();
-			Assert.True (view.IgnoreHasFocusPropertyOnRedraw);
-			Assert.True (view.CanFocus);
-			Assert.True (view.HasFocus);
-			TestHelpers.AssertDriverColorsAre (@"
-0000000
-0111110
-0111110
-0111110
-0111110
-0111110
 0000000", attributes);
 		}
 


### PR DESCRIPTION
Fixes #2354 - A simple view now can be used as container with normal and focus color if `IgnoreHasFocusPropertyOnRedraw` is false (default) or only with the normal color if it's true. Now if it's possible to focus a enable view this is ensured, otherwise the cursor will be invisible.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

![imagem](https://user-images.githubusercontent.com/13117724/220145529-5d8bbe5a-23f6-4819-aed7-2d1da82e48b6.png)
