### PR TITLE
Fixes#2404. Tabbing to MenuBar and open/close.

### DIFF
--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -1047,6 +1047,7 @@ namespace Terminal.Gui {
 		private void MenuBar_Added (View obj)
 		{
 			_initialCanFocus = CanFocus;
+			Added -= MenuBar_Added;
 		}
 
 		bool openedByAltKey;

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -808,7 +808,7 @@ namespace Terminal.Gui {
 				}
 			}
 
-			host?.openMenu.SetNeedsDisplay ();
+			host?.openMenu?.SetNeedsDisplay ();
 			host.SetNeedsDisplay ();
 		}
 
@@ -1025,6 +1025,8 @@ namespace Terminal.Gui {
 			WantMousePositionReports = true;
 			IsMenuOpen = false;
 
+			Added += MenuBar_Added;
+
 			// Things this view knows how to do
 			AddCommand (Command.Left, () => { MoveLeft (); return true; });
 			AddCommand (Command.Right, () => { MoveRight (); return true; });
@@ -1040,6 +1042,13 @@ namespace Terminal.Gui {
 			AddKeyBinding (Key.Enter, Command.Accept);
 		}
 
+		bool _initialCanFocus;
+
+		private void MenuBar_Added (View obj)
+		{
+			_initialCanFocus = CanFocus;
+		}
+
 		bool openedByAltKey;
 
 		bool isCleaning;
@@ -1049,9 +1058,8 @@ namespace Terminal.Gui {
 		{
 			if ((!(view is MenuBar) && !(view is Menu) || !(view is MenuBar) && !(view is Menu) && openMenu != null) && !isCleaning && !reopen) {
 				CleanUp ();
-				return true;
 			}
-			return false;
+			return base.OnLeave (view);
 		}
 
 		///<inheritdoc/>
@@ -1112,7 +1120,7 @@ namespace Terminal.Gui {
 			openedByAltKey = false;
 			IsMenuOpen = false;
 			selected = -1;
-			CanFocus = false;
+			CanFocus = _initialCanFocus;
 			if (lastFocused != null) {
 				lastFocused.SetFocus ();
 			}
@@ -1509,6 +1517,8 @@ namespace Terminal.Gui {
 						selected = -1;
 					}
 					LastFocused.SetFocus ();
+				} else if (openSubMenu == null || openSubMenu.Count == 0) {
+					CloseAllMenus ();
 				} else {
 					SetFocus ();
 					PositionCursor ();


### PR DESCRIPTION
Fixes #2404 - The Leave event is always invoked no matter the menu was closed or not. The menu is always closed on losing focus.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

Here the code I use to make it work:
```cs
	Application.Init ();

	var win = new Window ("Example App (Ctrl+Q to quit)");

	var mb = new MenuBar (
		new []{new MenuBarItem( new []{
			new MenuItem("Item1",null,()=>{}),
			new MenuItem("Item2",null,()=>{}),
		})}) {
			CanFocus = true,
			TabStop = true,
			X = 10,
			Y = 2,
			Width = 10,
			Text = "Open Me",
	};

	mb.Enter += (e) => {
		if (!mb.IsMenuOpen) {
			mb.OpenMenu ();
		}
	};

	win.Add (new TextField ("SomeText") { Y = 2, Width = 9 });
	win.Add (mb);
	Application.Run (win);
	Application.Shutdown ();

```