### PR TITLE
Removed additional colon in SaveAs dialog

### DIFF
--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -914,7 +914,7 @@ namespace Terminal.Gui {
 		/// <param name="message">The message.</param>
 		/// <param name="allowedTypes">The allowed types.</param>
 		public SaveDialog (ustring title, ustring message, List<string> allowedTypes = null)
-			: base (title, prompt: Strings.fdSave, nameFieldLabel: $"{Strings.fdSaveAs}:", message: message, allowedTypes) { }
+			: base (title, prompt: Strings.fdSave, nameFieldLabel: $"{Strings.fdSaveAs}", message: message, allowedTypes) { }
 
 		/// <summary>
 		/// Gets the name of the file the user selected for saving, or null


### PR DESCRIPTION
Fixes #2440 - Include a terse summary of the change or which issue is fixed.

This small change is related to the closed issue: 
https://github.com/gui-cs/Terminal.Gui/issues/2440

## Pull Request checklist:

- [X] I've named my PR in the form of "Fixes #issue. Terse description."
- [X] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [X] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [X] I ran `dotnet test` before commit
- [X] I have made corresponding changes to the API documentation (using `///` style comments)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any poor grammar or misspellings
- [X] I conducted basic QA to assure all features are working
