### PR TITLE
AOT - Fix UICatalog to support building as PublishSingleFile

### DIFF
--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -141,7 +141,7 @@ namespace UICatalog {
 		{
 			// Setup a file system watcher for `./.tui/`
 			_currentDirWatcher.NotifyFilter = NotifyFilters.LastWrite;
-			var f = new FileInfo (Assembly.GetExecutingAssembly ().Location);
+			var f = new FileInfo (System.AppContext.BaseDirectory);
 			var tuiDir = Path.Combine (f.Directory.FullName, ".tui");
 
 			if (!Directory.Exists (tuiDir)) {


### PR DESCRIPTION
## Fixes 

- #2414 - API changes to support running UICatalog under various publish options.

Starting with `PublishSingleFile`.  May also look into, trimmed and/or AOT etc

These changes must be backwards compatible.

```csproj
<PropertyGroup>
	<PublishSingleFile>true</PublishSingleFile>
	<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
</PropertyGroup>
```

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
