### PR TITLE
Fixes #2403. Dialog draws incorrectly if opened with small width

### DIFF
--- a/Terminal.Gui/Windows/Dialog.cs
+++ b/Terminal.Gui/Windows/Dialog.cs
@@ -62,7 +62,7 @@ namespace Terminal.Gui {
 		/// <remarks>
 		/// Use the constructor that does not take a <c>width</c> and <c>height</c> instead.
 		/// </remarks>
-		public Dialog (ustring title, int width, int height, params Button [] buttons) : base (title, padding: padding)
+		public Dialog (ustring title, int width, int height, params Button [] buttons) : base (title: title, padding: padding)
 		{
 			X = Pos.Center ();
 			Y = Pos.Center ();
@@ -118,6 +118,42 @@ namespace Terminal.Gui {
 		/// After initialization use <c>X</c>, <c>Y</c>, <c>Width</c>, and <c>Height</c> to override this with a location or size.
 		/// </remarks>
 		public Dialog (ustring title, params Button [] buttons) : this (title: title, width: 0, height: 0, buttons: buttons) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Dialog"/> class using <see cref="LayoutStyle.Computed"/> positioning, 
+		/// with a <see cref="Border"/> and with an optional set of <see cref="Button"/>s to display
+		/// </summary>
+		/// <param name="title">Title for the dialog.</param>
+		/// <param name="border">The border.</param>
+		/// <param name="buttons">Optional buttons to lay out at the bottom of the dialog.</param>
+		public Dialog (ustring title, Border border, params Button [] buttons)
+			: this (title: title, width: 0, height: 0, buttons: buttons)
+		{
+			Initialize (title, border);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Dialog"/> class using <see cref="LayoutStyle.Computed"/> positioning, 
+		/// with a <see cref="Border"/> and with an optional set of <see cref="Button"/>s to display
+		/// </summary>
+		/// <param name="title">Title for the dialog.</param>
+		/// <param name="width">Width for the dialog.</param>
+		/// <param name="height">Height for the dialog.</param>
+		/// <param name="border">The border.</param>
+		/// <param name="buttons">Optional buttons to lay out at the bottom of the dialog.</param>
+		public Dialog (ustring title, int width, int height, Border border, params Button [] buttons)
+			: this (title: title, width: width, height: height, buttons: buttons)
+		{
+			Initialize (title, border);
+		}
+
+		void Initialize (ustring title, Border border)
+		{
+			if (border != null) {
+				Border = border;
+				Border.Title = title;
+			}
+		}
 
 		/// <summary>
 		/// Adds a <see cref="Button"/> to the <see cref="Dialog"/>, its layout will be controlled by the <see cref="Dialog"/>

--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -135,6 +135,7 @@ namespace Terminal.Gui {
 		/// <param name="message">Message to display, might contain multiple lines.</param>
 		/// <param name="defaultButton">Index of the default button.</param>
 		/// <param name="border">The border settings.</param>
+		/// <param name="wrapMessagge">If wrap the message or not.</param>
 		/// <param name="buttons">Array of buttons to add.</param>
 		/// <remarks>
 		/// Use <see cref="Query(ustring, ustring, ustring[])"/> instead; it automatically sizes the MessageBox based on the contents.
@@ -152,6 +153,7 @@ namespace Terminal.Gui {
 		/// <param name="message">Message to display, might contain multiple lines.</param>
 		/// <param name="defaultButton">Index of the default button.</param>
 		/// <param name="border">The border settings.</param>
+		/// <param name="wrapMessagge">If wrap the message or not.</param>
 		/// <param name="buttons">Array of buttons to add.</param>
 		/// <remarks>
 		/// The message box will be vertically and horizontally centered in the container and the size will be automatically determined
@@ -208,6 +210,7 @@ namespace Terminal.Gui {
 		/// <param name="message">Message to display, might contain multiple lines.</param>
 		/// <param name="defaultButton">Index of the default button.</param>
 		/// <param name="border">The border settings.</param>
+		/// <param name="wrapMessagge">If wrap the message or not.</param>
 		/// <param name="buttons">Array of buttons to add.</param>
 		/// <remarks>
 		/// Use <see cref="ErrorQuery(ustring, ustring, ustring[])"/> instead; it automatically sizes the MessageBox based on the contents.
@@ -225,6 +228,7 @@ namespace Terminal.Gui {
 		/// <param name="message">Message to display, might contain multiple lines.</param>
 		/// <param name="defaultButton">Index of the default button.</param>
 		/// <param name="border">The border settings.</param>
+		/// <param name="wrapMessagge">If wrap the message or not.</param>
 		/// <param name="buttons">Array of buttons to add.</param>
 		/// <remarks>
 		/// The message box will be vertically and horizontally centered in the container and the size will be automatically determined

--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -38,7 +38,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public static int Query (int width, int height, ustring title, ustring message, params ustring [] buttons)
 		{
-			return QueryFull (false, width, height, title, message, 0, null, buttons);
+			return QueryFull (false, width, height, title, message, 0, null, true, buttons);
 		}
 
 		/// <summary>
@@ -54,7 +54,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public static int Query (ustring title, ustring message, params ustring [] buttons)
 		{
-			return QueryFull (false, 0, 0, title, message, 0, null, buttons);
+			return QueryFull (false, 0, 0, title, message, 0, null, true, buttons);
 		}
 
 		/// <summary>
@@ -71,7 +71,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public static int ErrorQuery (int width, int height, ustring title, ustring message, params ustring [] buttons)
 		{
-			return QueryFull (true, width, height, title, message, 0, null, buttons);
+			return QueryFull (true, width, height, title, message, 0, null, true, buttons);
 		}
 
 		/// <summary>
@@ -87,7 +87,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public static int ErrorQuery (ustring title, ustring message, params ustring [] buttons)
 		{
-			return QueryFull (true, 0, 0, title, message, 0, null, buttons);
+			return QueryFull (true, 0, 0, title, message, 0, null, true, buttons);
 		}
 
 		/// <summary>
@@ -105,7 +105,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public static int Query (int width, int height, ustring title, ustring message, int defaultButton = 0, params ustring [] buttons)
 		{
-			return QueryFull (false, width, height, title, message, defaultButton, null, buttons);
+			return QueryFull (false, width, height, title, message, defaultButton, null, true, buttons);
 		}
 
 		/// <summary>
@@ -122,7 +122,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public static int Query (ustring title, ustring message, int defaultButton = 0, params ustring [] buttons)
 		{
-			return QueryFull (false, 0, 0, title, message, defaultButton, null, buttons);
+			return QueryFull (false, 0, 0, title, message, defaultButton, null, true, buttons);
 		}
 
 		/// <summary>
@@ -139,9 +139,9 @@ namespace Terminal.Gui {
 		/// <remarks>
 		/// Use <see cref="Query(ustring, ustring, ustring[])"/> instead; it automatically sizes the MessageBox based on the contents.
 		/// </remarks>
-		public static int Query (int width, int height, ustring title, ustring message, int defaultButton = 0, Border border = null, params ustring [] buttons)
+		public static int Query (int width, int height, ustring title, ustring message, int defaultButton = 0, Border border = null, bool wrapMessagge = true, params ustring [] buttons)
 		{
-			return QueryFull (false, width, height, title, message, defaultButton, border, buttons);
+			return QueryFull (false, width, height, title, message, defaultButton, border, wrapMessagge, buttons);
 		}
 
 		/// <summary>
@@ -157,9 +157,9 @@ namespace Terminal.Gui {
 		/// The message box will be vertically and horizontally centered in the container and the size will be automatically determined
 		/// from the size of the message and buttons.
 		/// </remarks>
-		public static int Query (ustring title, ustring message, int defaultButton = 0, Border border = null, params ustring [] buttons)
+		public static int Query (ustring title, ustring message, int defaultButton = 0, Border border = null, bool wrapMessagge = true, params ustring [] buttons)
 		{
-			return QueryFull (false, 0, 0, title, message, defaultButton, border, buttons);
+			return QueryFull (false, 0, 0, title, message, defaultButton, border, wrapMessagge, buttons);
 		}
 
 
@@ -178,7 +178,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public static int ErrorQuery (int width, int height, ustring title, ustring message, int defaultButton = 0, params ustring [] buttons)
 		{
-			return QueryFull (true, width, height, title, message, defaultButton, null, buttons);
+			return QueryFull (true, width, height, title, message, defaultButton, null, true, buttons);
 		}
 
 		/// <summary>
@@ -195,7 +195,7 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public static int ErrorQuery (ustring title, ustring message, int defaultButton = 0, params ustring [] buttons)
 		{
-			return QueryFull (true, 0, 0, title, message, defaultButton, null, buttons);
+			return QueryFull (true, 0, 0, title, message, defaultButton, null, true, buttons);
 		}
 
 		/// <summary>
@@ -212,9 +212,9 @@ namespace Terminal.Gui {
 		/// <remarks>
 		/// Use <see cref="ErrorQuery(ustring, ustring, ustring[])"/> instead; it automatically sizes the MessageBox based on the contents.
 		/// </remarks>
-		public static int ErrorQuery (int width, int height, ustring title, ustring message, int defaultButton = 0, Border border = null, params ustring [] buttons)
+		public static int ErrorQuery (int width, int height, ustring title, ustring message, int defaultButton = 0, Border border = null, bool wrapMessagge = true, params ustring [] buttons)
 		{
-			return QueryFull (true, width, height, title, message, defaultButton, border, buttons);
+			return QueryFull (true, width, height, title, message, defaultButton, border, wrapMessagge, buttons);
 		}
 
 		/// <summary>
@@ -230,20 +230,20 @@ namespace Terminal.Gui {
 		/// The message box will be vertically and horizontally centered in the container and the size will be automatically determined
 		/// from the size of the title, message. and buttons.
 		/// </remarks>
-		public static int ErrorQuery (ustring title, ustring message, int defaultButton = 0, Border border = null, params ustring [] buttons)
+		public static int ErrorQuery (ustring title, ustring message, int defaultButton = 0, Border border = null, bool wrapMessagge = true, params ustring [] buttons)
 		{
-			return QueryFull (true, 0, 0, title, message, defaultButton, border, buttons);
+			return QueryFull (true, 0, 0, title, message, defaultButton, border, wrapMessagge, buttons);
 		}
 
 		static int QueryFull (bool useErrorColors, int width, int height, ustring title, ustring message,
-			int defaultButton = 0, Border border = null, params ustring [] buttons)
+			int defaultButton = 0, Border border = null, bool wrapMessagge = true, params ustring [] buttons)
 		{
 			int defaultWidth = 50;
 			if (defaultWidth > Application.Driver.Cols / 2) {
 				defaultWidth = (int)(Application.Driver.Cols * 0.60f);
 			}
 			int maxWidthLine = TextFormatter.MaxWidthLine (message);
-			if (maxWidthLine > Application.Driver.Cols) {
+			if (wrapMessagge && maxWidthLine > Application.Driver.Cols) {
 				maxWidthLine = Application.Driver.Cols;
 			}
 			if (width == 0) {
@@ -251,10 +251,14 @@ namespace Terminal.Gui {
 			} else {
 				maxWidthLine = width;
 			}
-			int textWidth = Math.Min (TextFormatter.MaxWidth (message, maxWidthLine), Application.Driver.Cols);
+			int textWidth = TextFormatter.MaxWidth (message, maxWidthLine);
 			int textHeight = TextFormatter.MaxLines (message, textWidth); // message.Count (ustring.Make ('\n')) + 1;
-			int msgboxHeight = Math.Min (Math.Max (1, textHeight) + 4, Application.Driver.Rows); // textHeight + (top + top padding + buttons + bottom)
+			int msgboxHeight = Math.Max (1, textHeight) + 4; // textHeight + (top + top padding + buttons + bottom)
 
+			if (wrapMessagge) {
+				textWidth = Math.Min (textWidth, Application.Driver.Cols);
+				msgboxHeight = Math.Min (msgboxHeight, Application.Driver.Rows);
+			}
 			// Create button array for Dialog
 			int count = 0;
 			List<Button> buttonList = new List<Button> ();
@@ -288,7 +292,7 @@ namespace Terminal.Gui {
 				d.ColorScheme = Colors.Error;
 			}
 
-			if (message != null) {
+			if (!ustring.IsNullOrEmpty (message)) {
 				var l = new Label (message) {
 					LayoutStyle = LayoutStyle.Computed,
 					TextAlignment = TextAlignment.Centered,
@@ -303,7 +307,12 @@ namespace Terminal.Gui {
 
 			if (width == 0 & height == 0) {
 				// Dynamically size Width
-				d.Width = Math.Min (Math.Max (maxWidthLine, Math.Max (title.ConsoleWidth, Math.Max (textWidth + 2, d.GetButtonsWidth () + d.buttons.Count + 2))), Application.Driver.Cols); // textWidth + (left + padding + padding + right)
+				var dWidth = Math.Max (maxWidthLine, Math.Max (title.ConsoleWidth, Math.Max (textWidth + 2, d.GetButtonsWidth () + d.buttons.Count + 2))); // textWidth + (left + padding + padding + right)
+				if (wrapMessagge) {
+					d.Width = Math.Min (dWidth, Application.Driver.Cols);
+				} else {
+					d.Width = dWidth;
+				}
 			}
 
 			// Setup actions

--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -290,8 +290,8 @@ namespace Terminal.Gui {
 
 			if (useErrorColors) {
 				d.ColorScheme = Colors.Error;
-				border.BorderBrush = Colors.Error.Normal.Foreground;
-				border.Background = Colors.Error.Normal.Background;
+				d.Border.BorderBrush = Colors.Error.Normal.Foreground;
+				d.Border.Background = Colors.Error.Normal.Background;
 			} else {
 				d.ColorScheme = Colors.Dialog;
 				d.Border.BorderBrush = Colors.Dialog.Normal.Foreground;

--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -290,6 +290,12 @@ namespace Terminal.Gui {
 
 			if (useErrorColors) {
 				d.ColorScheme = Colors.Error;
+				border.BorderBrush = Colors.Error.Normal.Foreground;
+				border.Background = Colors.Error.Normal.Background;
+			} else {
+				d.ColorScheme = Colors.Dialog;
+				d.Border.BorderBrush = Colors.Dialog.Normal.Foreground;
+				d.Border.Background = Colors.Dialog.Normal.Background;
 			}
 
 			if (!ustring.IsNullOrEmpty (message)) {

--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -281,15 +281,11 @@ namespace Terminal.Gui {
 			// Create Dialog (retain backwards compat by supporting specifying height/width)
 			Dialog d;
 			if (width == 0 & height == 0) {
-				d = new Dialog (title, buttonList.ToArray ()) {
+				d = new Dialog (title, border, buttonList.ToArray ()) {
 					Height = msgboxHeight
 				};
 			} else {
-				d = new Dialog (title, width, Math.Max (height, 4), buttonList.ToArray ());
-			}
-
-			if (border != null) {
-				d.Border = border;
+				d = new Dialog (title, width, Math.Max (height, 4), border, buttonList.ToArray ());
 			}
 
 			if (useErrorColors) {

--- a/UICatalog/Scenarios/MessageBoxes.cs
+++ b/UICatalog/Scenarios/MessageBoxes.cs
@@ -143,18 +143,6 @@ namespace UICatalog.Scenarios {
 				X = Pos.Right (label) + 1,
 				Y = Pos.Top (label),
 			};
-			styleRadioGroup.SelectedItemChanged += e => {
-				switch (e.SelectedItem) {
-				case 0:
-					border.BorderBrush = Colors.Dialog.Normal.Foreground;
-					border.Background = Colors.Dialog.Normal.Background;
-					break;
-				case 1:
-					border.BorderBrush = Colors.Error.Normal.Foreground;
-					border.Background = Colors.Error.Normal.Background;
-					break;
-				}
-			};
 			frame.Add (styleRadioGroup);
 
 			var ckbEffect3D = new CheckBox ("Effect3D", true) {

--- a/UICatalog/Scenarios/MessageBoxes.cs
+++ b/UICatalog/Scenarios/MessageBoxes.cs
@@ -151,11 +151,16 @@ namespace UICatalog.Scenarios {
 				border.Effect3D = (bool)!e;
 			};
 			frame.Add (ckbEffect3D);
+			var ckbWrapMessage = new CheckBox ("Wrap Message", true) {
+				X = Pos.Right (label) + 1,
+				Y = Pos.Top (label) + 3
+			};
+			frame.Add (ckbWrapMessage);
 
 			void Top_Loaded ()
 			{
 				frame.Height = Dim.Height (widthEdit) + Dim.Height (heightEdit) + Dim.Height (titleEdit) + Dim.Height (messageEdit)
-				+ Dim.Height (numButtonsEdit) + Dim.Height (defaultButtonEdit) + Dim.Height (styleRadioGroup) + 2 + Dim.Height (ckbEffect3D);
+				+ Dim.Height (numButtonsEdit) + Dim.Height (defaultButtonEdit) + Dim.Height (styleRadioGroup) + 2 + Dim.Height (ckbEffect3D) + Dim.Height (ckbWrapMessage);
 				Application.Top.Loaded -= Top_Loaded;
 			}
 			Application.Top.Loaded += Top_Loaded;
@@ -196,9 +201,9 @@ namespace UICatalog.Scenarios {
 						btns.Add (NumberToWords.Convert (i));
 					}
 					if (styleRadioGroup.SelectedItem == 0) {
-						buttonPressedLabel.Text = $"{MessageBox.Query (width, height, titleEdit.Text.ToString (), messageEdit.Text.ToString (), defaultButton, border, btns.ToArray ())}";
+						buttonPressedLabel.Text = $"{MessageBox.Query (width, height, titleEdit.Text.ToString (), messageEdit.Text.ToString (), defaultButton, border, (bool)ckbWrapMessage.Checked, btns.ToArray ())}";
 					} else {
-						buttonPressedLabel.Text = $"{MessageBox.ErrorQuery (width, height, titleEdit.Text.ToString (), messageEdit.Text.ToString (), defaultButton, border, btns.ToArray ())}";
+						buttonPressedLabel.Text = $"{MessageBox.ErrorQuery (width, height, titleEdit.Text.ToString (), messageEdit.Text.ToString (), defaultButton, border, (bool)ckbWrapMessage.Checked, btns.ToArray ())}";
 					}
 				} catch (FormatException) {
 					buttonPressedLabel.Text = "Invalid Options";

--- a/UICatalog/Scenarios/MessageBoxes.cs
+++ b/UICatalog/Scenarios/MessageBoxes.cs
@@ -125,6 +125,11 @@ namespace UICatalog.Scenarios {
 			};
 			frame.Add (defaultButtonEdit);
 
+			var border = new Border () {
+				Effect3D = true,
+				BorderStyle = BorderStyle.Single
+			};
+
 			label = new Label ("Style:") {
 				X = 0,
 				Y = Pos.Bottom (label),
@@ -133,16 +138,25 @@ namespace UICatalog.Scenarios {
 				TextAlignment = Terminal.Gui.TextAlignment.Right,
 			};
 			frame.Add (label);
+
 			var styleRadioGroup = new RadioGroup (new ustring [] { "_Query", "_Error" }) {
 				X = Pos.Right (label) + 1,
 				Y = Pos.Top (label),
 			};
+			styleRadioGroup.SelectedItemChanged += e => {
+				switch (e.SelectedItem) {
+				case 0:
+					border.BorderBrush = Colors.Dialog.Normal.Foreground;
+					border.Background = Colors.Dialog.Normal.Background;
+					break;
+				case 1:
+					border.BorderBrush = Colors.Error.Normal.Foreground;
+					border.Background = Colors.Error.Normal.Background;
+					break;
+				}
+			};
 			frame.Add (styleRadioGroup);
 
-			var border = new Border () {
-				Effect3D = true,
-				BorderStyle = BorderStyle.Single
-			};
 			var ckbEffect3D = new CheckBox ("Effect3D", true) {
 				X = Pos.Right (label) + 1,
 				Y = Pos.Top (label) + 2

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -52,7 +52,7 @@ namespace UICatalog {
 		//[SerializableConfigurationProperty (Scope = typeof (AppScope), OmitClassName = true), JsonPropertyName ("UICatalog.StatusBar")]
 		//public static bool ShowStatusBar { get; set; } = true;
 
-		[SerializableConfigurationProperty (Scope = typeof (AppScope), OmitClassName = true), JsonPropertyName("UICatalog.StatusBar")]
+		[SerializableConfigurationProperty (Scope = typeof (AppScope), OmitClassName = true), JsonPropertyName ("UICatalog.StatusBar")]
 		public static bool ShowStatusBar { get; set; } = true;
 
 		static readonly FileSystemWatcher _currentDirWatcher = new FileSystemWatcher ();
@@ -127,7 +127,8 @@ namespace UICatalog {
 			VerifyObjectsWereDisposed ();
 		}
 
-		private static void StopConfigFileWatcher() {
+		private static void StopConfigFileWatcher ()
+		{
 			_currentDirWatcher.EnableRaisingEvents = false;
 			_currentDirWatcher.Changed -= ConfigFileChanged;
 			_currentDirWatcher.Created -= ConfigFileChanged;
@@ -137,7 +138,7 @@ namespace UICatalog {
 			_homeDirWatcher.Created -= ConfigFileChanged;
 		}
 
-		private static void StartConfigFileWatcher()
+		private static void StartConfigFileWatcher ()
 		{
 			// Setup a file system watcher for `./.tui/`
 			_currentDirWatcher.NotifyFilter = NotifyFilters.LastWrite;
@@ -258,7 +259,7 @@ namespace UICatalog {
 						new MenuItem ("_gui.cs API Overview", "", () => OpenUrl ("https://gui-cs.github.io/Terminal.Gui/articles/overview.html"), null, null, Key.F1),
 						new MenuItem ("gui.cs _README", "", () => OpenUrl ("https://github.com/gui-cs/Terminal.Gui"), null, null, Key.F2),
 						new MenuItem ("_About...",
-							"About UI Catalog", () =>  MessageBox.Query ("About UI Catalog", _aboutMessage.ToString(), "_Ok"), null, null, Key.CtrlMask | Key.A),
+							"About UI Catalog", () =>  MessageBox.Query ("About UI Catalog", _aboutMessage.ToString(), 0, null, false, "_Ok"), null, null, Key.CtrlMask | Key.A),
 					}),
 				});
 
@@ -269,7 +270,7 @@ namespace UICatalog {
 				OS = new StatusItem (Key.CharMask, "OS:", null);
 
 				StatusBar = new StatusBar () {
-					Visible = UICatalogApp.ShowStatusBar					
+					Visible = UICatalogApp.ShowStatusBar
 				};
 
 				StatusBar.Items = new StatusItem [] {
@@ -303,7 +304,7 @@ namespace UICatalog {
 				ContentPane.Border.BorderStyle = BorderStyle.Single;
 				ContentPane.SetSplitterPos (0, 25);
 				ContentPane.ShortcutAction = () => ContentPane.SetFocus ();
-					
+
 				CategoryListView = new ListView (_categories) {
 					X = 0,
 					Y = 0,
@@ -351,7 +352,7 @@ namespace UICatalog {
 
 				ConfigurationManager.Applied += ConfigAppliedHandler;
 			}
- 
+
 			void LoadedHandler ()
 			{
 				ConfigChanged ();
@@ -386,7 +387,7 @@ namespace UICatalog {
 				ConfigurationManager.Applied -= ConfigAppliedHandler;
 				Unloaded -= UnloadedHandler;
 			}
-			
+
 			void ConfigAppliedHandler (ConfigurationManagerEventArgs a)
 			{
 				ConfigChanged ();
@@ -614,7 +615,7 @@ namespace UICatalog {
 				if (_topLevelColorScheme == null || !Colors.ColorSchemes.ContainsKey (_topLevelColorScheme)) {
 					_topLevelColorScheme = "Base";
 				}
-				
+
 				_themeMenuItems = ((UICatalogTopLevel)Application.Top).CreateThemeMenuItems ();
 				_themeMenuBarItem.Children = _themeMenuItems;
 
@@ -700,7 +701,7 @@ namespace UICatalog {
 			// after a scenario was selected to run. This proves the main UI Catalog
 			// 'app' closed cleanly.
 			foreach (var inst in Responder.Instances) {
-				
+
 				Debug.Assert (inst.WasDisposed);
 			}
 			Responder.Instances.Clear ();

--- a/UnitTests/TopLevels/MessageBoxTests.cs
+++ b/UnitTests/TopLevels/MessageBoxTests.cs
@@ -319,5 +319,38 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 			Application.Run ();
 		}
+
+		[Theory, AutoInitShutdown]
+		[InlineData ("", true)]
+		[InlineData ("", false)]
+		[InlineData ("\n", true)]
+		[InlineData ("\n", false)]
+		public void MessageBox_With_A_Empty_Message_Or_A_NewLline_WrapMessagge_True_Or_False (string message, bool wrapMessage)
+		{
+			var iterations = -1;
+			Application.Begin (Application.Top);
+
+			Application.Iteration += () => {
+				iterations++;
+
+				if (iterations == 0) {
+					MessageBox.Query ("mywindow", message, 0, null, wrapMessage, "ok");
+
+					Application.RequestStop ();
+				} else if (iterations == 1) {
+					Application.Refresh ();
+					TestHelpers.AssertDriverContentsWithFrameAre (@"
+                ┌ mywindow ────────────────────────────────────┐
+                │                                              │
+                │                                              │
+                │                   [◦ ok ◦]                   │
+                └──────────────────────────────────────────────┘", output);
+
+					Application.RequestStop ();
+				}
+			};
+
+			Application.Run ();
+		}
 	}
 }

--- a/UnitTests/TopLevels/MessageBoxTests.cs
+++ b/UnitTests/TopLevels/MessageBoxTests.cs
@@ -157,7 +157,7 @@ namespace Terminal.Gui.TopLevelTests {
 		}
 
 		[Fact, AutoInitShutdown]
-		public void MessageBox_With_A_Label_Without_Spaces ()
+		public void MessageBox_With_A_Label_Without_Spaces_WrapMessagge_True ()
 		{
 			var iterations = -1;
 			Application.Begin (Application.Top);
@@ -196,8 +196,7 @@ namespace Terminal.Gui.TopLevelTests {
 │ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
 │ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff│
 │                                   [◦ ok ◦]                                   │
-└──────────────────────────────────────────────────────────────────────────────┘
-", output);
+└──────────────────────────────────────────────────────────────────────────────┘", output);
 
 					Application.RequestStop ();
 				}
@@ -207,7 +206,7 @@ namespace Terminal.Gui.TopLevelTests {
 		}
 
 		[Fact, AutoInitShutdown]
-		public void MessageBox_With_A_Label_With_Spaces ()
+		public void MessageBox_With_A_Label_With_Spaces_WrapMessagge_True ()
 		{
 			var iterations = -1;
 			Application.Begin (Application.Top);
@@ -250,8 +249,69 @@ namespace Terminal.Gui.TopLevelTests {
 │ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
 │ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff │
 │                                   [◦ ok ◦]                                   │
-└──────────────────────────────────────────────────────────────────────────────┘
-", output);
+└──────────────────────────────────────────────────────────────────────────────┘", output);
+
+					Application.RequestStop ();
+				}
+			};
+
+			Application.Run ();
+		}
+
+		[Fact, AutoInitShutdown]
+		public void MessageBox_With_A_Label_Without_Spaces_WrapMessagge_False ()
+		{
+			var iterations = -1;
+			Application.Begin (Application.Top);
+
+			Application.Iteration += () => {
+				iterations++;
+
+				if (iterations == 0) {
+					MessageBox.Query ("mywindow", new string ('f', 2000), 0, null, false, "ok");
+
+					Application.RequestStop ();
+				} else if (iterations == 1) {
+					Application.Refresh ();
+					TestHelpers.AssertDriverContentsWithFrameAre (@"
+────────────────────────────────────────────────────────────────────────────────
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                                                                                
+                                    [◦ ok ◦]                                    
+────────────────────────────────────────────────────────────────────────────────", output);
+
+					Application.RequestStop ();
+				}
+			};
+
+			Application.Run ();
+		}
+
+		[Fact, AutoInitShutdown]
+		public void MessageBox_With_A_Label_With_Spaces_WrapMessagge_False ()
+		{
+			var iterations = -1;
+			Application.Begin (Application.Top);
+
+			Application.Iteration += () => {
+				iterations++;
+
+				if (iterations == 0) {
+					var sb = new StringBuilder ();
+					for (int i = 0; i < 1000; i++)
+						sb.Append ("ff ");
+
+					MessageBox.Query ("mywindow", sb.ToString (), 0, null, false, "ok");
+
+					Application.RequestStop ();
+				} else if (iterations == 1) {
+					Application.Refresh ();
+					TestHelpers.AssertDriverContentsWithFrameAre (@"
+────────────────────────────────────────────────────────────────────────────────
+ ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff f
+                                                                                
+                                    [◦ ok ◦]                                    
+────────────────────────────────────────────────────────────────────────────────", output);
 
 					Application.RequestStop ();
 				}


### PR DESCRIPTION
Fixes #2403- Added an option to wrap or not the message text, allowing complex text been understandable when the console is expanded. I also changed the `MessageBoxes` scenario to demonstrate this behavior and unit tests. I had to hack the scenario to accept the right dialog style colors for query or error. I think this is due the static settings which override the view defaults.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
