### PR TITLE
Fixes #2429. Error when replacing a word in textView.

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -387,7 +387,7 @@ namespace Terminal.Gui {
 						pos = new Point (col, i);
 						col += (textToReplace.Length - matchText.Length);
 					}
-					if (col + 1 > txt.Length) {
+					if (col < 0 || col + 1 > txt.Length) {
 						break;
 					}
 					col = txt.IndexOf (matchText, col + 1);

--- a/UnitTests/Views/TextViewTests.cs
+++ b/UnitTests/Views/TextViewTests.cs
@@ -949,7 +949,7 @@ namespace Terminal.Gui.ViewTests {
 					Assert.Equal (0, _textView.CursorPosition.X);
 					Assert.Equal (0, _textView.CursorPosition.Y);
 					Assert.Equal ("This is the second line.", _textView.Text.ToString ());
-					Assert.Equal ($"This is the first line.{Environment.NewLine}", Clipboard.Contents.ToString());
+					Assert.Equal ($"This is the first line.{Environment.NewLine}", Clipboard.Contents.ToString ());
 					break;
 				case 2:
 					_textView.ProcessKey (new KeyEvent (Key.K | Key.CtrlMask, new KeyModifiers ()));
@@ -985,7 +985,7 @@ namespace Terminal.Gui.ViewTests {
 					_textView.ProcessKey (new KeyEvent (Key.K | Key.AltMask, new KeyModifiers ()));
 					Assert.Equal (0, _textView.CursorPosition.X);
 					Assert.Equal (1, _textView.CursorPosition.Y);
-					Assert.Equal ($"This is the first line.{Environment.NewLine}", _textView.Text.ToString());
+					Assert.Equal ($"This is the first line.{Environment.NewLine}", _textView.Text.ToString ());
 					Assert.Equal ($"This is the second line.", Clipboard.Contents.ToString ());
 					break;
 				case 1:
@@ -6814,6 +6814,18 @@ This is the second line.
 			tv.LoadFile (fileName);
 			Assert.Equal (1, eventcount);
 			Assert.Equal ($"This is the first line.{Environment.NewLine}This is the second line.{Environment.NewLine}", tv.Text);
+		}
+
+		[Fact]
+		public void ReplaceAllText_Does_Not_Throw_Exception ()
+		{
+			var textToFind = "hello! hello!";
+			var textToReplace = "hello!";
+			var tv = new TextView () { Width = 20, Height = 3, Text = textToFind };
+
+			var exception = Record.Exception (() => tv.ReplaceAllText (textToFind, false, false, textToReplace));
+			Assert.Null (exception);
+			Assert.Equal (textToReplace, tv.Text);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2429 - For v1.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
