### PR TITLE
Fixes #2418. SetToplevelsSize is wrongly forcing toplevels resizing to console size.

### DIFF
--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -1523,7 +1523,6 @@ namespace Terminal.Gui {
 		static void TerminalResized ()
 		{
 			var full = new Rect (0, 0, Driver.Cols, Driver.Rows);
-			SetToplevelsSize (full);
 			Resized?.Invoke (new ResizedEventArgs () { Cols = full.Width, Rows = full.Height });
 			Driver.Clip = full;
 			foreach (var t in toplevels) {
@@ -1533,23 +1532,6 @@ namespace Terminal.Gui {
 				t.OnResized (full.Size);
 			}
 			Refresh ();
-		}
-
-		static void SetToplevelsSize (Rect full)
-		{
-			if (MdiTop == null) {
-				foreach (var t in toplevels) {
-					if (t?.SuperView == null && !t.Modal) {
-						t.Frame = full;
-						t.Width = full.Width;
-						t.Height = full.Height;
-					}
-				}
-			} else {
-				Top.Frame = full;
-				Top.Width = full.Width;
-				Top.Height = full.Height;
-			}
 		}
 
 		static bool SetCurrentAsTop ()


### PR DESCRIPTION
Fixes #2418 - This method was created before to avoid the issue #2416 and since it is already fix on the #2417, it's not needed any more.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

![imagem](https://user-images.githubusercontent.com/13117724/225457133-6d013744-00a6-4b1f-8bc4-522c41c6538c.png)
