### PR TITLE
Fixes #2430. Launching a Dialog from a Dialog causes errors in v2_develop.

### DIFF
--- a/Terminal.Gui/Core/Window.cs
+++ b/Terminal.Gui/Core/Window.cs
@@ -240,9 +240,12 @@ namespace Terminal.Gui {
 					contentView.Frame = cFrame;
 				}
 			}
-			if (Subviews?.Count == 0)
+			if (Subviews?.Count == 0) {
 				base.Add (contentView);
-			Border.Child = contentView;
+			}
+			if (Border.Child != contentView) {
+				Border.Child = contentView;
+			}
 		}
 
 		///// <summary>
@@ -273,7 +276,13 @@ namespace Terminal.Gui {
 			}
 
 			SetNeedsDisplay ();
-			contentView.Remove (view);
+			if (view == contentView) {
+				base.Remove (view);
+				contentView.Dispose ();
+				return;
+			} else {
+				contentView.Remove (view);
+			}
 
 			if (contentView.InternalSubviews.Count < 1) {
 				CanFocus = false;

--- a/Terminal.Gui/Windows/Dialog.cs
+++ b/Terminal.Gui/Windows/Dialog.cs
@@ -78,8 +78,10 @@ namespace Terminal.Gui {
 			ColorScheme = Colors.Dialog;
 			Modal = true;
 			ButtonAlignment = DefaultButtonAlignment;
-			Border = DefaultBorder;
-			Border.Title = title;
+			if (Border == null) {
+				Border = DefaultBorder;
+				Border.Title = title;
+			}
 
 			if (buttons != null) {
 				foreach (var b in buttons) {

--- a/Terminal.Gui/Windows/MessageBox.cs
+++ b/Terminal.Gui/Windows/MessageBox.cs
@@ -1,6 +1,8 @@
 ﻿using NStack;
 using System;
 using System.Collections.Generic;
+using Terminal.Gui.Configuration;
+using static Terminal.Gui.Configuration.ConfigurationManager;
 
 namespace Terminal.Gui {
 	/// <summary>
@@ -239,6 +241,17 @@ namespace Terminal.Gui {
 			return QueryFull (true, 0, 0, title, message, defaultButton, border, wrapMessagge, buttons);
 		}
 
+		/// <summary>
+		/// Defines the default border styling for <see cref="Dialog"/>. Can be configured via <see cref="ConfigurationManager"/>.
+		/// </summary>
+		[SerializableConfigurationProperty (Scope = typeof (ThemeScope))]
+		public static Border DefaultBorder { get; set; } = new Border () {
+			BorderStyle = BorderStyle.Single,
+			DrawMarginFrame = false,
+			Effect3D = true,
+			Effect3DOffset = new Point (1, 1),
+		};
+
 		static int QueryFull (bool useErrorColors, int width, int height, ustring title, ustring message,
 			int defaultButton = 0, Border border = null, bool wrapMessagge = true, params ustring [] buttons)
 		{
@@ -277,7 +290,10 @@ namespace Terminal.Gui {
 				buttonList.Add (b);
 				count++;
 			}
-
+			if (border == null) {
+				border = DefaultBorder;
+				border.Title = title;
+			}
 			// Create Dialog (retain backwards compat by supporting specifying height/width)
 			Dialog d;
 			if (width == 0 & height == 0) {
@@ -326,7 +342,7 @@ namespace Terminal.Gui {
 			for (int n = 0; n < buttonList.Count; n++) {
 				int buttonId = n;
 				var b = buttonList [n];
-				b.Clicked += (s,e) => {
+				b.Clicked += (s, e) => {
 					Clicked = buttonId;
 					Application.RequestStop ();
 				};


### PR DESCRIPTION
Fixes #2430 - The static configuration is overwriting an instance to other instance which is bad.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
