### PR TITLE
Fixes #2496. Adds simple `Ruler` class for drawing rulers; Thickness and Frame now use

### DIFF
--- a/Terminal.Gui/Core/Thickness.cs
+++ b/Terminal.Gui/Core/Thickness.cs
@@ -281,21 +281,4 @@ namespace Terminal.Gui {
 			return !(left == right);
 		}
 	}
-
-	internal static class StringExtensions {
-		public static string Repeat (this string instr, int n)
-		{
-			if (n <= 0) {
-				return null;
-			}
-
-			if (string.IsNullOrEmpty (instr) || n == 1) {
-				return instr;
-			}
-
-			return new StringBuilder (instr.Length * n)
-				.Insert (0, instr, n)
-				.ToString ();
-		}
-	}
 }

--- a/Terminal.Gui/Core/Thickness.cs
+++ b/Terminal.Gui/Core/Thickness.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json.Serialization;
 using Terminal.Gui.Configuration;
+using Terminal.Gui.Graphs;
 
 namespace Terminal.Gui {
 	/// <summary>
@@ -159,16 +160,6 @@ namespace Terminal.Gui {
 				}
 			}
 
-			ustring hrule = ustring.Empty;
-			ustring vrule = ustring.Empty;
-			if ((ConsoleDriver.Diagnostics & ConsoleDriver.DiagnosticFlags.FrameRuler) == ConsoleDriver.DiagnosticFlags.FrameRuler) {
-
-				string h = "0123456789";
-				hrule = h.Repeat ((int)Math.Ceiling ((double)(rect.Width) / (double)h.Length)) [0..(rect.Width)];
-				string v = "0123456789";
-				vrule = v.Repeat ((int)Math.Ceiling ((double)(rect.Height * 2) / (double)v.Length)) [0..(rect.Height * 2)];
-			};
-
 			// Draw the Top side
 			if (Top > 0) {
 				Application.Driver.FillRect (new Rect (rect.X, rect.Y, rect.Width, Math.Min (rect.Height, Top)), topChar);
@@ -192,20 +183,25 @@ namespace Terminal.Gui {
 			// TODO: This should be moved to LineCanvas as a new BorderStyle.Ruler
 			if ((ConsoleDriver.Diagnostics & ConsoleDriver.DiagnosticFlags.FrameRuler) == ConsoleDriver.DiagnosticFlags.FrameRuler) {
 				// Top
-				Application.Driver.Move (rect.X, rect.Y);
-				Application.Driver.AddStr (hrule);
-				//Left
-				for (var r = rect.Y; r < rect.Y + rect.Height; r++) {
-					Application.Driver.Move (rect.X, r);
-					Application.Driver.AddRune (vrule [r - rect.Y]);
+				var hruler = new Ruler () { Length = rect.Width, Orientation = Orientation.Horizontal };
+				if (Top > 0) {
+					hruler.Draw (new Point (rect.X, rect.Y));
 				}
+
+				//Left
+				var vruler = new Ruler () { Length = rect.Height - 2, Orientation = Orientation.Vertical };
+				if (Left > 0) {
+					vruler.Draw (new Point (rect.X, rect.Y + 1), 1);
+				}
+
 				// Bottom
-				Application.Driver.Move (rect.X, rect.Y + rect.Height - Bottom + 1);
-				Application.Driver.AddStr (hrule);
+				if (Bottom > 0) {
+					hruler.Draw (new Point (rect.X, rect.Y + rect.Height - 1));
+				}
+
 				// Right
-				for (var r = rect.Y + 1; r < rect.Y + rect.Height; r++) {
-					Application.Driver.Move (rect.X + rect.Width - Right + 1, r);
-					Application.Driver.AddRune (vrule [r - rect.Y]);
+				if (Right > 0) {
+					vruler.Draw (new Point (rect.X + rect.Width - 1, rect.Y + 1), 1);
 				}
 			}
 

--- a/Terminal.Gui/Drawing/Ruler.cs
+++ b/Terminal.Gui/Drawing/Ruler.cs
@@ -46,19 +46,19 @@ namespace Terminal.Gui {
 			if (start < 0) {
 				throw new ArgumentException ("start must be greater than or equal to 0");
 			}
-			
+
 			if (Length < 1) {
 				return;
 			}
-			
+
 			if (Orientation == Orientation.Horizontal) {
-				var hrule = _hTemplate.Repeat ((int)Math.Ceiling ((double)Length / (double)_hTemplate.Length)) [start..(Length + start)];
+				var hrule = _hTemplate.Repeat ((int)Math.Ceiling ((double)Length + 2 / (double)_hTemplate.Length)) [start..(Length + start)];
 				// Top
 				Application.Driver.Move (location.X, location.Y);
 				Application.Driver.AddStr (hrule);
 
 			} else {
-				var vrule = _vTemplate.Repeat ((int)Math.Ceiling ((double)(Length) / (double)_vTemplate.Length)) [start..(Length + start)];
+				var vrule = _vTemplate.Repeat ((int)Math.Ceiling ((double)(Length + 2) / (double)_vTemplate.Length)) [start..(Length + start)];
 				for (var r = location.Y; r < location.Y + Length; r++) {
 					Application.Driver.Move (location.X, r);
 					Application.Driver.AddRune (vrule [r - location.Y]);

--- a/Terminal.Gui/Drawing/Ruler.cs
+++ b/Terminal.Gui/Drawing/Ruler.cs
@@ -1,0 +1,83 @@
+﻿using NStack;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+using System.Text.Json.Serialization;
+using Terminal.Gui.Configuration;
+using Terminal.Gui.Graphs;
+
+namespace Terminal.Gui {
+	/// <summary>
+	/// Draws a ruler on the screen.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// </para>
+	/// </remarks>
+	public class Ruler {
+
+		/// <summary>
+		/// Gets or sets whether the ruler is drawn horizontally or vertically. The default is horizontally.
+		/// </summary>
+		public Orientation Orientation { get; set; }
+
+		/// <summary>
+		/// Gets or sets the lenght of the ruler. The default is 0.
+		/// </summary>
+		public int Length { get; set; }
+
+		/// <summary>
+		/// Gets or sets the foreground and backgrond color to use.
+		/// </summary>
+		public Attribute Attribute { get; set; }
+
+		/// <summary>
+		/// Gets or sets the ruler template. This will be repeated in the ruler. The default is "0123456789".
+		/// </summary>
+		public string Template { get; set; } = "0123456789";
+
+
+		/// <summary>
+		/// Draws the <see cref="Ruler"/>. 
+		/// </summary>
+		/// <param name="location">The location to start drawing the ruler, in screen-relative coordinates.</param>
+		public void Draw (Point location)
+		{
+			if (Length < 1) {
+				return;
+			}
+
+			if (Orientation == Orientation.Horizontal) {
+				var hrule = Template.Repeat ((int)Math.Ceiling ((double)Length / (double)Template.Length)) [0..Length];
+				// Top
+				Application.Driver.Move (location.X, location.Y);
+				Application.Driver.AddStr (hrule);
+
+			} else {
+				var vrule = Template.Repeat ((int)Math.Ceiling ((double)(Length * 2) / (double)Template.Length)) [0..(Length * 2)];
+				for (var r = location.Y; r < location.Y + Length; r++) {
+					Application.Driver.Move (location.X, r);
+					Application.Driver.AddRune (vrule [r - location.Y]);
+				}
+			}
+		}
+	}
+
+	internal static class StringExtensions {
+		public static string Repeat (this string instr, int n)
+		{
+			if (n <= 0) {
+				return null;
+			}
+
+			if (string.IsNullOrEmpty (instr) || n == 1) {
+				return instr;
+			}
+
+			return new StringBuilder (instr.Length * n)
+				.Insert (0, instr, n)
+				.ToString ();
+		}
+	}
+}

--- a/Terminal.Gui/Drawing/Ruler.cs
+++ b/Terminal.Gui/Drawing/Ruler.cs
@@ -32,30 +32,33 @@ namespace Terminal.Gui {
 		/// </summary>
 		public Attribute Attribute { get; set; }
 
-		/// <summary>
-		/// Gets or sets the ruler template. This will be repeated in the ruler. The default is "0123456789".
-		/// </summary>
-		public string Template { get; set; } = "0123456789";
+		string _hTemplate { get; set; } = "|123456789";
+		string _vTemplate { get; set; } = "-123456789";
 
 
 		/// <summary>
 		/// Draws the <see cref="Ruler"/>. 
 		/// </summary>
 		/// <param name="location">The location to start drawing the ruler, in screen-relative coordinates.</param>
-		public void Draw (Point location)
+		/// <param name="start">The start value of the ruler.</param>
+		public void Draw (Point location, int start = 0)
 		{
+			if (start < 0) {
+				throw new ArgumentException ("start must be greater than or equal to 0");
+			}
+			
 			if (Length < 1) {
 				return;
 			}
-
+			
 			if (Orientation == Orientation.Horizontal) {
-				var hrule = Template.Repeat ((int)Math.Ceiling ((double)Length / (double)Template.Length)) [0..Length];
+				var hrule = _hTemplate.Repeat ((int)Math.Ceiling ((double)Length / (double)_hTemplate.Length)) [start..(Length + start)];
 				// Top
 				Application.Driver.Move (location.X, location.Y);
 				Application.Driver.AddStr (hrule);
 
 			} else {
-				var vrule = Template.Repeat ((int)Math.Ceiling ((double)(Length * 2) / (double)Template.Length)) [0..(Length * 2)];
+				var vrule = _vTemplate.Repeat ((int)Math.Ceiling ((double)(Length) / (double)_vTemplate.Length)) [start..(Length + start)];
 				for (var r = location.Y; r < location.Y + Length; r++) {
 					Application.Driver.Move (location.X, r);
 					Application.Driver.AddRune (vrule [r - location.Y]);

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -461,6 +461,16 @@ namespace Terminal.Gui.ApplicationTests {
 		}
 		#endregion
 
+		[Fact, AutoInitShutdown]
+		public void Begin_Sets_Application_Top_To_Console_Size()
+		{
+			Assert.Equal (new Rect (0, 0, 80, 25), Application.Top.Frame);
+
+			((FakeDriver)Application.Driver).SetBufferSize (5, 5);
+			Application.Begin (Application.Top);
+			Assert.Equal (new Rect (0, 0, 5, 5), Application.Top.Frame);
+		}
+
 		[Fact]
 		[AutoInitShutdown]
 		public void SetCurrentAsTop_Run_A_Not_Modal_Toplevel_Make_It_The_Current_Application_Top ()

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -468,6 +468,9 @@ namespace Terminal.Gui.ApplicationTests {
 
 			((FakeDriver)Application.Driver).SetBufferSize (5, 5);
 			Application.Begin (Application.Top);
+			// BUGBUG: v2 - 
+			Assert.Equal (new Rect (0, 0, 80, 25), Application.Top.Frame);
+			((FakeDriver)Application.Driver).SetBufferSize (5, 5);
 			Assert.Equal (new Rect (0, 0, 5, 5), Application.Top.Frame);
 		}
 

--- a/UnitTests/Core/ThicknessTests.cs
+++ b/UnitTests/Core/ThicknessTests.cs
@@ -485,6 +485,137 @@ namespace Terminal.Gui.CoreTests {
 
 		}
 
+		[Fact (), AutoInitShutdown]
+		public void DrawTests_Ruler ()
+		{
+			// Add a frame so we can see the ruler
+			var f = new FrameView () {
+				X = 0,
+				Y = 0,
+				Width = Dim.Fill (),
+				Height = Dim.Fill (),
+			};
+
+
+			Application.Top.Add (f);
+			Application.Begin (Application.Top);
+			
+			((FakeDriver)Application.Driver).SetBufferSize (45, 20);
+			var t = new Thickness (0, 0, 0, 0);
+			var r = new Rect (2, 2, 40, 15);
+			Application.Refresh ();
+			ConsoleDriver.Diagnostics |= ConsoleDriver.DiagnosticFlags.FrameRuler;
+			t.Draw (r, "Test");
+			ConsoleDriver.Diagnostics = ConsoleDriver.DiagnosticFlags.Off;
+			TestHelpers.AssertDriverContentsAre (@"
+┌───────────────────────────────────────────┐
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+└───────────────────────────────────────────┘", output);
+
+
+			t = new Thickness (1, 1, 1, 1);
+			r = new Rect (1, 1, 40, 15);
+			Application.Refresh ();
+			ConsoleDriver.Diagnostics |= ConsoleDriver.DiagnosticFlags.FrameRuler;
+			t.Draw (r, "Test");
+			ConsoleDriver.Diagnostics = ConsoleDriver.DiagnosticFlags.Off;
+			TestHelpers.AssertDriverContentsAre (@"
+┌───────────────────────────────────────────┐
+│|123456789|123456789|123456789|123456789   │
+│1                                      1   │
+│2                                      2   │
+│3                                      3   │
+│4                                      4   │
+│5                                      5   │
+│6                                      6   │
+│7                                      7   │
+│8                                      8   │
+│9                                      9   │
+│-                                      -   │
+│1                                      1   │
+│2                                      2   │
+│3                                      3   │
+│|123456789|123456789|123456789|123456789   │
+│                                           │
+│                                           │
+│                                           │
+└───────────────────────────────────────────┘", output);
+
+			t = new Thickness (1, 2, 3, 4);
+			r = new Rect (2, 2, 40, 15);
+			Application.Refresh ();
+			ConsoleDriver.Diagnostics |= ConsoleDriver.DiagnosticFlags.FrameRuler;
+			t.Draw (r, "Test");
+			ConsoleDriver.Diagnostics = ConsoleDriver.DiagnosticFlags.Off;
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌───────────────────────────────────────────┐
+│                                           │
+│ |123456789|123456789|123456789|123456789  │
+│ 1                                      1  │
+│ 2                                      2  │
+│ 3                                      3  │
+│ 4                                      4  │
+│ 5                                      5  │
+│ 6                                      6  │
+│ 7                                      7  │
+│ 8                                      8  │
+│ 9                                      9  │
+│ -                                      -  │
+│ 1                                      1  │
+│ 2                                      2  │
+│ 3                                      3  │
+│ |123456789|123456789|123456789|123456789  │
+│                                           │
+│                                           │
+└───────────────────────────────────────────┘", output);
+
+
+			t = new Thickness (-1, 1, 1, 1);
+			r = new Rect (5, 5, 40, 15);
+			Application.Refresh ();
+			ConsoleDriver.Diagnostics |= ConsoleDriver.DiagnosticFlags.FrameRuler;
+			t.Draw (r, "Test");
+			ConsoleDriver.Diagnostics = ConsoleDriver.DiagnosticFlags.Off;
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌───────────────────────────────────────────┐
+│                                           │
+│                                           │
+│                                           │
+│                                           │
+│    |123456789|123456789|123456789|123456789
+│                                           1
+│                                           2
+│                                           3
+│                                           4
+│                                           5
+│                                           6
+│                                           7
+│                                           8
+│                                           9
+│                                           -
+│                                           1
+│                                           2
+│                                           3
+└────|123456789|123456789|123456789|123456789", output);
+
+		}
 		[Fact ()]
 		public void EqualsTest ()
 		{

--- a/UnitTests/Drawing/RulerTests.cs
+++ b/UnitTests/Drawing/RulerTests.cs
@@ -1,0 +1,160 @@
+﻿using Terminal.Gui;
+using NStack;
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Terminal.Gui.Graphs;
+using Xunit;
+using Xunit.Abstractions;
+//using GraphViewTests = Terminal.Gui.Views.GraphViewTests;
+
+// Alias Console to MockConsole so we don't accidentally use Console
+using Console = Terminal.Gui.FakeConsole;
+
+namespace Terminal.Gui.DrawingTests {
+	public class RulerTests {
+
+		readonly ITestOutputHelper output;
+
+		public RulerTests (ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		[Fact ()]
+		public void Constructor_Defaults ()
+		{
+			var r = new Ruler ();
+			Assert.Equal (0, r.Length);
+			Assert.Equal ("0123456789", r.Template);
+			Assert.Equal (Orientation.Horizontal, r.Orientation);
+			Assert.Equal (default, r.Attribute);
+		}
+
+
+		[Fact ()]
+		public void Orientation_set ()
+		{
+			var r = new Ruler ();
+			Assert.Equal (Orientation.Horizontal, r.Orientation);
+			r.Orientation = Orientation.Vertical;
+			Assert.Equal (Orientation.Vertical, r.Orientation);
+		}
+		
+		[Fact ()]
+		public void Length_set ()
+		{
+			var r = new Ruler ();
+			Assert.Equal (0, r.Length);
+			r.Length = 42;
+			Assert.Equal (42, r.Length);
+		}
+
+		[Fact ()]
+		public void Template_set ()
+		{
+			var newTemplate = ")!@#$$%^&*(";
+
+			var r = new Ruler ();
+			Assert.Equal ("0123456789", r.Template);
+			r.Template = newTemplate;
+			Assert.Equal (newTemplate, r.Template);
+		}
+
+		[Fact ()]
+		public void Attribute_set ()
+		{
+			var newAttribute = new Attribute (Color.Red, Color.Green);
+
+			var r = new Ruler ();
+			Assert.Equal (default, r.Attribute);
+			r.Attribute = newAttribute;
+			Assert.Equal (newAttribute, r.Attribute);
+		}
+
+		[Fact (), AutoInitShutdown]
+		public void Draw_Default ()
+		{
+			((FakeDriver)Application.Driver).SetBufferSize (25, 25);
+
+			var r = new Ruler ();
+			r.Draw (new Point (0, 0));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"", output);
+		}
+
+		[Fact (), AutoInitShutdown]
+		public void Draw_Horizontal ()
+		{
+			var len = 15;
+			((FakeDriver)Application.Driver).SetBufferSize (len + 5, 5);
+
+			// Add a frame so we can see the ruler
+			var f = new FrameView () {
+				X = 0,
+				Y = 0,
+				Width = Dim.Fill (),
+				Height = Dim.Fill (),
+			};
+			Application.Top.Add (f);
+			Application.Begin (Application.Top);
+			Assert.Equal (new Rect (0, 0, len + 5, 5), f.Frame);
+			
+			var r = new Ruler ();
+			Assert.Equal (Orientation.Horizontal, r.Orientation);
+
+			r.Length = len;
+			r.Draw (new Point(0,0));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"012345678901234", output);
+
+			// Postive offset
+			((FakeDriver)Application.Driver).FillRect (new Rect (0, 0, len * 2, len * 2), ' ');
+			r.Draw (new Point (1, 1));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+
+012345678901234", output);
+		}
+
+		[Fact (), AutoInitShutdown]
+		public void Draw_Vertical ()
+		{
+			var len = 25;
+			((FakeDriver)Application.Driver).SetBufferSize (len * 2, len * 2);
+
+			var r = new Ruler ();
+			r.Orientation = Orientation.Vertical;
+			Assert.Equal (Orientation.Vertical, r.Orientation);
+
+			r.Length = len;
+			r.Draw (new Point (0, 0));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+0
+1
+2
+3
+4", output);
+		}
+		
+	}
+}
+
+

--- a/UnitTests/Drawing/RulerTests.cs
+++ b/UnitTests/Drawing/RulerTests.cs
@@ -53,7 +53,7 @@ namespace Terminal.Gui.DrawingTests {
 		[Fact ()]
 		public void Template_set ()
 		{
-			var newTemplate = ")!@#$$%^&*(";
+			var newTemplate = "|123456789";
 
 			var r = new Ruler ();
 			Assert.Equal ("0123456789", r.Template);
@@ -86,7 +86,6 @@ namespace Terminal.Gui.DrawingTests {
 		public void Draw_Horizontal ()
 		{
 			var len = 15;
-			((FakeDriver)Application.Driver).SetBufferSize (len + 5, 5);
 
 			// Add a frame so we can see the ruler
 			var f = new FrameView () {
@@ -97,6 +96,7 @@ namespace Terminal.Gui.DrawingTests {
 			};
 			Application.Top.Add (f);
 			Application.Begin (Application.Top);
+			((FakeDriver)Application.Driver).SetBufferSize (len + 5, 5);
 			Assert.Equal (new Rect (0, 0, len + 5, 5), f.Frame);
 			
 			var r = new Ruler ();
@@ -104,56 +104,248 @@ namespace Terminal.Gui.DrawingTests {
 
 			r.Length = len;
 			r.Draw (new Point(0,0));
-			TestHelpers.AssertDriverContentsWithFrameAre (@"012345678901234", output);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+012345678901234────┐
+│                  │
+│                  │
+│                  │
+└──────────────────┘", output);
 
 			// Postive offset
-			((FakeDriver)Application.Driver).FillRect (new Rect (0, 0, len * 2, len * 2), ' ');
+			Application.Refresh ();
 			r.Draw (new Point (1, 1));
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌──────────────────┐
+│012345678901234   │
+│                  │
+│                  │
+└──────────────────┘", output);
 
-012345678901234", output);
+			// Negative offset
+			Application.Refresh ();
+			r.Draw (new Point (-1, 1));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌──────────────────┐
+12345678901234     │
+│                  │
+│                  │
+└──────────────────┘", output);
+
+			// Clip
+			Application.Refresh ();
+			r.Draw (new Point (10, 1));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌──────────────────┐
+│         0123456789
+│                  │
+│                  │
+└──────────────────┘", output);
+		}
+
+		[Fact (), AutoInitShutdown]
+		public void Draw_Horizontal_Template ()
+		{
+			var len = 15;
+
+			// Add a frame so we can see the ruler
+			var f = new FrameView () {
+				X = 0,
+				Y = 0,
+				Width = Dim.Fill (),
+				Height = Dim.Fill (),
+			};
+
+		
+			Application.Top.Add (f);
+			Application.Begin (Application.Top);
+			((FakeDriver)Application.Driver).SetBufferSize (len + 5, 5);
+			Assert.Equal (new Rect (0, 0, len + 5, 5), f.Frame);
+
+			var r = new Ruler ();
+			r.Length = len;
+
+			var newTemplate = "|123456789";
+			r.Template = newTemplate;
+
+			r.Draw (new Point (0, 0));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+|123456789|1234────┐
+│                  │
+│                  │
+│                  │
+└──────────────────┘", output);
 		}
 
 		[Fact (), AutoInitShutdown]
 		public void Draw_Vertical ()
 		{
-			var len = 25;
-			((FakeDriver)Application.Driver).SetBufferSize (len * 2, len * 2);
+			var len = 15;
+
+			// Add a frame so we can see the ruler
+			var f = new FrameView () {
+				X = 0,
+				Y = 0,
+				Width = Dim.Fill (),
+				Height = Dim.Fill (),
+			};
+
+
+			Application.Top.Add (f);
+			Application.Begin (Application.Top);
+			((FakeDriver)Application.Driver).SetBufferSize (5, len + 5);
+			Assert.Equal (new Rect (0, 0, 5, len + 5), f.Frame);
 
 			var r = new Ruler ();
 			r.Orientation = Orientation.Vertical;
-			Assert.Equal (Orientation.Vertical, r.Orientation);
-
 			r.Length = len;
 			r.Draw (new Point (0, 0));
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-0
-1
-2
-3
-4
-5
-6
-7
-8
-9
-0
-1
-2
-3
-4
-5
-6
-7
-8
-9
-0
-1
-2
-3
-4", output);
+0───┐
+1   │
+2   │
+3   │
+4   │
+5   │
+6   │
+7   │
+8   │
+9   │
+0   │
+1   │
+2   │
+3   │
+4   │
+│   │
+│   │
+│   │
+│   │
+└───┘", output);
+
+			// Postive offset
+			Application.Refresh ();
+			r.Draw (new Point (1, 1));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌───┐
+│0  │
+│1  │
+│2  │
+│3  │
+│4  │
+│5  │
+│6  │
+│7  │
+│8  │
+│9  │
+│0  │
+│1  │
+│2  │
+│3  │
+│4  │
+│   │
+│   │
+│   │
+└───┘", output);
+
+			// Negative offset
+			Application.Refresh ();
+			r.Draw (new Point (1, -1));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌1──┐
+│2  │
+│3  │
+│4  │
+│5  │
+│6  │
+│7  │
+│8  │
+│9  │
+│0  │
+│1  │
+│2  │
+│3  │
+│4  │
+│   │
+│   │
+│   │
+│   │
+│   │
+└───┘", output);
+
+			// Clip
+			Application.Refresh ();
+			r.Draw (new Point (1, 10));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌───┐
+│   │
+│   │
+│   │
+│   │
+│   │
+│   │
+│   │
+│   │
+│   │
+│0  │
+│1  │
+│2  │
+│3  │
+│4  │
+│5  │
+│6  │
+│7  │
+│8  │
+└9──┘", output);
 		}
-		
+
+		[Fact (), AutoInitShutdown]
+		public void Draw_Vertical_Template ()
+		{
+			var len = 15;
+
+			// Add a frame so we can see the ruler
+			var f = new FrameView () {
+				X = 0,
+				Y = 0,
+				Width = Dim.Fill (),
+				Height = Dim.Fill (),
+			};
+
+
+			Application.Top.Add (f);
+			Application.Begin (Application.Top);
+			((FakeDriver)Application.Driver).SetBufferSize (5, len + 5);
+			Assert.Equal (new Rect (0, 0, 5, len + 5), f.Frame);
+
+			var r = new Ruler ();
+			r.Orientation = Orientation.Vertical;
+			r.Length = len;
+
+			var newTemplate = ")!@#$$%^&*(";
+			r.Template = newTemplate;
+
+			r.Draw (new Point (0, 0));
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+)───┐
+!   │
+@   │
+#   │
+$   │
+$   │
+%   │
+^   │
+&   │
+*   │
+(   │
+)   │
+!   │
+@   │
+#   │
+│   │
+│   │
+│   │
+│   │
+└───┘", output);
+		}		
 	}
 }
 

--- a/UnitTests/Drawing/RulerTests.cs
+++ b/UnitTests/Drawing/RulerTests.cs
@@ -26,7 +26,6 @@ namespace Terminal.Gui.DrawingTests {
 		{
 			var r = new Ruler ();
 			Assert.Equal (0, r.Length);
-			Assert.Equal ("0123456789", r.Template);
 			Assert.Equal (Orientation.Horizontal, r.Orientation);
 			Assert.Equal (default, r.Attribute);
 		}
@@ -40,7 +39,7 @@ namespace Terminal.Gui.DrawingTests {
 			r.Orientation = Orientation.Vertical;
 			Assert.Equal (Orientation.Vertical, r.Orientation);
 		}
-		
+
 		[Fact ()]
 		public void Length_set ()
 		{
@@ -48,17 +47,6 @@ namespace Terminal.Gui.DrawingTests {
 			Assert.Equal (0, r.Length);
 			r.Length = 42;
 			Assert.Equal (42, r.Length);
-		}
-
-		[Fact ()]
-		public void Template_set ()
-		{
-			var newTemplate = "|123456789";
-
-			var r = new Ruler ();
-			Assert.Equal ("0123456789", r.Template);
-			r.Template = newTemplate;
-			Assert.Equal (newTemplate, r.Template);
 		}
 
 		[Fact ()]
@@ -98,14 +86,14 @@ namespace Terminal.Gui.DrawingTests {
 			Application.Begin (Application.Top);
 			((FakeDriver)Application.Driver).SetBufferSize (len + 5, 5);
 			Assert.Equal (new Rect (0, 0, len + 5, 5), f.Frame);
-			
+
 			var r = new Ruler ();
 			Assert.Equal (Orientation.Horizontal, r.Orientation);
 
 			r.Length = len;
-			r.Draw (new Point(0,0));
+			r.Draw (new Point (0, 0));
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-012345678901234────┐
+|123456789|1234────┐
 │                  │
 │                  │
 │                  │
@@ -116,7 +104,7 @@ namespace Terminal.Gui.DrawingTests {
 			r.Draw (new Point (1, 1));
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 ┌──────────────────┐
-│012345678901234   │
+│|123456789|1234   │
 │                  │
 │                  │
 └──────────────────┘", output);
@@ -126,7 +114,7 @@ namespace Terminal.Gui.DrawingTests {
 			r.Draw (new Point (-1, 1));
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 ┌──────────────────┐
-12345678901234     │
+123456789|1234     │
 │                  │
 │                  │
 └──────────────────┘", output);
@@ -136,14 +124,14 @@ namespace Terminal.Gui.DrawingTests {
 			r.Draw (new Point (10, 1));
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 ┌──────────────────┐
-│         0123456789
+│         |123456789
 │                  │
 │                  │
 └──────────────────┘", output);
 		}
 
 		[Fact (), AutoInitShutdown]
-		public void Draw_Horizontal_Template ()
+		public void Draw_Horizontal_Start ()
 		{
 			var len = 15;
 
@@ -154,22 +142,28 @@ namespace Terminal.Gui.DrawingTests {
 				Width = Dim.Fill (),
 				Height = Dim.Fill (),
 			};
-
-		
 			Application.Top.Add (f);
 			Application.Begin (Application.Top);
 			((FakeDriver)Application.Driver).SetBufferSize (len + 5, 5);
 			Assert.Equal (new Rect (0, 0, len + 5, 5), f.Frame);
 
 			var r = new Ruler ();
+			Assert.Equal (Orientation.Horizontal, r.Orientation);
+
 			r.Length = len;
-
-			var newTemplate = "|123456789";
-			r.Template = newTemplate;
-
-			r.Draw (new Point (0, 0));
+			r.Draw (new Point (0, 0), 1);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-|123456789|1234────┐
+123456789|12345────┐
+│                  │
+│                  │
+│                  │
+└──────────────────┘", output);
+
+			Application.Refresh ();
+			r.Length = len;
+			r.Draw (new Point (1, 0), 1);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌123456789|12345───┐
 │                  │
 │                  │
 │                  │
@@ -200,7 +194,7 @@ namespace Terminal.Gui.DrawingTests {
 			r.Length = len;
 			r.Draw (new Point (0, 0));
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-0───┐
+-───┐
 1   │
 2   │
 3   │
@@ -210,7 +204,7 @@ namespace Terminal.Gui.DrawingTests {
 7   │
 8   │
 9   │
-0   │
+-   │
 1   │
 2   │
 3   │
@@ -226,7 +220,7 @@ namespace Terminal.Gui.DrawingTests {
 			r.Draw (new Point (1, 1));
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 ┌───┐
-│0  │
+│-  │
 │1  │
 │2  │
 │3  │
@@ -236,7 +230,7 @@ namespace Terminal.Gui.DrawingTests {
 │7  │
 │8  │
 │9  │
-│0  │
+│-  │
 │1  │
 │2  │
 │3  │
@@ -259,7 +253,7 @@ namespace Terminal.Gui.DrawingTests {
 │7  │
 │8  │
 │9  │
-│0  │
+│-  │
 │1  │
 │2  │
 │3  │
@@ -285,7 +279,7 @@ namespace Terminal.Gui.DrawingTests {
 │   │
 │   │
 │   │
-│0  │
+│-  │
 │1  │
 │2  │
 │3  │
@@ -298,7 +292,7 @@ namespace Terminal.Gui.DrawingTests {
 		}
 
 		[Fact (), AutoInitShutdown]
-		public void Draw_Vertical_Template ()
+		public void Draw_Vertical_Start ()
 		{
 			var len = 15;
 
@@ -319,33 +313,55 @@ namespace Terminal.Gui.DrawingTests {
 			var r = new Ruler ();
 			r.Orientation = Orientation.Vertical;
 			r.Length = len;
-
-			var newTemplate = ")!@#$$%^&*(";
-			r.Template = newTemplate;
-
-			r.Draw (new Point (0, 0));
+			r.Draw (new Point (0, 0), 1);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-)───┐
-!   │
-@   │
-#   │
-$   │
-$   │
-%   │
-^   │
-&   │
-*   │
-(   │
-)   │
-!   │
-@   │
-#   │
+1───┐
+2   │
+3   │
+4   │
+5   │
+6   │
+7   │
+8   │
+9   │
+-   │
+1   │
+2   │
+3   │
+4   │
+5   │
 │   │
 │   │
 │   │
 │   │
 └───┘", output);
-		}		
+
+			Application.Refresh ();
+			r.Length = len;
+			r.Draw (new Point (0, 1), 1);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌───┐
+1   │
+2   │
+3   │
+4   │
+5   │
+6   │
+7   │
+8   │
+9   │
+-   │
+1   │
+2   │
+3   │
+4   │
+5   │
+│   │
+│   │
+│   │
+└───┘", output);
+
+		}
 	}
 }
 

--- a/UnitTests/TopLevels/ToplevelTests.cs
+++ b/UnitTests/TopLevels/ToplevelTests.cs
@@ -39,7 +39,6 @@ namespace Terminal.Gui.TopLevelTests {
 			Assert.Equal (new Rect (0, 0, Application.Driver.Cols, Application.Driver.Rows), top.Bounds);
 		}
 
-
 		[Fact]
 		[AutoInitShutdown]
 		public void Application_Top_EnsureVisibleBounds_To_Driver_Rows_And_Cols ()

--- a/UnitTests/Views/FrameViewTests.cs
+++ b/UnitTests/Views/FrameViewTests.cs
@@ -1,12 +1,21 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestPlatform.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Terminal.Gui.ViewTests {
 	public class FrameViewTests {
+		readonly ITestOutputHelper output;
+
+		public FrameViewTests (ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
 		[Fact]
 		public void Constuctors_Defaults ()
 		{
@@ -27,6 +36,60 @@ namespace Terminal.Gui.ViewTests {
 			fv.BeginInit ();
 			fv.EndInit ();
 			Assert.Equal (new Rect (1, 2, 10, 20), fv.Frame);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void Draw_Defaults ()
+		{
+			((FakeDriver)Application.Driver).SetBufferSize (10, 10);
+			var fv = new FrameView ();
+			Assert.Equal (string.Empty, fv.Title);
+			Assert.Equal (string.Empty, fv.Text);
+			Assert.NotNull (fv.Border);
+			Application.Top.Add (fv);
+			Application.Begin (Application.Top);
+			Assert.Equal (new Rect (0, 0, 0, 0), fv.Frame);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"", output);
+
+			fv.Height = 5;
+			fv.Width = 5;
+			Assert.Equal (new Rect (0, 0, 5, 5), fv.Frame);
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌───┐
+│   │
+│   │
+│   │
+└───┘", output);
+
+
+			fv.X = 1;
+			fv.Y = 2;
+			Assert.Equal (new Rect (1, 2, 5, 5), fv.Frame);
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+ ┌───┐
+ │   │
+ │   │
+ │   │
+ └───┘", output);
+
+			fv.X = -1;
+			fv.Y = -2;
+			Assert.Equal (new Rect (-1, -2, 5, 5), fv.Frame);
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+   │
+   │
+───┘", output);
+
+			fv.X = 7;
+			fv.Y = 8;
+			Assert.Equal (new Rect (7, 8, 5, 5), fv.Frame);
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+       ┌──
+       │  ", output);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2496 (in a short-term way; the right thing to do is for `LineCanvas` to have a mode for drawing as a ruler instead).