### PR TITLE
Fixes #2511. Cannot cycle selections in lists/tables when Numlock is pressed.

### DIFF
--- a/Terminal.Gui/Text/CollectionNavigator.cs
+++ b/Terminal.Gui/Text/CollectionNavigator.cs
@@ -212,14 +212,14 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Returns true if <paramref name="kb"/> is a searchable key
-		/// (e.g. letters, numbers etc) that is valid to pass to to this
+		/// (e.g. letters, numbers etc) that is valid to pass to this
 		/// class for search filtering.
 		/// </summary>
 		/// <param name="kb"></param>
 		/// <returns></returns>
 		public static bool IsCompatibleKey (KeyEvent kb)
 		{
-			return !kb.IsAlt && !kb.IsCapslock && !kb.IsCtrl && !kb.IsScrolllock && !kb.IsNumlock;
+			return !kb.IsAlt && !kb.IsCtrl;
 		}
 	}
 }

--- a/Terminal.Gui/Text/CollectionNavigator.cs
+++ b/Terminal.Gui/Text/CollectionNavigator.cs
@@ -212,7 +212,7 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Returns true if <paramref name="kb"/> is a searchable key
-		/// (e.g. letters, numbers etc) that is valid to pass to this
+		/// (e.g. letters, numbers, etc) that are valid to pass to this
 		/// class for search filtering.
 		/// </summary>
 		/// <param name="kb"></param>

--- a/UnitTests/Text/CollectionNavigatorTests.cs
+++ b/UnitTests/Text/CollectionNavigatorTests.cs
@@ -378,7 +378,7 @@ namespace Terminal.Gui.TextTests {
 		}
 
 		[Fact]
-		public void IsCompatibleKey_Does_Not_Allows_Alt_And_Ctrl_Keys ()
+		public void IsCompatibleKey_Does_Not_Allow_Alt_And_Ctrl_Keys ()
 		{
 			// test all Keys
 			foreach (Key key in Enum.GetValues (typeof (Key))) {

--- a/UnitTests/Text/CollectionNavigatorTests.cs
+++ b/UnitTests/Text/CollectionNavigatorTests.cs
@@ -394,25 +394,13 @@ namespace Terminal.Gui.TextTests {
 				}
 			}
 
-			// test Capslock
+			// test Capslock, Numlock and Scrolllock
 			Assert.True (CollectionNavigator.IsCompatibleKey (new KeyEvent (Key.Null, new KeyModifiers () {
 				Alt = false,
 				Ctrl = false,
 				Shift = false,
 				Capslock = true,
-			})));
-			// test Numlock
-			Assert.True (CollectionNavigator.IsCompatibleKey (new KeyEvent (Key.Null, new KeyModifiers () {
-				Alt = false,
-				Ctrl = false,
-				Shift = false,
 				Numlock = true,
-			})));
-			// test Scrolllock
-			Assert.True (CollectionNavigator.IsCompatibleKey (new KeyEvent (Key.Null, new KeyModifiers () {
-				Alt = false,
-				Ctrl = false,
-				Shift = false,
 				Scrolllock = true,
 			})));
 		}

--- a/UnitTests/Text/CollectionNavigatorTests.cs
+++ b/UnitTests/Text/CollectionNavigatorTests.cs
@@ -376,5 +376,45 @@ namespace Terminal.Gui.TextTests {
 
 			Assert.Equal (-1, current = n.GetNextMatchingItem (current, "x", true));
 		}
+
+		[Fact]
+		public void IsCompatibleKey_Does_Not_Allows_Alt_And_Ctrl_Keys ()
+		{
+			// test all Keys
+			foreach (Key key in Enum.GetValues (typeof (Key))) {
+				var ke = new KeyEvent (key, new KeyModifiers () {
+					Alt = key == Key.AltMask,
+					Ctrl = key == Key.CtrlMask,
+					Shift = key == Key.ShiftMask
+				});
+				if (key == Key.AltMask || key == Key.CtrlMask) {
+					Assert.False (CollectionNavigator.IsCompatibleKey (ke));
+				} else {
+					Assert.True (CollectionNavigator.IsCompatibleKey (ke));
+				}
+			}
+
+			// test Capslock
+			Assert.True (CollectionNavigator.IsCompatibleKey (new KeyEvent (Key.Null, new KeyModifiers () {
+				Alt = false,
+				Ctrl = false,
+				Shift = false,
+				Capslock = true,
+			})));
+			// test Numlock
+			Assert.True (CollectionNavigator.IsCompatibleKey (new KeyEvent (Key.Null, new KeyModifiers () {
+				Alt = false,
+				Ctrl = false,
+				Shift = false,
+				Numlock = true,
+			})));
+			// test Scrolllock
+			Assert.True (CollectionNavigator.IsCompatibleKey (new KeyEvent (Key.Null, new KeyModifiers () {
+				Alt = false,
+				Ctrl = false,
+				Shift = false,
+				Scrolllock = true,
+			})));
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2511 - Include a terse summary of the change or which issue is fixed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
