### PR TITLE
Fix typo in link in a readme

### DIFF
--- a/UICatalog/README.md
+++ b/UICatalog/README.md
@@ -12,7 +12,7 @@ said concepts & features.
 ## Motivation
 
 The original `demo.cs` sample app for Terminal.Gui is neither good to showcase, nor does it explain different concepts. In addition, because it is built on a single source file, it has proven to cause friction when multiple contributors are simultaneously working on different aspects of Terminal.Gui. 
-See [Issue #368](https://github.com/giu-cs/Terminal.Gui/issues/368) for more background.
+See [Issue #368](https://github.com/gui-cs/Terminal.Gui/issues/368) for more background.
 
 # API Reference
 


### PR DESCRIPTION
The link: (https://github.com/gui-cs/Terminal.Gui/issues/368) was typed out like (https://github.com/giu-cs/Terminal.Gui/issues/368).

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
