### PR TITLE
Fix typo in link in a readme (#2409)

### DIFF
--- a/UICatalog/README.md
+++ b/UICatalog/README.md
@@ -12,7 +12,7 @@ said concepts & features.
 ## Motivation
 
 The original `demo.cs` sample app for Terminal.Gui is neither good to showcase, nor does it explain different concepts. In addition, because it is built on a single source file, it has proven to cause friction when multiple contributors are simultaneously working on different aspects of Terminal.Gui. 
-See [Issue #368](https://github.com/giu-cs/Terminal.Gui/issues/368) for more background.
+See [Issue #368](https://github.com/gui-cs/Terminal.Gui/issues/368) for more background.
 
 # API Reference
 


### PR DESCRIPTION
The link: (https://github.com/gui-cs/Terminal.Gui/issues/368) was typed out like (https://github.com/giu-cs/Terminal.Gui/issues/368).

Fixes #_____ - Include a terse summary of the change or which issue is fixed.

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
