### PR TITLE
Fixes 2368. Nested views with height of 1 not rendering correctly.

### DIFF
--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -1190,8 +1190,8 @@ namespace Terminal.Gui {
 			for (int line = 0; line < linesFormated.Count; line++) {
 				if ((isVertical && line > bounds.Width) || (!isVertical && line > bounds.Height))
 					continue;
-				if ((isVertical && line >= maxBounds.Left + maxBounds.Width - 1)
-					|| (!isVertical && line >= maxBounds.Top + maxBounds.Height - 1))
+				if ((isVertical && line >= maxBounds.Left + maxBounds.Width)
+					|| (!isVertical && line >= maxBounds.Top + maxBounds.Height))
 
 					break;
 

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -1,5 +1,6 @@
 ﻿using NStack;
 using System;
+using Terminal.Gui.Graphs;
 using Xunit;
 using Xunit.Abstractions;
 //using GraphViewTests = Terminal.Gui.Views.GraphViewTests;
@@ -4488,6 +4489,32 @@ At 0,0
                              
   A text with some long width
    A text witith two lines.  ", output);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void Test_Nested_Views_With_Height_Equal_To_One ()
+		{
+			var v = new View () { Width = 11, Height = 3, ColorScheme = new ColorScheme () };
+
+			var top = new View () { Width = Dim.Fill (), Height = 1 };
+			var bottom = new View () { Width = Dim.Fill (), Height = 1, Y = 2 };
+
+			top.Add (new Label ("111"));
+			v.Add (top);
+			v.Add (new LineView (Orientation.Horizontal) { Y = 1 });
+			bottom.Add (new Label ("222"));
+			v.Add (bottom);
+
+			v.LayoutSubviews ();
+			v.Redraw (v.Bounds);
+
+
+			string looksLike =
+@"    
+111
+───────────
+222";
+			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2368 - I had included minus 1 in the width and height by mistake, sorry about that.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
