### PR TITLE
Fixes #2416. Single smaller top level leaves chunk trails on move.

### DIFF
--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -1134,6 +1134,7 @@ namespace Terminal.Gui {
 			_initialized = false;
 			mouseGrabView = null;
 			_enableConsoleScrolling = false;
+			lastMouseOwnerView = null;
 
 			// Reset synchronization context to allow the user to run async/await,
 			// as the main loop has been ended, the synchronization context from 

--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -1241,6 +1241,14 @@ namespace Terminal.Gui {
 				}
 				state.Toplevel.SetNeedsDisplay (state.Toplevel.Bounds);
 			}
+			if (toplevels.Count == 1 && state.Toplevel == Top
+				&& (Driver.Cols != state.Toplevel.Frame.Width || Driver.Rows != state.Toplevel.Frame.Height)
+				&& (!state.Toplevel.NeedDisplay.IsEmpty || state.Toplevel.ChildNeedsDisplay || state.Toplevel.LayoutNeeded)) {
+
+				Driver.SetAttribute (Colors.TopLevel.Normal);
+				state.Toplevel.Clear (new Rect (0, 0, Driver.Cols, Driver.Rows));
+
+			}
 			if (!state.Toplevel.NeedDisplay.IsEmpty || state.Toplevel.ChildNeedsDisplay || state.Toplevel.LayoutNeeded
 				|| MdiChildNeedsDisplay ()) {
 				state.Toplevel.Redraw (state.Toplevel.Bounds);

--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -984,6 +984,13 @@ namespace Terminal.Gui {
 		{
 			return MostFocused?.OnLeave (view) ?? base.OnLeave (view);
 		}
+
+		///<inheritdoc/>
+		protected override void Dispose (bool disposing)
+		{
+			dragPosition = null;
+			base.Dispose (disposing);
+		}
 	}
 
 	/// <summary>

--- a/UnitTests/TopLevels/ToplevelTests.cs
+++ b/UnitTests/TopLevels/ToplevelTests.cs
@@ -1081,5 +1081,88 @@ namespace Terminal.Gui.TopLevelTests {
 			Assert.Equal (new Rect (1, 3, 10, 5), view.Frame);
 			Assert.Equal (new Rect (0, 0, 10, 5), view.NeedDisplay);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void Single_Smaller_Top_Will_Have_Cleaning_Trails_Chunk_On_Move ()
+		{
+			var dialog = new Dialog ("Single smaller Dialog") { Width = 30, Height = 10 };
+			dialog.Add (new Label (
+				"How should I've to react. Cleaning all chunk trails or setting the 'Cols' and 'Rows' to this dialog length?\n" +
+				"Cleaning is more easy to fix this.") {
+				X = Pos.Center (),
+				Y = Pos.Center (),
+				Width = Dim.Fill (),
+				Height = Dim.Fill (),
+				TextAlignment = TextAlignment.Centered,
+				VerticalTextAlignment = VerticalTextAlignment.Middle,
+				AutoSize = false
+			});
+
+			var rs = Application.Begin (dialog);
+
+			Assert.Null (Application.MouseGrabView);
+			Assert.Equal (new Rect (25, 7, 30, 10), dialog.Frame);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+                         ┌ Single smaller Dialog ─────┐
+                         │ How should I've to react.  │
+                         │Cleaning all chunk trails or│
+                         │   setting the 'Cols' and   │
+                         │   'Rows' to this dialog    │
+                         │          length?           │
+                         │Cleaning is more easy to fix│
+                         │           this.            │
+                         │                            │
+                         └────────────────────────────┘", output);
+
+			ReflectionTools.InvokePrivate (
+				typeof (Application),
+				"ProcessMouseEvent",
+				new MouseEvent () {
+					X = 25,
+					Y = 7,
+					Flags = MouseFlags.Button1Pressed
+				});
+
+			var firstIteration = false;
+			Application.RunMainLoopIteration (ref rs, true, ref firstIteration); Assert.Equal (dialog, Application.MouseGrabView);
+
+			Assert.Equal (new Rect (25, 7, 30, 10), dialog.Frame);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+                         ┌ Single smaller Dialog ─────┐
+                         │ How should I've to react.  │
+                         │Cleaning all chunk trails or│
+                         │   setting the 'Cols' and   │
+                         │   'Rows' to this dialog    │
+                         │          length?           │
+                         │Cleaning is more easy to fix│
+                         │           this.            │
+                         │                            │
+                         └────────────────────────────┘", output);
+
+			ReflectionTools.InvokePrivate (
+				typeof (Application),
+				"ProcessMouseEvent",
+				new MouseEvent () {
+					X = 20,
+					Y = 10,
+					Flags = MouseFlags.Button1Pressed | MouseFlags.ReportMousePosition
+				});
+
+			firstIteration = false;
+			Application.RunMainLoopIteration (ref rs, true, ref firstIteration);
+			Assert.Equal (dialog, Application.MouseGrabView);
+			Assert.Equal (new Rect (20, 10, 30, 10), dialog.Frame);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+                    ┌ Single smaller Dialog ─────┐
+                    │ How should I've to react.  │
+                    │Cleaning all chunk trails or│
+                    │   setting the 'Cols' and   │
+                    │   'Rows' to this dialog    │
+                    │          length?           │
+                    │Cleaning is more easy to fix│
+                    │           this.            │
+                    │                            │
+                    └────────────────────────────┘", output);
+		}
 	}
 }

--- a/UnitTests/TopLevels/ToplevelTests.cs
+++ b/UnitTests/TopLevels/ToplevelTests.cs
@@ -1163,6 +1163,8 @@ namespace Terminal.Gui.TopLevelTests {
                     │           this.            │
                     │                            │
                     └────────────────────────────┘", output);
+
+			Application.End (rs);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2416 - Since the `Application` only have one top and is smaller than the console size it must to deal with the cleanup itself.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

![toplevel-chunk-trails-fix](https://user-images.githubusercontent.com/13117724/225420029-0d400641-1555-4b2e-a9aa-aa116e520f72.gif)
