### PR TITLE
Fixes #2433 - Change how LineCanvas interprets zero length

### DIFF
--- a/Terminal.Gui/Core/Graphs/LineCanvas.cs
+++ b/Terminal.Gui/Core/Graphs/LineCanvas.cs
@@ -487,14 +487,6 @@ namespace Terminal.Gui.Graphs {
 
 			internal IntersectionDefinition Intersects (int x, int y)
 			{
-				if (IsDot ()) {
-					if (StartsAt (x, y)) {
-						return new IntersectionDefinition (Start, IntersectionType.Dot, this);
-					} else {
-						return null;
-					}
-				}
-
 				switch (Orientation) {
 				case Orientation.Horizontal: return IntersectsHorizontally (x, y);
 				case Orientation.Vertical: return IntersectsVertically (x, y);
@@ -552,7 +544,7 @@ namespace Terminal.Gui.Graphs {
 
 						return new IntersectionDefinition (
 							Start,
-							Length < 0 ? IntersectionType.StartUp : IntersectionType.StartDown,
+							GetTypeByLength(IntersectionType.StartUp, IntersectionType.PassOverVertical, IntersectionType.StartDown),
 							this
 							);
 
@@ -581,6 +573,15 @@ namespace Terminal.Gui.Graphs {
 
 					return null;
 				}
+			}
+
+			private IntersectionType GetTypeByLength (IntersectionType typeWhenNegative, IntersectionType typeWhenZero, IntersectionType typeWhenPositive)
+			{
+				if (Length == 0) {
+					return typeWhenZero;
+				} 
+
+				return Length < 0 ? typeWhenNegative : typeWhenPositive;
 			}
 
 			private bool EndsAt (int x, int y)

--- a/Terminal.Gui/Core/Graphs/LineCanvas.cs
+++ b/Terminal.Gui/Core/Graphs/LineCanvas.cs
@@ -199,8 +199,8 @@ namespace Terminal.Gui.Graphs {
 			}
 
 			// TODO: Remove these two once we have all of the below ported to IntersectionRuneResolvers
-			var useDouble = intersects.Any (i => i.Line.Style == BorderStyle.Double && i.Line.Length != 0);
-			var useRounded = intersects.Any (i => i.Line.Style == BorderStyle.Rounded && i.Line.Length != 0);
+			var useDouble = intersects.Any (i => i.Line.Style == BorderStyle.Double);
+			var useRounded = intersects.Any (i => i.Line.Style == BorderStyle.Rounded);
 
 			// TODO: maybe make these resolvers to for simplicity?
 			// or for dotted lines later on or that kind of thing?
@@ -220,13 +220,6 @@ namespace Terminal.Gui.Graphs {
 
 		private IntersectionRuneType GetRuneTypeForIntersects (IntersectionDefinition [] intersects)
 		{
-			if (intersects.All (i => i.Line.Length == 0)) {
-				return IntersectionRuneType.Dot;
-			}
-
-			// ignore dots
-			intersects = intersects.Where (i => i.Type != IntersectionType.Dot).ToArray ();
-
 			var set = new HashSet<IntersectionType> (intersects.Select (i => i.Type));
 
 			#region Crosshair Conditions
@@ -504,7 +497,7 @@ namespace Terminal.Gui.Graphs {
 
 						return new IntersectionDefinition (
 							Start,
-							Length < 0 ? IntersectionType.StartLeft : IntersectionType.StartRight,
+							GetTypeByLength(IntersectionType.StartLeft, IntersectionType.PassOverHorizontal,IntersectionType.StartRight),
 							this
 							);
 
@@ -596,11 +589,6 @@ namespace Terminal.Gui.Graphs {
 			private bool StartsAt (int x, int y)
 			{
 				return Start.X == x && Start.Y == y;
-			}
-
-			private bool IsDot ()
-			{
-				return Length == 0;
 			}
 		}
 	}

--- a/UnitTests/Core/LineCanvasTests.cs
+++ b/UnitTests/Core/LineCanvasTests.cs
@@ -15,20 +15,6 @@ namespace Terminal.Gui.CoreTests {
 			this.output = output;
 		}
 
-		[Fact, AutoInitShutdown]
-		public void TestLineCanvas_Dot ()
-		{
-			var v = GetCanvas (out var canvas);
-			canvas.AddLine (new Point (0, 0), 0, Orientation.Horizontal, BorderStyle.Single);
-
-			v.Redraw (v.Bounds);
-
-			string looksLike =
-@"    
-.";
-			TestHelpers.AssertDriverContentsAre (looksLike, output);
-		}
-
 		[InlineData (BorderStyle.Single)]
 		[InlineData (BorderStyle.Rounded)]
 		[Theory, AutoInitShutdown]
@@ -326,10 +312,10 @@ namespace Terminal.Gui.CoreTests {
 			//LHS line down
 			lc.AddLine (new Point (0, 0), 5, Orientation.Vertical, BorderStyle.Double);
 
-			//Vertical line before Title (must cover 3 squares so it results in a ╡ intersection
-			lc.AddLine (new Point (1, -1), 3, Orientation.Vertical, BorderStyle.Single);
-			//Vertical line after Title (must cover 3 squares so it results in a ╞ intersection
-			lc.AddLine (new Point (6, -1), 3, Orientation.Vertical, BorderStyle.Single);
+			//Vertical line before Title, results in a ╡
+			lc.AddLine (new Point (1, 0), 0, Orientation.Vertical, BorderStyle.Single);
+			//Vertical line after Title, results in a ╞
+			lc.AddLine (new Point (6, 0), 0, Orientation.Vertical, BorderStyle.Single);
 
 			// remainder of title
 			lc.AddLine (new Point (6, 0), 3, Orientation.Horizontal, BorderStyle.Double);
@@ -345,28 +331,85 @@ namespace Terminal.Gui.CoreTests {
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
 
-
-		[Fact, AutoInitShutdown]
-		public void TestLineCanvas_CreateT_With_1Length_Plus_0Length ()
+		[InlineData(0,0,0, Orientation.Horizontal,BorderStyle.Double,"═")]
+		[InlineData(0,0,0, Orientation.Vertical,BorderStyle.Double,"║")]
+		[InlineData(0,0,0, Orientation.Horizontal,BorderStyle.Single,"─")]
+		[InlineData(0,0,0, Orientation.Vertical,BorderStyle.Single,"│")]
+		[AutoInitShutdown, Theory]
+		public void TestLineCanvas_1LineTests(
+			int x1, int y1,int l1, Orientation o1, BorderStyle s1,
+			string expected
+		)
 		{
-			// Draw at 1,1 within client area of View (i.e. leave a top and left margin of 1)
 			var v = GetCanvas (out var lc);
 			v.Width = 10;
-			v.Height = 1;
-			v.Bounds = new Rect (0, 0, 10, 1);
+			v.Height = 10;
+			v.Bounds = new Rect (0, 0, 10, 10);
 
-			// Create ═╡ with:
-			// A 1 width horizontal
-			lc.AddLine (new Point (0, 0), 1, Orientation.Horizontal, BorderStyle.Double);
-			// And a 0 length vertical 
-			lc.AddLine (new Point (1, 0), 0, Orientation.Vertical, BorderStyle.Single);
+			lc.AddLine (new Point (x1, y1), l1, o1, s1);
 
 			v.Redraw (v.Bounds);
-
-			string looksLike =
-		@"═╡";
-			TestHelpers.AssertDriverContentsAre (looksLike, output);
+		
+			TestHelpers.AssertDriverContentsAre (expected, output);
 		}
+
+
+		[Theory, AutoInitShutdown]
+		[InlineData(
+			0,0,1,Orientation.Horizontal,BorderStyle.Double,
+			1,0,0, Orientation.Vertical,BorderStyle.Single, "═╡"
+		)]
+		[InlineData(
+			0,0,0, Orientation.Vertical,BorderStyle.Single,
+			0,0,1,Orientation.Horizontal,BorderStyle.Double,
+			 "╞═"
+		)]
+		[InlineData(
+			0,0,1, Orientation.Vertical,BorderStyle.Single,
+			0,0,0,Orientation.Horizontal,BorderStyle.Double,
+@"
+╤
+│"
+		)]
+		[InlineData(
+			0,0,1, Orientation.Vertical,BorderStyle.Single,
+			0,1,0,Orientation.Horizontal,BorderStyle.Double,
+			@"
+│
+╧
+"
+		)]
+		[InlineData(
+			0,0,0, Orientation.Vertical,BorderStyle.Single,
+			0,0,0,Orientation.Horizontal,BorderStyle.Single,
+			@"┼
+"
+		)]
+		[InlineData(
+			0,0,0, Orientation.Vertical,BorderStyle.Double,
+			0,0,0,Orientation.Horizontal,BorderStyle.Double,
+			@"╬
+"
+		)]
+		public void TestLineCanvas_2LineTests(
+			int x1, int y1,int l1, Orientation o1, BorderStyle s1,
+			int x2, int y2, int l2, Orientation o2, BorderStyle s2,
+			string expected
+		)
+		{
+			var v = GetCanvas (out var lc);
+			v.Width = 10;
+			v.Height = 10;
+			v.Bounds = new Rect (0, 0, 10, 10);
+
+			lc.AddLine (new Point (x1, y1), l1, o1, s1);
+			lc.AddLine (new Point (x2, y2), l2, o2, s2);
+
+			v.Redraw (v.Bounds);
+		
+			TestHelpers.AssertDriverContentsAre (expected, output);
+		}
+		
 
 		/// <summary>
 		/// Creates a new <see cref="View"/> into which a <see cref="LineCanvas"/> is rendered

--- a/UnitTests/Core/LineCanvasTests.cs
+++ b/UnitTests/Core/LineCanvasTests.cs
@@ -311,7 +311,62 @@ namespace Terminal.Gui.CoreTests {
 ";
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
+		[Fact, AutoInitShutdown]
+		public void TestLineCanvas_ClipArea_Intersections ()
+		{
+			// Draw at 1,1 within client area of View (i.e. leave a top and left margin of 1)
+			var v = GetCanvas (out var lc);
+			v.Width = 10;
+			v.Height = 1;
+			v.Bounds = new Rect (0, 0, 10, 1);
 
+			// ╔╡ Title ╞═════╗
+			// Add a short horiz line for ╔╡
+			lc.AddLine (new Point (0, 0), 1, Orientation.Horizontal, BorderStyle.Double);
+			//LHS line down
+			lc.AddLine (new Point (0, 0), 5, Orientation.Vertical, BorderStyle.Double);
+
+			//Vertical line before Title (must cover 3 squares so it results in a ╡ intersection
+			lc.AddLine (new Point (1, -1), 3, Orientation.Vertical, BorderStyle.Single);
+			//Vertical line after Title (must cover 3 squares so it results in a ╞ intersection
+			lc.AddLine (new Point (6, -1), 3, Orientation.Vertical, BorderStyle.Single);
+
+			// remainder of title
+			lc.AddLine (new Point (6, 0), 3, Orientation.Horizontal, BorderStyle.Double);
+			//RHS line down
+			lc.AddLine (new Point (9, 0), 5, Orientation.Vertical, BorderStyle.Double);
+
+			v.Redraw (v.Bounds);
+
+			string looksLike =
+		@"
+╔╡    ╞══╗
+";
+			TestHelpers.AssertDriverContentsAre (looksLike, output);
+		}
+
+
+		[Fact, AutoInitShutdown]
+		public void TestLineCanvas_CreateT_With_1Length_Plus_0Length ()
+		{
+			// Draw at 1,1 within client area of View (i.e. leave a top and left margin of 1)
+			var v = GetCanvas (out var lc);
+			v.Width = 10;
+			v.Height = 1;
+			v.Bounds = new Rect (0, 0, 10, 1);
+
+			// Create ═╡ with:
+			// A 1 width horizontal
+			lc.AddLine (new Point (0, 0), 1, Orientation.Horizontal, BorderStyle.Double);
+			// And a 0 length vertical 
+			lc.AddLine (new Point (1, 0), 0, Orientation.Vertical, BorderStyle.Single);
+
+			v.Redraw (v.Bounds);
+
+			string looksLike =
+		@"═╡";
+			TestHelpers.AssertDriverContentsAre (looksLike, output);
+		}
 
 		/// <summary>
 		/// Creates a new <see cref="View"/> into which a <see cref="LineCanvas"/> is rendered


### PR DESCRIPTION
Fixes #2433 - Previously a line of length 0 was `.` Now it is instead an HLine or VLine.  Also full intersection is supported for 0 length lines.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
