### PR TITLE
Add Style.ShowHeaders to TableView

### DIFF
--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -262,12 +262,14 @@ namespace Terminal.Gui {
 					line++;
 				}
 
-				RenderHeaderMidline (line, columnsToRender);
-				line++;
-
-				if (Style.ShowHorizontalHeaderUnderline) {
-					RenderHeaderUnderline (line, bounds.Width, columnsToRender);
+				if (!Style.HideHeaders) {
+					RenderHeaderMidline (line, columnsToRender);
 					line++;
+
+					if (Style.ShowHorizontalHeaderUnderline) {
+						RenderHeaderUnderline (line, bounds.Width, columnsToRender);
+						line++;
+					}
 				}
 			}
 
@@ -316,8 +318,11 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		private int GetHeaderHeight ()
 		{
-			if (Style.HideHeaders)
+			if (Style.HideHeaders) {
+				if (Style.ShowHorizontalHeaderOverline)
+					return 1;
 				return 0;
+			}
 
 			int heightRequired = 1;
 
@@ -1583,7 +1588,7 @@ namespace Terminal.Gui {
 
 		private bool ShouldRenderHeaders ()
 		{
-			if (TableIsNullOrInvisible () || Style.HideHeaders)
+			if (TableIsNullOrInvisible ())
 				return false;
 
 			return Style.AlwaysShowHeaders || rowOffset == 0;
@@ -1773,7 +1778,8 @@ namespace Terminal.Gui {
 
 			/// <summary>
 			/// Gets or sets a flag indicating whether to suppress rendering headers of a <see cref="TableView"/>.
-			/// Defaults to false.
+			/// Defaults to false.  ShowHorizontalHeaderOverline may still be used, and AlwaysShowHeaders will
+			/// always show it.
 			/// </summary>
 			public bool HideHeaders { get; set; } = false;
 

--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -315,13 +315,16 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		private int GetHeaderHeight ()
 		{
-			int heightRequired = 1;
-
-			if (Style.ShowHorizontalHeaderOverline)
+			int heightRequired = 0;
+			if (!Style.HideHeaders) {
 				heightRequired++;
 
-			if (Style.ShowHorizontalHeaderUnderline)
-				heightRequired++;
+				if (Style.ShowHorizontalHeaderOverline)
+					heightRequired++;
+
+				if (Style.ShowHorizontalHeaderUnderline)
+					heightRequired++;
+			}
 
 			return heightRequired;
 		}
@@ -1579,7 +1582,7 @@ namespace Terminal.Gui {
 
 		private bool ShouldRenderHeaders ()
 		{
-			if (TableIsNullOrInvisible ())
+			if (TableIsNullOrInvisible () || Style.HideHeaders)
 				return false;
 
 			return Style.AlwaysShowHeaders || rowOffset == 0;
@@ -1771,6 +1774,11 @@ namespace Terminal.Gui {
 			/// When scrolling down always lock the column headers in place as the first row of the table
 			/// </summary>
 			public bool AlwaysShowHeaders { get; set; } = false;
+
+			/// <summary>
+			/// Hide header
+			/// </summary>
+			public bool HideHeaders { get; set; } = false;
 
 			/// <summary>
 			/// True to render a solid line above the headers

--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -1,5 +1,6 @@
 ﻿using NStack;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -315,16 +316,16 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		private int GetHeaderHeight ()
 		{
-			int heightRequired = 0;
-			if (!Style.HideHeaders) {
+			if (Style.HideHeaders)
+				return 0;
+
+			int heightRequired = 1;
+
+			if (Style.ShowHorizontalHeaderOverline)
 				heightRequired++;
 
-				if (Style.ShowHorizontalHeaderOverline)
-					heightRequired++;
-
-				if (Style.ShowHorizontalHeaderUnderline)
-					heightRequired++;
-			}
+			if (Style.ShowHorizontalHeaderUnderline)
+				heightRequired++;
 
 			return heightRequired;
 		}
@@ -1771,14 +1772,15 @@ namespace Terminal.Gui {
 		public class TableStyle {
 
 			/// <summary>
+			/// Gets or sets a flag indicating whether to suppress rendering headers of a <see cref="TableView"/>.
+			/// Defaults to false.
+			/// </summary>
+			public bool HideHeaders { get; set; } = false;
+
+			/// <summary>
 			/// When scrolling down always lock the column headers in place as the first row of the table
 			/// </summary>
 			public bool AlwaysShowHeaders { get; set; } = false;
-
-			/// <summary>
-			/// Hide header
-			/// </summary>
-			public bool HideHeaders { get; set; } = false;
 
 			/// <summary>
 			/// True to render a solid line above the headers

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -16,6 +16,7 @@ namespace UICatalog.Scenarios {
 	[ScenarioCategory ("Top Level Windows")]
 	public class TableEditor : Scenario {
 		TableView tableView;
+		private MenuItem miHideHeaders;
 		private MenuItem miAlwaysShowHeaders;
 		private MenuItem miHeaderOverline;
 		private MenuItem miHeaderMidline;
@@ -55,7 +56,8 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Quit", "", () => Quit()),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
-					miAlwaysShowHeaders = new MenuItem ("_AlwaysShowHeaders", "", () => ToggleAlwaysShowHeader()){Checked = tableView.Style.AlwaysShowHeaders, CheckType = MenuItemCheckStyle.Checked },
+					miHideHeaders = new MenuItem ("_HideHeaders", "", () => ToggleHideHeaders()){Checked = tableView.Style.HideHeaders, CheckType = MenuItemCheckStyle.Checked },
+					miAlwaysShowHeaders = new MenuItem ("_AlwaysShowHeaders", "", () => ToggleAlwaysShowHeaders()){Checked = tableView.Style.AlwaysShowHeaders, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderOverline = new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()){Checked = tableView.Style.ShowHorizontalHeaderOverline, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderMidline = new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()){Checked = tableView.Style.ShowVerticalHeaderLines, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderUnderline = new MenuItem ("_HeaderUnderLine", "", () => ToggleUnderline()){Checked = tableView.Style.ShowHorizontalHeaderUnderline, CheckType = MenuItemCheckStyle.Checked },
@@ -374,7 +376,14 @@ namespace UICatalog.Scenarios {
 			tableView.Update ();
 		}
 
-		private void ToggleAlwaysShowHeader ()
+		private void ToggleHideHeaders ()
+		{
+			miHideHeaders.Checked = !miHideHeaders.Checked;
+			tableView.Style.HideHeaders = (bool)miHideHeaders.Checked;
+			tableView.Update ();
+		}
+
+		private void ToggleAlwaysShowHeaders ()
 		{
 			miAlwaysShowHeaders.Checked = !miAlwaysShowHeaders.Checked;
 			tableView.Style.AlwaysShowHeaders = (bool)miAlwaysShowHeaders.Checked;

--- a/UnitTests/Views/TableViewTests.cs
+++ b/UnitTests/Views/TableViewTests.cs
@@ -456,6 +456,71 @@ namespace Terminal.Gui.ViewsTests {
 		}
 
 		[Fact, AutoInitShutdown]
+		public void TableView_HideHeaders_True_ExactBounds ()
+		{
+			var tv = SetUpMiniTable ();
+
+			// the thing we are testing
+			tv.Style.HideHeaders = true;
+			tv.Style.ShowHorizontalHeaderOverline = false;
+			// width exactly matches the max col widths
+			tv.Bounds = new Rect (0, 0, 5, 1);
+
+			tv.Redraw (tv.Bounds);
+
+			string expected = @"
+│1│2│
+";
+			TestHelpers.AssertDriverContentsAre (expected, output);
+
+			// test borders without headers
+			tv.Style.ShowHorizontalHeaderUnderline = false;
+			tv.Style.ShowHorizontalHeaderOverline = true;
+			// width exactly matches the max col widths
+			tv.Bounds = new Rect (0, 0, 5, 2);
+
+			tv.Redraw (tv.Bounds);
+
+			expected = @"
+┌─┬─┐
+│1│2│
+";
+			TestHelpers.AssertDriverContentsAre (expected, output);
+
+			// test underline is ignored when set to true
+			tv.Style.ShowHorizontalHeaderUnderline = true;
+			// width exactly matches the max col widths
+			tv.Bounds = new Rect (0, 0, 5, 2);
+
+			tv.Redraw (tv.Bounds);
+
+			expected = @"
+┌─┬─┐
+│1│2│
+";
+			TestHelpers.AssertDriverContentsAre (expected, output);
+
+			// test HideHeaders disabling brings back header row
+			tv.Style.HideHeaders = false;
+			tv.Style.ShowHorizontalHeaderUnderline = false;
+			// width exactly matches the max col widths
+			tv.Bounds = new Rect (0, 0, 5, 3);
+
+			tv.Redraw (tv.Bounds);
+
+			expected = @"
+┌─┬─┐
+│A│B│
+│1│2│
+";
+			TestHelpers.AssertDriverContentsAre (expected, output);
+
+			// Shutdown must be called to safely clean up Application if Init has been called
+			Application.Shutdown ();
+		}
+
+
+		[Fact, AutoInitShutdown]
 		public void TableView_ExpandLastColumn_True ()
 		{
 			var tv = SetUpMiniTable ();


### PR DESCRIPTION
Very simple change to allow table headers to be hidden (necessary for e.g., using TableView as a single-dimension ListView split into multiple columns).  I'm also currently looking at methods of making such a use case easier (with options for horizontal or vertical item population and horizontal or vertical scrolling).

## Pull Request checklist:

- [X] I've named my PR in the form of "Fixes #issue. Terse description."
- [X] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [X] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [X] I ran `dotnet test` before commit
- [X] I have made corresponding changes to the API documentation (using `///` style comments)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any poor grammar or misspellings
- [X] I conducted basic QA to assure all features are working
