### PR TITLE
Fixes #2382. Nested views throws TopologicalSort exception if they reference Pos/Dim to the root view.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -2469,8 +2469,8 @@ namespace Terminal.Gui {
 			if (SuperView != null && GetTopSuperView () != null && LayoutNeeded
 			    && ordered.Count == 0 && edges.Count > 0 && LayoutStyle == LayoutStyle.Computed) {
 
-				(var _, var to) = edges.First ();
-				LayoutSubview (to, SuperView.Frame);
+				(var from, var to) = edges.First ();
+				LayoutSubview (to, from.Frame);
 			}
 
 			LayoutNeeded = false;

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1525,7 +1525,7 @@ namespace Terminal.Gui {
 
 			if (!ustring.IsNullOrEmpty (TextFormatter.Text)) {
 				Rect containerBounds = GetContainerBounds ();
-				Clear (ViewToScreen (GetNeedDisplay (containerBounds)));
+				Clear (GetNeedDisplay (containerBounds));
 				SetChildNeedsDisplay ();
 				// Draw any Text
 				if (TextFormatter != null) {
@@ -1570,7 +1570,7 @@ namespace Terminal.Gui {
 
 		Rect GetNeedDisplay (Rect containerBounds)
 		{
-			Rect rect = NeedDisplay;
+			Rect rect = ViewToScreen (NeedDisplay);
 			if (!containerBounds.IsEmpty) {
 				rect.Width = Math.Min (NeedDisplay.Width, containerBounds.Width);
 				rect.Height = Math.Min (NeedDisplay.Height, containerBounds.Height);

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -2319,7 +2319,7 @@ namespace Terminal.Gui {
 
 			if (edges.Any ()) {
 				(var from, var to) = edges.First ();
-				if (from != Application.Top) {
+				if (from != GetTopSuperView (to, from)) {
 					if (!ReferenceEquals (from, to)) {
 						throw new InvalidOperationException ($"TopologicalSort (for Pos/Dim) cannot find {from} linked with {to}. Did you forget to add it to {this}?");
 					} else {
@@ -2463,22 +2463,29 @@ namespace Terminal.Gui {
 			var ordered = TopologicalSort (nodes, edges);
 
 			foreach (var v in ordered) {
-				if (v.LayoutStyle == LayoutStyle.Computed) {
-					v.SetRelativeLayout (Frame);
-				}
-
-				v.LayoutSubviews ();
-				v.LayoutNeeded = false;
+				LayoutSubview (v, Frame);
 			}
 
-			if (SuperView != null && SuperView == Application.Top && LayoutNeeded
-			    && ordered.Count == 0 && LayoutStyle == LayoutStyle.Computed) {
-				SetRelativeLayout (SuperView.Frame);
+			if (SuperView != null && GetTopSuperView () != null && LayoutNeeded
+			    && ordered.Count == 0 && edges.Count > 0 && LayoutStyle == LayoutStyle.Computed) {
+
+				(var _, var to) = edges.First ();
+				LayoutSubview (to, SuperView.Frame);
 			}
 
 			LayoutNeeded = false;
 
 			OnLayoutComplete (new LayoutEventArgs () { OldBounds = oldBounds });
+		}
+
+		private void LayoutSubview (View v, Rect hostFrame)
+		{
+			if (v.LayoutStyle == LayoutStyle.Computed) {
+				v.SetRelativeLayout (hostFrame);
+			}
+
+			v.LayoutSubviews ();
+			v.LayoutNeeded = false;
 		}
 
 		ustring text;
@@ -3147,11 +3154,14 @@ namespace Terminal.Gui {
 		/// Get the top superview of a given <see cref="View"/>.
 		/// </summary>
 		/// <returns>The superview view.</returns>
-		public View GetTopSuperView ()
+		public View GetTopSuperView (View view = null, View superview = null)
 		{
-			View top = Application.Top;
-			for (var v = this?.SuperView; v != null; v = v.SuperView) {
+			View top = superview ?? Application.Top;
+			for (var v = view?.SuperView ?? (this?.SuperView); v != null; v = v.SuperView) {
 				top = v;
+				if (top == superview) {
+					break;
+				}
 			}
 
 			return top;

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -155,6 +155,53 @@ namespace Terminal.Gui.ViewTests {
 		}
 
 		[Fact]
+		public void TopologicalSort_Does_Never_Throws_If_Root_Is_Not_Null ()
+		{
+			var root = new View () { Id = "root", Width = 20, Height = 20 };
+			var sub1 = new View () {
+				Id = "sub1",
+				X = Pos.Left (root) + 1,
+				Y = Pos.Top (root) + 1,
+				Width = Dim.Width (root) - 2,
+				Height = Dim.Height (root) - 2
+			};
+			var sub2 = new View () {
+				Id = "sub2",
+				X = Pos.Left (root) + 1,
+				Y = Pos.Top (root) + 1,
+				Width = Dim.Width (root) - 2,
+				Height = Dim.Height (root) - 2
+			};
+			var sub3 = new View () {
+				Id = "sub3",
+				X = Pos.Left (root) + 1,
+				Y = Pos.Top (root) + 1,
+				Width = Dim.Width (root) - 2,
+				Height = Dim.Height (root) - 2
+			};
+			sub2.Add (sub3);
+			sub1.Add (sub2);
+			root.Add (sub1);
+
+			var exception = Record.Exception (root.LayoutSubviews);
+			Assert.Null (exception);
+			Assert.Equal (new Rect (0, 0, 20, 20), root.Frame);
+			Assert.Equal (new Rect (1, 1, 18, 18), sub1.Frame);
+			Assert.Equal (new Rect (1, 1, 18, 18), sub2.Frame);
+			Assert.Equal (new Rect (1, 1, 18, 18), sub3.Frame);
+
+			sub2.Width = Dim.Width (root);
+			exception = Record.Exception (root.LayoutSubviews);
+			Assert.Null (exception);
+			Assert.Equal (new Rect (1, 1, 20, 18), sub2.Frame);
+
+			sub3.Width = Dim.Width (root);
+			exception = Record.Exception (root.LayoutSubviews);
+			Assert.Null (exception);
+			Assert.Equal (new Rect (1, 1, 20, 18), sub3.Frame);
+		}
+
+		[Fact]
 		public void TopologicalSort_Recursive_Ref ()
 		{
 			var root = new View ();


### PR DESCRIPTION
Fixes #2382 - When the root of the nested views is valid, so not null, the exception must not throw.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
