### PR TITLE
Fixes #2453. TextField OnEnter throws exception if IsInitialized is false.

### DIFF
--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -250,6 +250,16 @@ namespace Terminal.Gui {
 		}
 
 		///<inheritdoc/>
+		public override bool OnEnter (View view)
+		{
+			if (IsInitialized) {
+				Application.Driver.SetCursorVisibility (DesiredCursorVisibility);
+			}
+
+			return base.OnEnter (view);
+		}
+
+		///<inheritdoc/>
 		public override bool OnLeave (View view)
 		{
 			if (Application.MouseGrabView != null && Application.MouseGrabView == this)
@@ -308,7 +318,7 @@ namespace Terminal.Gui {
 						, HistoryText.LineStatus.Replaced);
 				}
 
-				TextChanged?.Invoke (this, new TextChangedEventArgs(oldText));
+				TextChanged?.Invoke (this, new TextChangedEventArgs (oldText));
 
 				if (point > text.Count) {
 					point = Math.Max (TextModel.DisplaySize (text, 0).size - 1, 0);
@@ -1267,14 +1277,6 @@ namespace Terminal.Gui {
 
 				desiredCursorVisibility = value;
 			}
-		}
-
-		///<inheritdoc/>
-		public override bool OnEnter (View view)
-		{
-			Application.Driver.SetCursorVisibility (DesiredCursorVisibility);
-
-			return base.OnEnter (view);
 		}
 
 		/// <summary>

--- a/UnitTests/Views/TextFieldTests.cs
+++ b/UnitTests/Views/TextFieldTests.cs
@@ -663,7 +663,7 @@ namespace Terminal.Gui.ViewTests {
 		{
 			bool cancel = true;
 
-			_textField.TextChanging += (s,e) => {
+			_textField.TextChanging += (s, e) => {
 				Assert.Equal ("changing", e.NewText);
 				if (cancel) {
 					e.Cancel = true;
@@ -681,7 +681,7 @@ namespace Terminal.Gui.ViewTests {
 		[TextFieldTestsAutoInitShutdown]
 		public void TextChanged_Event ()
 		{
-			_textField.TextChanged += (s,e) => {
+			_textField.TextChanged += (s, e) => {
 				Assert.Equal ("TAB to jump between text fields.", e.OldValue);
 			};
 
@@ -781,7 +781,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal ("A", tf.Text.ToString ());
 
 			// cancel the next keystroke
-			tf.TextChanging += (s,e) => e.Cancel = e.NewText == "AB";
+			tf.TextChanging += (s, e) => e.Cancel = e.NewText == "AB";
 			tf.ProcessKey (new KeyEvent (Key.B, new KeyModifiers ()));
 
 			// B was canceled so should just be A
@@ -1137,7 +1137,7 @@ namespace Terminal.Gui.ViewTests {
 			var oldText = "";
 			var tf = new TextField () { Width = 10, Text = "-1" };
 
-			tf.TextChanging += (s,e) => newText = e.NewText.ToString ();
+			tf.TextChanging += (s, e) => newText = e.NewText.ToString ();
 			tf.TextChanged += (s, e) => oldText = e.OldValue.ToString ();
 
 			Application.Top.Add (tf);
@@ -1439,6 +1439,17 @@ Les Miśerables", output);
 			Application.Refresh ();
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 ắ", output);
+		}
+
+		[Fact]
+		public void OnEnter_Does_Not_Throw_If_Not_IsInitialized_SetCursorVisibility ()
+		{
+			var top = new Toplevel ();
+			var tf = new TextField () { Width = 10 };
+			top.Add (tf);
+
+			var exception = Record.Exception (tf.SetFocus);
+			Assert.Null (exception);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2453 - `Driver` was accessed before `IsInitialized` is `true`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
