### PR TITLE
Fixes #2459. ListView SelectedItem throw exception if the value is -1.

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -684,9 +684,7 @@ namespace Terminal.Gui {
 			if (selected != lastSelectedItem) {
 				var value = source?.Count > 0 ? source.ToList () [selected] : null;
 				SelectedItemChanged?.Invoke (this, new ListViewItemEventArgs (selected, value));
-				if (HasFocus) {
-					lastSelectedItem = selected;
-				}
+				lastSelectedItem = selected;
 				return true;
 			}
 
@@ -724,21 +722,11 @@ namespace Terminal.Gui {
 		{
 			Application.Driver.SetCursorVisibility (CursorVisibility.Invisible);
 
-			if (lastSelectedItem == -1) {
+			if (lastSelectedItem != selected) {
 				EnsureSelectedItemVisible ();
 			}
 
 			return base.OnEnter (view);
-		}
-
-		///<inheritdoc/>
-		public override bool OnLeave (View view)
-		{
-			if (lastSelectedItem > -1) {
-				lastSelectedItem = -1;
-			}
-
-			return base.OnLeave (view);
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -244,7 +244,7 @@ namespace Terminal.Gui {
 				if (source == null || source.Count == 0) {
 					return;
 				}
-				if (value < 0 || value >= source.Count) {
+				if (value < -1 || value >= source.Count) {
 					throw new ArgumentException ("value");
 				}
 				selected = value;

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -721,8 +721,9 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override bool OnEnter (View view)
 		{
-			Application.Driver.SetCursorVisibility (CursorVisibility.Invisible);
-
+			if (IsInitialized) {
+				Application.Driver.SetCursorVisibility (CursorVisibility.Invisible);
+			}
 			if (lastSelectedItem != selected) {
 				EnsureSelectedItemVisible ();
 			}

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -685,6 +685,7 @@ namespace Terminal.Gui {
 				var value = source?.Count > 0 ? source.ToList () [selected] : null;
 				SelectedItemChanged?.Invoke (this, new ListViewItemEventArgs (selected, value));
 				lastSelectedItem = selected;
+				EnsureSelectedItemVisible ();
 				return true;
 			}
 

--- a/UnitTests/Views/ListViewTests.cs
+++ b/UnitTests/Views/ListViewTests.cs
@@ -531,5 +531,15 @@ Item 6", output);
 			var exception = Record.Exception (() => lv.SelectedItem = -1);
 			Assert.Null (exception);
 		}
+
+		[Fact]
+		public void OnEnter_Does_Not_Throw_Exception ()
+		{
+			var lv = new ListView ();
+			var top = new View ();
+			top.Add (lv);
+			var exception = Record.Exception (lv.SetFocus);
+			Assert.Null (exception);
+		}
 	}
 }

--- a/UnitTests/Views/ListViewTests.cs
+++ b/UnitTests/Views/ListViewTests.cs
@@ -529,5 +529,15 @@ Item 4
 Item 5
 Item 6", output);
 		}
+
+		[Fact]
+		public void SelectedItem_Get_Set ()
+		{
+			var lv = new ListView (new List<string> { "One", "Two", "Three" });
+			Assert.Equal (-1, lv.SelectedItem);
+			Assert.Throws<ArgumentException> (() => lv.SelectedItem = 3);
+			var exception = Record.Exception (() => lv.SelectedItem = -1);
+			Assert.Null (exception);
+		}
 	}
 }

--- a/UnitTests/Views/ListViewTests.cs
+++ b/UnitTests/Views/ListViewTests.cs
@@ -224,7 +224,6 @@ namespace Terminal.Gui.ViewTests {
 			var source = new List<string> () { "First", "Second" };
 			ListView lv = new ListView (source) { Width = Dim.Fill (), Height = 1 };
 			lv.SelectedItem = 1;
-			lv.EnsureSelectedItemVisible ();
 			Application.Top.Add (lv);
 			Application.Begin (Application.Top);
 
@@ -512,16 +511,8 @@ Item 2
 Item 3
 Item 4", output);
 
+			// EnsureSelectedItemVisible is auto enabled on the OnSelectedChanged
 			lv.SelectedItem = 6;
-			Application.Refresh ();
-			TestHelpers.AssertDriverContentsWithFrameAre (@"
-Item 0
-Item 1
-Item 2
-Item 3
-Item 4", output);
-
-			lv.EnsureSelectedItemVisible ();
 			Application.Refresh ();
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 Item 2

--- a/UnitTests/Views/ListViewTests.cs
+++ b/UnitTests/Views/ListViewTests.cs
@@ -224,6 +224,7 @@ namespace Terminal.Gui.ViewTests {
 			var source = new List<string> () { "First", "Second" };
 			ListView lv = new ListView (source) { Width = Dim.Fill (), Height = 1 };
 			lv.SelectedItem = 1;
+			lv.EnsureSelectedItemVisible ();
 			Application.Top.Add (lv);
 			Application.Begin (Application.Top);
 


### PR DESCRIPTION
Fixes #2459 - Since now it's initialized as -1 it must also allow set to -1.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
