### PR TITLE
Add many styles to SpinnerView

### DIFF
--- a/Terminal.Gui/Views/SpinnerView.cs
+++ b/Terminal.Gui/Views/SpinnerView.cs
@@ -1,44 +1,271 @@
-﻿using System;
+﻿//------------------------------------------------------------------------------
+// SpinnerStyles below are derived from <https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json>
+// MIT License
+// Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Windows Terminal supports Unicode and Emoji characters, but by default conhost shells (e.g., PowerShell and cmd.exe) do not. See <https://spectreconsole.net/best-practices>.
+//------------------------------------------------------------------------------
+
+using System;
+using System.Text;
 
 namespace Terminal.Gui {
+	/// <summary>
+	/// Spinner styles used in a <see cref="SpinnerView"/>.
+	/// </summary>
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+	public enum SpinnerStyle {
+		Custom,
+		Dots,
+		Dots2,
+		Dots3,
+		Dots4,
+		Dots5,
+		Dots6,
+		Dots7,
+		Dots8,
+		Dots9,
+		Dots10,
+		Dots11,
+		Dots12,
+		Dots8Bit,
+		Line,
+		Line2,
+		Pipe,
+		SimpleDots,
+		SimpleDotsScrolling,
+		Star,
+		Star2,
+		Flip,
+		Hamburger,
+		GrowVertical,
+		GrowHorizontal,
+		Balloon,
+		Balloon2,
+		Noise,
+		Bounce,
+		BoxBounce,
+		BoxBounce2,
+		Triangle,
+		Arc,
+		Circle,
+		SquareCorners,
+		CircleQuarters,
+		CircleHalves,
+		Squish,
+		Toggle,
+		Toggle2,
+		Toggle3,
+		Toggle4,
+		Toggle5,
+		Toggle6,
+		Toggle7,
+		Toggle8,
+		Toggle9,
+		Toggle10,
+		Toggle11,
+		Toggle12,
+		Toggle13,
+		Arrow,
+		Arrow2,
+		Arrow3,
+		BouncingBar,
+		BouncingBall,
+		Smiley,
+		Monkey,
+		Hearts,
+		Clock,
+		Earth,
+		Material,
+		Moon,
+		Runner,
+		Pong,
+		Shark,
+		Dqpb,
+		Weather,
+		Christmas,
+		Grenade,
+		Point,
+		Layer,
+		BetaWave,
+		FingerDance,
+		FistBump,
+		SoccerHeader,
+		MindBlown,
+		Speaker,
+		OrangePulse,
+		BluePulse,
+		OrangeBluePulse,
+		TimeTravelClock,
+		Aesthetic,
+		Aesthetic2,
+	}
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 	/// <summary>
-	/// A 1x1 <see cref="View"/> based on <see cref="Label"/> which displays a spinning
-	/// line character.
+	/// A <see cref="View"/> based on <see cref="Label"/> which displays (by default) a
+	/// spinning line character.
 	/// </summary>
 	/// <remarks>
 	/// By default animation only occurs when you call <see cref="View.SetNeedsDisplay()"/>.
 	/// Use <see cref="AutoSpin"/> to make the automate calls to <see cref="View.SetNeedsDisplay()"/>.
 	/// </remarks>
 	public class SpinnerView : Label {
-		private Rune [] _runes = new Rune [] { '|', '/', '\u2500', '\\' };
+
+		private const SpinnerStyle DEFAULT_STYLE = SpinnerStyle.Line;
+		private const int DEFAULT_DELAY = 130;
+
+		private bool _hasSpecial = false;
+		private bool _bounceReverse = false;
+		private SpinnerStyle _style;
 		private int _currentIdx = 0;
 		private DateTime _lastRender = DateTime.MinValue;
 		private object _timeout;
 
 		/// <summary>
+		/// Gets or sets the frames used to animate the spinner.
+		/// </summary>
+		public string [] Frames { get; set; }
+
+		/// <summary>
 		/// Gets or sets the number of milliseconds to wait between characters
-		/// in the spin.  Defaults to 250.
+		/// in the spin.  Defaults to the SpinnerStyle's Interval value.
 		/// </summary>
 		/// <remarks>This is the maximum speed the spinner will rotate at.  You still need to
 		/// call <see cref="View.SetNeedsDisplay()"/> or <see cref="SpinnerView.AutoSpin"/> to
 		/// advance/start animation.</remarks>
-		public int SpinDelayInMilliseconds { get; set; } = 250;
+		public int SpinDelayInMilliseconds { get; set; } = DEFAULT_DELAY;
+
+		/// <summary>
+		/// Gets or sets whether spinner should go through frames in reverse order.
+		/// If SpinBounce is true, this sets the starting order.
+		/// </summary>
+		public bool SpinReverse { get; set; } = false;
+
+		/// <summary>
+		/// Gets or sets whether spinner should go back and forth through frames rather than
+		/// going to the end and starting again at the beginning.
+		/// </summary>
+		public bool SpinBounce { get; set; } = false;
+
+		/// <summary>
+		/// Gets the size in characters of the spinner.
+		/// </summary>
+		public int SpinnerWidth { get => GetSpinnerWidth (); }
+
+		/// <summary>
+		/// Gets whether the current spinner style contains only ASCII characters.
+		/// </summary>
+		public bool IsAsciiOnly { get => GetIsAsciiOnly (); }
+
+		/// <summary>
+		/// Gets whether the current spinner style contains emoji or other special characters.
+		/// </summary>
+		public bool HasSpecialCharacters { get => GetHasSpecial (); }
 
 		/// <summary>
 		/// Creates a new instance of the <see cref="SpinnerView"/> class.
 		/// </summary>
 		public SpinnerView ()
 		{
-			Width = 1; Height = 1;
+			SpinnerStyle = DEFAULT_STYLE;
+			Width = GetSpinnerWidth ();
+			Height = 1;
+		}
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="SpinnerView"/> class.
+		/// </summary>
+		public SpinnerView (SpinnerStyle style)
+		{
+			SpinnerStyle = style;
+			Width = GetSpinnerWidth ();
+			Height = 1;
+		}
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="SpinnerView"/> class with
+		/// a custom spinner.
+		/// </summary>
+		public SpinnerView (string [] frames, int delay = DEFAULT_DELAY)
+		{
+			if (frames is not null &&
+				frames.Length > 0) {
+				_style = SpinnerStyle.Custom;
+				Frames = frames;
+				Width = GetSpinnerWidth ();
+				SpinDelayInMilliseconds = delay;
+			} else {
+				Width = 1;
+			}
+			Height = 1;
+		}
+
+		private int GetSpinnerWidth ()
+		{
+			int max = 0;
+			foreach (string frame in Frames) {
+				if (frame.Length > max)
+					max = frame.Length;
+			}
+			return max;
+		}
+
+		private bool GetIsAsciiOnly ()
+		{
+			foreach (string frame in Frames) {
+				foreach (char c in frame) {
+					if (!char.IsAscii (c))
+						return false;
+				}
+			}
+			return true;
+		}
+
+		private bool GetHasSpecial ()
+		{
+			if (_hasSpecial) return true;
+			return false;
 		}
 
 		/// <inheritdoc/>
 		public override void Redraw (Rect bounds)
 		{
 			if (DateTime.Now - _lastRender > TimeSpan.FromMilliseconds (SpinDelayInMilliseconds)) {
-				_currentIdx = (_currentIdx + 1) % _runes.Length;
-				Text = "" + _runes [_currentIdx];
+				//_currentIdx = (_currentIdx + 1) % Frames.Length;
+				if (Frames.Length > 1) {
+					int d = 1;
+					if ((_bounceReverse && !SpinReverse) || (!_bounceReverse && SpinReverse))
+						d = -1;
+					_currentIdx += d;
+
+					if (_currentIdx >= Frames.Length) {
+						if (SpinBounce) {
+							if (SpinReverse)
+								_bounceReverse = false;
+							else
+								_bounceReverse = true;
+							_currentIdx = Frames.Length - 1;
+						} else {
+							_currentIdx = 0;
+						}
+					}
+					if (_currentIdx < 0) {
+						if (SpinBounce) {
+							if (SpinReverse)
+								_bounceReverse = true;
+							else
+								_bounceReverse = false;
+							_currentIdx = 1;
+						}
+						else
+							_currentIdx = Frames.Length - 1;
+					}
+					Text = "" + Frames [_currentIdx]; //.EnumerateRunes;
+				}
 				_lastRender = DateTime.Now;
 			}
 
@@ -70,6 +297,1493 @@ namespace Terminal.Gui {
 			}
 
 			base.Dispose (disposing);
+		}
+
+		/// <summary>
+		/// Gets/Sets the spinner view style based on the <see cref="Terminal.Gui.SpinnerStyle"/>
+		/// </summary>
+		public SpinnerStyle SpinnerStyle {
+			get => _style;
+			set {
+				_style = value;
+				_bounceReverse = false;
+				SpinDelayInMilliseconds = 80;
+				SpinBounce = false;
+				SpinReverse = false;
+				_hasSpecial = false;
+				switch (value) {
+				case SpinnerStyle.Custom: // Placeholder when user has specified delay and frames manually
+					SpinDelayInMilliseconds = 0;
+					Frames = Array.Empty<string> ();
+					break;
+				case SpinnerStyle.Dots:
+					Frames = new string []
+					{
+						"⠋",
+						"⠙",
+						"⠹",
+						"⠸",
+						"⠼",
+						"⠴",
+						"⠦",
+						"⠧",
+						"⠇",
+						"⠏",
+					};
+					break;
+				case SpinnerStyle.Dots2:
+					Frames = new string []
+					{
+						"⣾",
+						"⣽",
+						"⣻",
+						"⢿",
+						"⡿",
+						"⣟",
+						"⣯",
+						"⣷",
+					};
+					break;
+				case SpinnerStyle.Dots3:
+					Frames = new string []
+					{
+						"⠋",
+						"⠙",
+						"⠚",
+						"⠞",
+						"⠖",
+						"⠦",
+						"⠴",
+						"⠲",
+						"⠳",
+						"⠓",
+					};
+					break;
+				case SpinnerStyle.Dots4:
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"⠄",
+						"⠆",
+						"⠇",
+						"⠋",
+						"⠙",
+						"⠸",
+						"⠰",
+						"⠠",
+					};
+					break;
+				case SpinnerStyle.Dots5:
+					Frames = new string []
+					{
+						"⠋",
+						"⠙",
+						"⠚",
+						"⠒",
+						"⠂",
+						"⠂",
+						"⠒",
+						"⠲",
+						"⠴",
+						"⠦",
+						"⠖",
+						"⠒",
+						"⠐",
+						"⠐",
+						"⠒",
+						"⠓",
+						"⠋",
+					};
+					break;
+				case SpinnerStyle.Dots6:
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"⠁",
+						"⠁",
+						"⠉",
+						"⠙",
+						"⠚",
+						"⠒",
+						"⠂",
+						"⠂",
+						"⠒",
+						"⠲",
+						"⠴",
+						"⠤",
+						"⠄",
+						"⠄",
+					};
+					break;
+				case SpinnerStyle.Dots7:
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"⠈",
+						"⠈",
+						"⠉",
+						"⠋",
+						"⠓",
+						"⠒",
+						"⠐",
+						"⠐",
+						"⠒",
+						"⠖",
+						"⠦",
+						"⠤",
+						"⠠",
+						"⠠",
+					};
+					break;
+				case SpinnerStyle.Dots8:
+					Frames = new string []
+					{
+						"⠁",
+						"⠁",
+						"⠉",
+						"⠙",
+						"⠚",
+						"⠒",
+						"⠂",
+						"⠂",
+						"⠒",
+						"⠲",
+						"⠴",
+						"⠤",
+						"⠄",
+						"⠄",
+						"⠤",
+						"⠠",
+						"⠠",
+						"⠤",
+						"⠦",
+						"⠖",
+						"⠒",
+						"⠐",
+						"⠐",
+						"⠒",
+						"⠓",
+						"⠋",
+						"⠉",
+						"⠈",
+						"⠈",
+					};
+					break;
+				case SpinnerStyle.Dots9:
+					Frames = new string []
+					{
+						"⢹",
+						"⢺",
+						"⢼",
+						"⣸",
+						"⣇",
+						"⡧",
+						"⡗",
+						"⡏",
+					};
+					break;
+				case SpinnerStyle.Dots10:
+					Frames = new string []
+					{
+						"⢄",
+						"⢂",
+						"⢁",
+						"⡁",
+						"⡈",
+						"⡐",
+						"⡠",
+					};
+					break;
+				case SpinnerStyle.Dots11:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"⠁",
+						"⠂",
+						"⠄",
+						"⡀",
+						"⢀",
+						"⠠",
+						"⠐",
+						"⠈",
+					};
+					break;
+				case SpinnerStyle.Dots12:
+					Frames = new string []
+					{
+						"⢀⠀",
+						"⡀⠀",
+						"⠄⠀",
+						"⢂⠀",
+						"⡂⠀",
+						"⠅⠀",
+						"⢃⠀",
+						"⡃⠀",
+						"⠍⠀",
+						"⢋⠀",
+						"⡋⠀",
+						"⠍⠁",
+						"⢋⠁",
+						"⡋⠁",
+						"⠍⠉",
+						"⠋⠉",
+						"⠋⠉",
+						"⠉⠙",
+						"⠉⠙",
+						"⠉⠩",
+						"⠈⢙",
+						"⠈⡙",
+						"⢈⠩",
+						"⡀⢙",
+						"⠄⡙",
+						"⢂⠩",
+						"⡂⢘",
+						"⠅⡘",
+						"⢃⠨",
+						"⡃⢐",
+						"⠍⡐",
+						"⢋⠠",
+						"⡋⢀",
+						"⠍⡁",
+						"⢋⠁",
+						"⡋⠁",
+						"⠍⠉",
+						"⠋⠉",
+						"⠋⠉",
+						"⠉⠙",
+						"⠉⠙",
+						"⠉⠩",
+						"⠈⢙",
+						"⠈⡙",
+						"⠈⠩",
+						"⠀⢙",
+						"⠀⡙",
+						"⠀⠩",
+						"⠀⢘",
+						"⠀⡘",
+						"⠀⠨",
+						"⠀⢐",
+						"⠀⡐",
+						"⠀⠠",
+						"⠀⢀",
+						"⠀⡀",
+					};
+					break;
+				case SpinnerStyle.Dots8Bit:
+					Frames = new string []
+					{
+						"⠀",
+						"⠁",
+						"⠂",
+						"⠃",
+						"⠄",
+						"⠅",
+						"⠆",
+						"⠇",
+						"⡀",
+						"⡁",
+						"⡂",
+						"⡃",
+						"⡄",
+						"⡅",
+						"⡆",
+						"⡇",
+						"⠈",
+						"⠉",
+						"⠊",
+						"⠋",
+						"⠌",
+						"⠍",
+						"⠎",
+						"⠏",
+						"⡈",
+						"⡉",
+						"⡊",
+						"⡋",
+						"⡌",
+						"⡍",
+						"⡎",
+						"⡏",
+						"⠐",
+						"⠑",
+						"⠒",
+						"⠓",
+						"⠔",
+						"⠕",
+						"⠖",
+						"⠗",
+						"⡐",
+						"⡑",
+						"⡒",
+						"⡓",
+						"⡔",
+						"⡕",
+						"⡖",
+						"⡗",
+						"⠘",
+						"⠙",
+						"⠚",
+						"⠛",
+						"⠜",
+						"⠝",
+						"⠞",
+						"⠟",
+						"⡘",
+						"⡙",
+						"⡚",
+						"⡛",
+						"⡜",
+						"⡝",
+						"⡞",
+						"⡟",
+						"⠠",
+						"⠡",
+						"⠢",
+						"⠣",
+						"⠤",
+						"⠥",
+						"⠦",
+						"⠧",
+						"⡠",
+						"⡡",
+						"⡢",
+						"⡣",
+						"⡤",
+						"⡥",
+						"⡦",
+						"⡧",
+						"⠨",
+						"⠩",
+						"⠪",
+						"⠫",
+						"⠬",
+						"⠭",
+						"⠮",
+						"⠯",
+						"⡨",
+						"⡩",
+						"⡪",
+						"⡫",
+						"⡬",
+						"⡭",
+						"⡮",
+						"⡯",
+						"⠰",
+						"⠱",
+						"⠲",
+						"⠳",
+						"⠴",
+						"⠵",
+						"⠶",
+						"⠷",
+						"⡰",
+						"⡱",
+						"⡲",
+						"⡳",
+						"⡴",
+						"⡵",
+						"⡶",
+						"⡷",
+						"⠸",
+						"⠹",
+						"⠺",
+						"⠻",
+						"⠼",
+						"⠽",
+						"⠾",
+						"⠿",
+						"⡸",
+						"⡹",
+						"⡺",
+						"⡻",
+						"⡼",
+						"⡽",
+						"⡾",
+						"⡿",
+						"⢀",
+						"⢁",
+						"⢂",
+						"⢃",
+						"⢄",
+						"⢅",
+						"⢆",
+						"⢇",
+						"⣀",
+						"⣁",
+						"⣂",
+						"⣃",
+						"⣄",
+						"⣅",
+						"⣆",
+						"⣇",
+						"⢈",
+						"⢉",
+						"⢊",
+						"⢋",
+						"⢌",
+						"⢍",
+						"⢎",
+						"⢏",
+						"⣈",
+						"⣉",
+						"⣊",
+						"⣋",
+						"⣌",
+						"⣍",
+						"⣎",
+						"⣏",
+						"⢐",
+						"⢑",
+						"⢒",
+						"⢓",
+						"⢔",
+						"⢕",
+						"⢖",
+						"⢗",
+						"⣐",
+						"⣑",
+						"⣒",
+						"⣓",
+						"⣔",
+						"⣕",
+						"⣖",
+						"⣗",
+						"⢘",
+						"⢙",
+						"⢚",
+						"⢛",
+						"⢜",
+						"⢝",
+						"⢞",
+						"⢟",
+						"⣘",
+						"⣙",
+						"⣚",
+						"⣛",
+						"⣜",
+						"⣝",
+						"⣞",
+						"⣟",
+						"⢠",
+						"⢡",
+						"⢢",
+						"⢣",
+						"⢤",
+						"⢥",
+						"⢦",
+						"⢧",
+						"⣠",
+						"⣡",
+						"⣢",
+						"⣣",
+						"⣤",
+						"⣥",
+						"⣦",
+						"⣧",
+						"⢨",
+						"⢩",
+						"⢪",
+						"⢫",
+						"⢬",
+						"⢭",
+						"⢮",
+						"⢯",
+						"⣨",
+						"⣩",
+						"⣪",
+						"⣫",
+						"⣬",
+						"⣭",
+						"⣮",
+						"⣯",
+						"⢰",
+						"⢱",
+						"⢲",
+						"⢳",
+						"⢴",
+						"⢵",
+						"⢶",
+						"⢷",
+						"⣰",
+						"⣱",
+						"⣲",
+						"⣳",
+						"⣴",
+						"⣵",
+						"⣶",
+						"⣷",
+						"⢸",
+						"⢹",
+						"⢺",
+						"⢻",
+						"⢼",
+						"⢽",
+						"⢾",
+						"⢿",
+						"⣸",
+						"⣹",
+						"⣺",
+						"⣻",
+						"⣼",
+						"⣽",
+						"⣾",
+						"⣿",
+					};
+					break;
+				case SpinnerStyle.Line:
+					SpinDelayInMilliseconds = 130;
+					Frames = new string []
+					{
+						 "-",
+						@"\",
+						 "|",
+						 "/",
+					};
+					break;
+				case SpinnerStyle.Line2:
+					SpinDelayInMilliseconds = 100;
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"⠂",
+						"-",
+						"–",
+						"—",
+					};
+					break;
+				case SpinnerStyle.Pipe:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"┤",
+						"┘",
+						"┴",
+						"└",
+						"├",
+						"┌",
+						"┬",
+						"┐",
+					};
+					break;
+				case SpinnerStyle.SimpleDots:
+					SpinDelayInMilliseconds = 400;
+					Frames = new string []
+					{
+						".  ",
+						".. ",
+						"...",
+						"   ",
+					};
+					break;
+				case SpinnerStyle.SimpleDotsScrolling:
+					SpinDelayInMilliseconds = 200;
+					Frames = new string []
+					{
+						".  ",
+						".. ",
+						"...",
+						" ..",
+						"  .",
+						"   ",
+					};
+					break;
+				case SpinnerStyle.Star:
+					SpinDelayInMilliseconds = 70;
+					Frames = new string []
+					{
+						"✶",
+						"✸",
+						"✹",
+						"✺",
+						"✹",
+						"✷",
+					};
+					break;
+				case SpinnerStyle.Star2:
+					Frames = new string []
+					{
+						"+",
+						"x",
+						"*",
+					};
+					break;
+				case SpinnerStyle.Flip:
+					SpinDelayInMilliseconds = 70;
+					Frames = new string []
+					{
+						"_",
+						"_",
+						"_",
+						"-",
+						"`",
+						"`",
+						"'",
+						"´",
+						"-",
+						"_",
+						"_",
+						"_",
+					};
+					break;
+				case SpinnerStyle.Hamburger:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"☱",
+						"☲",
+						"☴",
+					};
+					break;
+				case SpinnerStyle.GrowVertical:
+					SpinDelayInMilliseconds = 120;
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"▁",
+						"▃",
+						"▄",
+						"▅",
+						"▆",
+						"▇",
+					};
+					break;
+				case SpinnerStyle.GrowHorizontal:
+					SpinDelayInMilliseconds = 120;
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"▏",
+						"▎",
+						"▍",
+						"▌",
+						"▋",
+						"▊",
+						"▉",
+					};
+					break;
+				case SpinnerStyle.Balloon:
+					SpinDelayInMilliseconds = 140;
+					Frames = new string []
+					{
+						" ",
+						".",
+						"o",
+						"O",
+						"@",
+						"*",
+						" ",
+					};
+					break;
+				case SpinnerStyle.Balloon2:
+					SpinDelayInMilliseconds = 120;
+					SpinBounce = true;
+					Frames = new string []
+					{
+						".",
+						".",
+						"o",
+						"O",
+						"°",
+					};
+					break;
+				case SpinnerStyle.Noise:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"▓",
+						"▒",
+						"░",
+					};
+					break;
+				case SpinnerStyle.Bounce:
+					SpinDelayInMilliseconds = 120;
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"⠁",
+						"⠂",
+						"⠄",
+					};
+					break;
+				case SpinnerStyle.BoxBounce:
+					SpinDelayInMilliseconds = 120;
+					Frames = new string []
+					{
+						"▖",
+						"▘",
+						"▝",
+						"▗",
+					};
+					break;
+				case SpinnerStyle.BoxBounce2:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"▌",
+						"▀",
+						"▐",
+						"▄",
+					};
+					break;
+				case SpinnerStyle.Triangle:
+					SpinDelayInMilliseconds = 50;
+					Frames = new string []
+					{
+						"◢",
+						"◣",
+						"◤",
+						"◥",
+					};
+					break;
+				case SpinnerStyle.Arc:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"◜",
+						"◠",
+						"◝",
+						"◞",
+						"◡",
+						"◟",
+					};
+					break;
+				case SpinnerStyle.Circle:
+					SpinDelayInMilliseconds = 120;
+					Frames = new string []
+					{
+						"◡",
+						"⊙",
+						"◠",
+					};
+					break;
+				case SpinnerStyle.SquareCorners:
+					SpinDelayInMilliseconds = 180;
+					Frames = new string []
+					{
+						"◰",
+						"◳",
+						"◲",
+						"◱",
+					};
+					break;
+				case SpinnerStyle.CircleQuarters:
+					SpinDelayInMilliseconds = 120;
+					Frames = new string []
+					{
+						"◴",
+						"◷",
+						"◶",
+						"◵",
+					};
+					break;
+				case SpinnerStyle.CircleHalves:
+					SpinDelayInMilliseconds = 50;
+					Frames = new string []
+					{
+						"◐",
+						"◓",
+						"◑",
+						"◒",
+					};
+					break;
+				case SpinnerStyle.Squish:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"╫",
+						"╪",
+					};
+					break;
+				case SpinnerStyle.Toggle:
+					SpinDelayInMilliseconds = 250;
+					Frames = new string []
+					{
+						"⊶",
+						"⊷",
+					};
+					break;
+				case SpinnerStyle.Toggle2:
+					Frames = new string []
+					{
+						"▫",
+						"▪",
+					};
+					break;
+				case SpinnerStyle.Toggle3:
+					SpinDelayInMilliseconds = 120;
+					Frames = new string []
+					{
+						"□",
+						"■",
+					};
+					break;
+				case SpinnerStyle.Toggle4:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"■",
+						"□",
+						"▪",
+						"▫",
+					};
+					break;
+				case SpinnerStyle.Toggle5:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"▮",
+						"▯",
+					};
+					break;
+				case SpinnerStyle.Toggle6:
+					SpinDelayInMilliseconds = 300;
+					Frames = new string []
+					{
+						"ဝ",
+						"၀",
+					};
+					break;
+				case SpinnerStyle.Toggle7:
+					Frames = new string []
+					{
+						"⦾",
+						"⦿",
+					};
+					break;
+				case SpinnerStyle.Toggle8:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"◍",
+						"◌",
+					};
+					break;
+				case SpinnerStyle.Toggle9:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"◉",
+						"◎",
+					};
+					break;
+				case SpinnerStyle.Toggle10:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"㊂",
+						"㊀",
+						"㊁",
+					};
+					break;
+				case SpinnerStyle.Toggle11:
+					SpinDelayInMilliseconds = 50;
+					Frames = new string []
+					{
+						"⧇",
+						"⧆",
+					};
+					break;
+				case SpinnerStyle.Toggle12:
+					SpinDelayInMilliseconds = 120;
+					Frames = new string []
+					{
+						"☗",
+						"☖",
+					};
+					break;
+				case SpinnerStyle.Toggle13:
+					Frames = new string []
+					{
+						"=",
+						"*",
+						"-",
+					};
+					break;
+				case SpinnerStyle.Arrow:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"←",
+						"↖",
+						"↑",
+						"↗",
+						"→",
+						"↘",
+						"↓",
+						"↙",
+					};
+					break;
+				case SpinnerStyle.Arrow2:
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"⬆️ ",
+						"↗️ ",
+						"➡️ ",
+						"↘️ ",
+						"⬇️ ",
+						"↙️ ",
+						"⬅️ ",
+						"↖️ ",
+					};
+					break;
+				case SpinnerStyle.Arrow3:
+					SpinDelayInMilliseconds = 120;
+					Frames = new string []
+					{
+						"▹▹▹▹▹",
+						"▸▹▹▹▹",
+						"▹▸▹▹▹",
+						"▹▹▸▹▹",
+						"▹▹▹▸▹",
+						"▹▹▹▹▸",
+					};
+					break;
+				case SpinnerStyle.BouncingBar:
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"[    ]",
+						"[=   ]",
+						"[==  ]",
+						"[=== ]",
+						"[ ===]",
+						"[  ==]",
+						"[   =]",
+						"[    ]",
+					};
+					break;
+				case SpinnerStyle.BouncingBall:
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"(●     )",
+						"( ●    )",
+						"(  ●   )",
+						"(   ●  )",
+						"(    ● )",
+						"(     ●)",
+					};
+					break;
+				case SpinnerStyle.Smiley:
+					SpinDelayInMilliseconds = 200;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"😄 ",
+						"😝 ",
+					};
+					break;
+				case SpinnerStyle.Monkey:
+					SpinDelayInMilliseconds = 300;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🙈 ",
+						"🙈 ",
+						"🙉 ",
+						"🙊 ",
+					};
+					break;
+				case SpinnerStyle.Hearts:
+					SpinDelayInMilliseconds = 100;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"💛 ",
+						"💙 ",
+						"💜 ",
+						"💚 ",
+						"❤️ ",
+					};
+					break;
+				case SpinnerStyle.Clock:
+					SpinDelayInMilliseconds = 100;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🕛 ",
+						"🕐 ",
+						"🕑 ",
+						"🕒 ",
+						"🕓 ",
+						"🕔 ",
+						"🕕 ",
+						"🕖 ",
+						"🕗 ",
+						"🕘 ",
+						"🕙 ",
+						"🕚 ",
+					};
+					break;
+				case SpinnerStyle.Earth:
+					SpinDelayInMilliseconds = 180;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🌍 ",
+						"🌎 ",
+						"🌏 ",
+					};
+					break;
+				case SpinnerStyle.Material:
+					SpinDelayInMilliseconds = 17;
+					Frames = new string []
+					{
+						"█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"███▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"██████▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"██████▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"███████▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"████████▁▁▁▁▁▁▁▁▁▁▁▁",
+						"█████████▁▁▁▁▁▁▁▁▁▁▁",
+						"█████████▁▁▁▁▁▁▁▁▁▁▁",
+						"██████████▁▁▁▁▁▁▁▁▁▁",
+						"███████████▁▁▁▁▁▁▁▁▁",
+						"█████████████▁▁▁▁▁▁▁",
+						"██████████████▁▁▁▁▁▁",
+						"██████████████▁▁▁▁▁▁",
+						"▁██████████████▁▁▁▁▁",
+						"▁██████████████▁▁▁▁▁",
+						"▁██████████████▁▁▁▁▁",
+						"▁▁██████████████▁▁▁▁",
+						"▁▁▁██████████████▁▁▁",
+						"▁▁▁▁█████████████▁▁▁",
+						"▁▁▁▁██████████████▁▁",
+						"▁▁▁▁██████████████▁▁",
+						"▁▁▁▁▁██████████████▁",
+						"▁▁▁▁▁██████████████▁",
+						"▁▁▁▁▁██████████████▁",
+						"▁▁▁▁▁▁██████████████",
+						"▁▁▁▁▁▁██████████████",
+						"▁▁▁▁▁▁▁█████████████",
+						"▁▁▁▁▁▁▁█████████████",
+						"▁▁▁▁▁▁▁▁████████████",
+						"▁▁▁▁▁▁▁▁████████████",
+						"▁▁▁▁▁▁▁▁▁███████████",
+						"▁▁▁▁▁▁▁▁▁███████████",
+						"▁▁▁▁▁▁▁▁▁▁██████████",
+						"▁▁▁▁▁▁▁▁▁▁██████████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁████████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁███████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁██████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█████",
+						"█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████",
+						"██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+						"██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+						"███▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+						"████▁▁▁▁▁▁▁▁▁▁▁▁▁▁██",
+						"█████▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+						"█████▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+						"██████▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+						"████████▁▁▁▁▁▁▁▁▁▁▁▁",
+						"█████████▁▁▁▁▁▁▁▁▁▁▁",
+						"█████████▁▁▁▁▁▁▁▁▁▁▁",
+						"█████████▁▁▁▁▁▁▁▁▁▁▁",
+						"█████████▁▁▁▁▁▁▁▁▁▁▁",
+						"███████████▁▁▁▁▁▁▁▁▁",
+						"████████████▁▁▁▁▁▁▁▁",
+						"████████████▁▁▁▁▁▁▁▁",
+						"██████████████▁▁▁▁▁▁",
+						"██████████████▁▁▁▁▁▁",
+						"▁██████████████▁▁▁▁▁",
+						"▁██████████████▁▁▁▁▁",
+						"▁▁▁█████████████▁▁▁▁",
+						"▁▁▁▁▁████████████▁▁▁",
+						"▁▁▁▁▁████████████▁▁▁",
+						"▁▁▁▁▁▁███████████▁▁▁",
+						"▁▁▁▁▁▁▁▁█████████▁▁▁",
+						"▁▁▁▁▁▁▁▁█████████▁▁▁",
+						"▁▁▁▁▁▁▁▁▁█████████▁▁",
+						"▁▁▁▁▁▁▁▁▁█████████▁▁",
+						"▁▁▁▁▁▁▁▁▁▁█████████▁",
+						"▁▁▁▁▁▁▁▁▁▁▁████████▁",
+						"▁▁▁▁▁▁▁▁▁▁▁████████▁",
+						"▁▁▁▁▁▁▁▁▁▁▁▁███████▁",
+						"▁▁▁▁▁▁▁▁▁▁▁▁███████▁",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁███████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁███████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁██",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁██",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁██",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+						"▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
+					};
+					break;
+				case SpinnerStyle.Moon:
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🌑 ",
+						"🌒 ",
+						"🌓 ",
+						"🌔 ",
+						"🌕 ",
+						"🌖 ",
+						"🌗 ",
+						"🌘 ",
+					};
+					break;
+				case SpinnerStyle.Runner:
+					_hasSpecial = true;
+					SpinDelayInMilliseconds = 140;
+					Frames = new string []
+					{
+						"🚶 ",
+						"🏃 ",
+					};
+					break;
+				case SpinnerStyle.Pong:
+					SpinBounce = true;
+					Frames = new string []
+					{
+						"▐⠂       ▌",
+						"▐⠈       ▌",
+						"▐ ⠂      ▌",
+						"▐ ⠠      ▌",
+						"▐  ⡀     ▌",
+						"▐  ⠠     ▌",
+						"▐   ⠂    ▌",
+						"▐   ⠈    ▌",
+						"▐    ⠂   ▌",
+						"▐    ⠠   ▌",
+						"▐     ⡀  ▌",
+						"▐     ⠠  ▌",
+						"▐      ⠂ ▌",
+						"▐      ⠈ ▌",
+						"▐       ⠂▌",
+						"▐       ⠠▌",
+						"▐       ⡀▌",
+						"▐      ⠠ ▌",
+						"▐      ⠂ ▌",
+						"▐     ⠈  ▌",
+						"▐     ⠂  ▌",
+						"▐    ⠠   ▌",
+						"▐    ⡀   ▌",
+						"▐   ⠠    ▌",
+						"▐   ⠂    ▌",
+						"▐  ⠈     ▌",
+						"▐  ⠂     ▌",
+						"▐ ⠠      ▌",
+						"▐ ⡀      ▌",
+						"▐⠠       ▌",
+					};
+					break;
+				case SpinnerStyle.Shark:
+					SpinDelayInMilliseconds = 120;
+					Frames = new string []
+					{
+						@"▐|\____________▌",
+						@"▐_|\___________▌",
+						@"▐__|\__________▌",
+						@"▐___|\_________▌",
+						@"▐____|\________▌",
+						@"▐_____|\_______▌",
+						@"▐______|\______▌",
+						@"▐_______|\_____▌",
+						@"▐________|\____▌",
+						@"▐_________|\___▌",
+						@"▐__________|\__▌",
+						@"▐___________|\_▌",
+						@"▐____________|\▌",
+						 "▐____________/|▌",
+						 "▐___________/|_▌",
+						 "▐__________/|__▌",
+						 "▐_________/|___▌",
+						 "▐________/|____▌",
+						 "▐_______/|_____▌",
+						 "▐______/|______▌",
+						 "▐_____/|_______▌",
+						 "▐____/|________▌",
+						 "▐___/|_________▌",
+						 "▐__/|__________▌",
+						 "▐_/|___________▌",
+						 "▐/|____________▌",
+					};
+					break;
+				case SpinnerStyle.Dqpb:
+					SpinDelayInMilliseconds = 100;
+					Frames = new string []
+					{
+						"d",
+						"q",
+						"p",
+						"b",
+					};
+					break;
+				case SpinnerStyle.Weather:
+					SpinDelayInMilliseconds = 100;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"☀️ ",
+						"☀️ ",
+						"☀️ ",
+						"🌤 ",
+						"⛅️ ",
+						"🌥 ",
+						"☁️ ",
+						"🌧 ",
+						"🌨 ",
+						"🌧 ",
+						"🌨 ",
+						"🌧 ",
+						"🌨 ",
+						"⛈ ",
+						"🌨 ",
+						"🌧 ",
+						"🌨 ",
+						"☁️ ",
+						"🌥 ",
+						"⛅️ ",
+						"🌤 ",
+						"☀️ ",
+						"☀️ ",
+					};
+					break;
+				case SpinnerStyle.Christmas:
+					SpinDelayInMilliseconds = 400;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🌲",
+						"🎄",
+					};
+					break;
+				case SpinnerStyle.Grenade:
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"،   ",
+						"′   ",
+						" ´ ",
+						" ‾ ",
+						"  ⸌",
+						"  ⸊",
+						"  |",
+						"  ⁎",
+						"  ⁕",
+						" ෴ ",
+						"  ⁓",
+						"   ",
+						"   ",
+						"   ",
+					};
+					break;
+				case SpinnerStyle.Point:
+					SpinDelayInMilliseconds = 125;
+					Frames = new string []
+					{
+						"∙∙∙",
+						"●∙∙",
+						"∙●∙",
+						"∙∙●",
+						"∙∙∙",
+					};
+					break;
+				case SpinnerStyle.Layer:
+					SpinDelayInMilliseconds = 150;
+					Frames = new string []
+					{
+						"-",
+						"=",
+						"≡",
+					};
+					break;
+				case SpinnerStyle.BetaWave:
+					Frames = new string []
+					{
+						"ρββββββ",
+						"βρβββββ",
+						"ββρββββ",
+						"βββρβββ",
+						"ββββρββ",
+						"βββββρβ",
+						"ββββββρ",
+					};
+					break;
+				case SpinnerStyle.FingerDance:
+					SpinDelayInMilliseconds = 160;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🤘 ",
+						"🤟 ",
+						"🖖 ",
+						"✋ ",
+						"🤚 ",
+						"👆 "
+					};
+					break;
+				case SpinnerStyle.FistBump:
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🤜\u3000\u3000\u3000\u3000🤛 ",
+						"🤜\u3000\u3000\u3000\u3000🤛 ",
+						"🤜\u3000\u3000\u3000\u3000🤛 ",
+						"\u3000🤜\u3000\u3000🤛\u3000 ",
+						"\u3000\u3000🤜🤛\u3000\u3000 ",
+						"\u3000🤜✨🤛\u3000\u3000 ",
+						"🤜\u3000✨\u3000🤛\u3000 "
+					};
+					break;
+				case SpinnerStyle.SoccerHeader:
+					SpinBounce = true;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						" 🧑⚽️       🧑 ",
+						"🧑  ⚽️      🧑 ",
+						"🧑   ⚽️     🧑 ",
+						"🧑    ⚽️    🧑 ",
+						"🧑     ⚽️   🧑 ",
+						"🧑      ⚽️  🧑 ",
+						"🧑       ⚽️🧑  ",
+					};
+					break;
+				case SpinnerStyle.MindBlown:
+					SpinDelayInMilliseconds = 160;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"😐 ",
+						"😐 ",
+						"😮 ",
+						"😮 ",
+						"😦 ",
+						"😦 ",
+						"😧 ",
+						"😧 ",
+						"🤯 ",
+						"💥 ",
+						"✨ ",
+						"\u3000 ",
+						"\u3000 ",
+						"\u3000 "
+					};
+					break;
+				case SpinnerStyle.Speaker:
+					SpinDelayInMilliseconds = 160;
+					SpinBounce = true;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🔈 ",
+						"🔉 ",
+						"🔊 ",
+					};
+					break;
+				case SpinnerStyle.OrangePulse:
+					SpinDelayInMilliseconds = 100;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🔸 ",
+						"🔶 ",
+						"🟠 ",
+						"🟠 ",
+						"🔶 "
+					};
+					break;
+				case SpinnerStyle.BluePulse:
+					SpinDelayInMilliseconds = 100;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🔹 ",
+						"🔷 ",
+						"🔵 ",
+						"🔵 ",
+						"🔷 "
+					};
+					break;
+				case SpinnerStyle.OrangeBluePulse:
+					SpinDelayInMilliseconds = 100;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🔸 ",
+						"🔶 ",
+						"🟠 ",
+						"🟠 ",
+						"🔶 ",
+						"🔹 ",
+						"🔷 ",
+						"🔵 ",
+						"🔵 ",
+						"🔷 "
+					};
+					break;
+				case SpinnerStyle.TimeTravelClock:
+					SpinDelayInMilliseconds = 100;
+					_hasSpecial = true;
+					Frames = new string []
+					{
+						"🕛 ",
+						"🕚 ",
+						"🕙 ",
+						"🕘 ",
+						"🕗 ",
+						"🕖 ",
+						"🕕 ",
+						"🕔 ",
+						"🕓 ",
+						"🕒 ",
+						"🕑 ",
+						"🕐 "
+					};
+					break;
+				case SpinnerStyle.Aesthetic:
+					Frames = new string []
+					{
+						"▰▱▱▱▱▱▱",
+						"▰▰▱▱▱▱▱",
+						"▰▰▰▱▱▱▱",
+						"▰▰▰▰▱▱▱",
+						"▰▰▰▰▰▱▱",
+						"▰▰▰▰▰▰▱",
+						"▰▰▰▰▰▰▰",
+						"▰▱▱▱▱▱▱",
+					};
+					break;
+				case SpinnerStyle.Aesthetic2:
+					Frames = new string []
+					{
+						"▰▱▱▱▱▱▱",
+						"▰▰▱▱▱▱▱",
+						"▰▰▰▱▱▱▱",
+						"▰▰▰▰▱▱▱",
+						"▰▰▰▰▰▱▱",
+						"▰▰▰▰▰▰▱",
+						"▰▰▰▰▰▰▰",
+						"▱▰▰▰▰▰▰",
+						"▱▱▰▰▰▰▰",
+						"▱▱▱▰▰▰▰",
+						"▱▱▱▱▰▰▰",
+						"▱▱▱▱▱▰▰",
+						"▱▱▱▱▱▱▰",
+						"▱▱▱▱▱▱▱",
+					};
+					break;
+				default:
+					break;
+				}
+			}
 		}
 	}
 }

--- a/UICatalog/Scenarios/Progress.cs
+++ b/UICatalog/Scenarios/Progress.cs
@@ -11,7 +11,7 @@ namespace UICatalog.Scenarios {
 	//
 	[ScenarioMetadata (Name: "Progress", Description: "Shows off ProgressBar and Threading.")]
 	[ScenarioCategory ("Controls")]
-	[ScenarioCategory ("Threading"), ScenarioCategory ("ProgressBar")]
+	[ScenarioCategory ("Threading"), ScenarioCategory ("Progress")]
 	public class Progress : Scenario {
 
 		class ProgressDemo : FrameView {
@@ -79,25 +79,30 @@ namespace UICatalog.Scenarios {
 				ActivityProgressBar = new ProgressBar () {
 					X = Pos.Right (LeftFrame) + 1,
 					Y = Pos.Bottom (startButton) + 1,
-					Width = Dim.Fill (),
+					Width = Dim.Fill () - 1,
 					Height = 1,
 					Fraction = 0.25F,
 					ColorScheme = Colors.Error
 				};
 				Add (ActivityProgressBar);
 
-				Spinner = new SpinnerView {
+				Spinner = new SpinnerView (SpinnerStyle.Line) {
+					//SpinReverse = true,
+					//SpinBounce = true,
 					X = Pos.Right (ActivityProgressBar),
 					Y = ActivityProgressBar.Y,
 					Visible = false,
 
 				};
+				Spinner.X = Pos.Right (ActivityProgressBar) - Spinner.SpinnerWidth + 1;
+				ActivityProgressBar.Width = Dim.Fill () - Spinner.SpinnerWidth;
+
 				Add (Spinner);
 
 				PulseProgressBar = new ProgressBar () {
 					X = Pos.Right (LeftFrame) + 1,
 					Y = Pos.Bottom (ActivityProgressBar) + 1,
-					Width = Dim.Fill (),
+					Width = Dim.Fill () - Spinner.SpinnerWidth,
 					Height = 1,
 					ColorScheme = Colors.Error
 				};
@@ -134,7 +139,7 @@ namespace UICatalog.Scenarios {
 
 				Application.MainLoop.Invoke(()=>{
 					Spinner.Visible = false;
-					ActivityProgressBar.Width = Dim.Fill();
+					ActivityProgressBar.Width = Dim.Fill() - Spinner.SpinnerWidth;
 					this.LayoutSubviews();
 				});
 			}

--- a/UICatalog/Scenarios/ProgressBarStyles.cs
+++ b/UICatalog/Scenarios/ProgressBarStyles.cs
@@ -6,7 +6,7 @@ using Terminal.Gui;
 namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "ProgressBar Styles", Description: "Shows the ProgressBar Styles.")]
 	[ScenarioCategory ("Controls")]
-	[ScenarioCategory ("ProgressBar")]
+	[ScenarioCategory ("Progress")]
 	[ScenarioCategory ("Threading")]
 
 	public class ProgressBarStyles : Scenario {

--- a/UICatalog/Scenarios/SpinnerStyles.cs
+++ b/UICatalog/Scenarios/SpinnerStyles.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Terminal.Gui;
+
+namespace UICatalog.Scenarios {
+	[ScenarioMetadata (Name: "SpinnerView Styles", Description: "Shows the SpinnerView Styles.")]
+	[ScenarioCategory ("Controls")]
+	[ScenarioCategory ("Progress")]
+
+	public class SpinnerViewStyles : Scenario {
+
+		public override void Setup ()
+		{
+			const int DEFAULT_DELAY = 130;
+			const string DEFAULT_CUSTOM = @"-\|/";
+			var styleEnum = Enum.GetValues (typeof (SpinnerStyle)).Cast<SpinnerStyle> ().ToList ();
+
+			var preview = new View () {
+				X = Pos.Center (),
+				Y = 0,
+				Width = 22,
+				Height = 3,
+				//Title = "Preview",
+				Border = new Border () {
+					BorderStyle = BorderStyle.Single
+				}
+			};
+			Win.Add (preview);
+
+			var spinner = new SpinnerView () {
+				X = Pos.Center (),
+				Y = 0
+			};
+			preview.Add (spinner);
+			spinner.AutoSpin ();
+
+			var ckbAscii = new CheckBox ("Ascii Only", false) {
+				X = Pos.Center () - 7,
+				Y = Pos.Bottom (preview),
+				Enabled = false,
+				Checked = true
+			};
+			Win.Add (ckbAscii);
+
+			var ckbNoSpecial = new CheckBox ("No Special", false) {
+				X = Pos.Center () + 7,
+				Y = Pos.Bottom (preview),
+				Enabled = false,
+				Checked = true
+			};
+			Win.Add (ckbNoSpecial);
+
+			var ckbReverse = new CheckBox ("Reverse", false) {
+				X = Pos.Center () - 22,
+				Y = Pos.Bottom (preview) + 1,
+				Checked = false
+			};
+			Win.Add (ckbReverse);
+
+			var ckbBounce = new CheckBox ("Bounce", false) {
+				X = Pos.Right (ckbReverse) + 2,
+				Y = Pos.Bottom (preview) + 1,
+				Checked = false
+			};
+			Win.Add (ckbBounce);
+
+			var delayLabel = new Label ("Delay:") {
+				X = Pos.Right (ckbBounce) + 2,
+				Y = Pos.Bottom (preview) + 1
+			};
+			Win.Add (delayLabel);
+			var delayField = new TextField (DEFAULT_DELAY.ToString ()) {
+				X = Pos.Right (delayLabel),
+				Y = Pos.Bottom (preview) + 1,
+				Width = 5
+			};
+			Win.Add (delayField);
+			delayField.TextChanged += (s, e) => {
+				if (ushort.TryParse (delayField.Text.ToString (), out var i))
+					spinner.SpinDelayInMilliseconds = i;
+			};
+
+			var customLabel = new Label ("Custom:") {
+				X = Pos.Right (delayField) + 2,
+				Y = Pos.Bottom (preview) + 1
+			};
+			Win.Add (customLabel);
+			var customField = new TextField (DEFAULT_CUSTOM) {
+				X = Pos.Right (customLabel),
+				Y = Pos.Bottom (preview) + 1,
+				Width = 12
+			};
+			Win.Add (customField);
+
+			var styleArray = styleEnum.Select (e => NStack.ustring.Make (e.ToString ())).ToArray ();
+			if (styleArray.Length < 2)
+				return;
+
+			var styles = new ListView () {
+				X = Pos.Center (),
+				Y = Pos.Bottom (preview) + 2,
+				Height = Dim.Fill (),
+				Width = Dim.Fill (1)
+			};
+			styles.SetSource (styleArray);
+			styles.SelectedItem = (int)SpinnerStyle.Custom;
+			Win.Add (styles);
+			customField.TextChanged += (s, e) => {
+				if (customField.Text.Length > 0) {
+					if (styles.SelectedItem != (int)SpinnerStyle.Custom)
+						styles.SelectedItem = (int)SpinnerStyle.Custom;
+					SetCustom ();
+				}
+			};
+
+			styles.SelectedItemChanged += (s, e) => {
+				if ((SpinnerStyle)e.Item == SpinnerStyle.Custom) {
+					//customField.Text = DEFAULT_CUSTOM;
+					delayField.Text = DEFAULT_DELAY.ToString ();
+					SetCustom ();
+				} else {
+					spinner.Visible = true;
+					spinner.SpinnerStyle = (SpinnerStyle)e.Item;
+					ckbReverse.Checked = false;
+					ckbBounce.Checked = spinner.SpinBounce;
+					ckbAscii.Checked = spinner.IsAsciiOnly;
+					ckbNoSpecial.Checked = !spinner.HasSpecialCharacters;
+					delayField.Text = spinner.SpinDelayInMilliseconds.ToString ();
+					customField.Text = "";
+				}
+			};
+
+			ckbReverse.Toggled += (s, e) => {
+				spinner.SpinReverse = (bool)!e.OldValue;
+			};
+
+			ckbBounce.Toggled += (s, e) => {
+				spinner.SpinBounce = (bool)!e.OldValue;
+			};
+
+			Application.Top.Unloaded += Top_Unloaded;
+
+			void SetCustom ()
+			{
+				if (customField.Text.Length > 0) {
+					spinner.Visible = true;
+					if (ushort.TryParse (delayField.Text.ToString (), out var d))
+						spinner.SpinDelayInMilliseconds = d;
+					else {
+						spinner.SpinDelayInMilliseconds = DEFAULT_DELAY;
+						delayField.Text = DEFAULT_DELAY.ToString ();
+					}
+					var str = new List<string> ();
+					foreach (var c in customField.Text.ToString ().ToCharArray ()) {
+						str.Add (c.ToString ());
+					}
+					spinner.Frames = str.ToArray ();
+				} else {
+					spinner.Visible = false;
+				}
+			}
+
+			void Top_Unloaded (object sender, EventArgs args)
+			{
+				if (spinner != null) {
+					spinner.Dispose ();
+					spinner = null;
+				}
+				Application.Top.Unloaded -= Top_Unloaded;
+			}
+		}
+	}
+}

--- a/UnitTests/Views/SpinnerViewTests.cs
+++ b/UnitTests/Views/SpinnerViewTests.cs
@@ -42,19 +42,19 @@ namespace Terminal.Gui.ViewsTests {
 
 			view.Redraw (view.Bounds);
 
-			var expected = "/";
+			var expected = @"\";
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
 			view.SetNeedsDisplay ();
 			view.Redraw (view.Bounds);
 
-			expected = "/";
+			expected = @"\";
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
 			view.SetNeedsDisplay ();
 			view.Redraw (view.Bounds);
 
-			expected = "/";
+			expected = @"\";
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
 			Task.Delay (400).Wait();
@@ -62,7 +62,7 @@ namespace Terminal.Gui.ViewsTests {
 			view.SetNeedsDisplay ();
 			view.Redraw (view.Bounds);
 
-			expected = "─";
+			expected = "|";
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 		}
 		[Fact, AutoInitShutdown]
@@ -74,14 +74,14 @@ namespace Terminal.Gui.ViewsTests {
 			view.Redraw (view.Bounds);
 
 
-			var expected = @"─";
+			var expected = "|";
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
 			view.SetNeedsDisplay ();
 			view.Redraw (view.Bounds);
 
 
-			expected = @"\";
+			expected = "/";
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 		}
 


### PR DESCRIPTION
I've added styles to the new SpinnerView based on [cli-spinners](https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json), which can be previewed [here](https://jsfiddle.net/sindresorhus/2eLtsbey/embedded/result/) or using the new SpinnerStyles scenario in the UICatalog.  I used an enum and switch/case rather than a class to match the existing coding style, but a class method could easily be adapted from [Spectre.Console](https://github.com/spectreconsole/spectre.console).

Spinners can now be larger than 1-character wide.  Some styles require special characters and emojis that are not supported by Windows conhost by default (these have been tagged with .HasSpecial).  See <https://spectreconsole.net/best-practices>.  For extra compatibility, a few styles return true for .IsAsciiOnly.

If the number of styles seems over-large, I later decided to add the ability to easily make custom spinners, which arguably negates the need for having a great plethora of built-in styles and the complications these introduce.  However, since I put in the work of adding them to a UICatalog entry, I figured I'd show off what I have at this point if there's any interest.

## Pull Request checklist:

- [X] I've named my PR in the form of "Fixes #issue. Terse description."
- [X] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [X] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [X] I ran `dotnet test` before commit
- [X] I have made corresponding changes to the API documentation (using `///` style comments)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any poor grammar or misspellings
- [X] I conducted basic QA to assure all features are working
