### PR TITLE
Fix "Border.ForgroundColor" typo

### DIFF
--- a/Terminal.Gui/View/Border.cs
+++ b/Terminal.Gui/View/Border.cs
@@ -44,7 +44,7 @@ namespace Terminal.Gui {
 		public event Action<Border> BorderChanged;
 
 		private BorderStyle _style;
-		private Color _forgroundColor;
+		private Color _foregroundColor;
 		private Color _backgroundColor;
 
 		/// <summary>
@@ -63,10 +63,10 @@ namespace Terminal.Gui {
 		/// Gets or sets the <see cref="Color"/> that draws the outer border color.
 		/// </summary>
 		[JsonInclude, JsonConverter (typeof (ColorJsonConverter))]
-		public Color ForgroundColor {
-			get => _forgroundColor;
+		public Color ForegroundColor {
+			get => _foregroundColor;
 			set {
-				_forgroundColor = value;
+				_foregroundColor = value;
 				OnBorderChanged ();
 			}
 		}

--- a/Terminal.Gui/Views/MessageBox.cs
+++ b/Terminal.Gui/Views/MessageBox.cs
@@ -299,11 +299,11 @@ namespace Terminal.Gui {
 
 			if (useErrorColors) {
 				d.ColorScheme = Colors.Error;
-				//d.Border.ForgroundColor = Colors.Error.Normal.Foreground;
+				//d.Border.ForegroundColor = Colors.Error.Normal.Foreground;
 				//d.Border.BackgroundColor = Colors.Error.Normal.Background;
 			} else {
 				d.ColorScheme = Colors.Dialog;
-				//d.Border.ForgroundColor = Colors.Dialog.Normal.Foreground;
+				//d.Border.ForegroundColor = Colors.Dialog.Normal.Foreground;
 				//d.Border.BackgroundColor = Colors.Dialog.Normal.Background;
 			}
 


### PR DESCRIPTION
## Pull Request checklist:

- [X] I've named my PR in the form of "Fixes #issue. Terse description."
- [X] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [X] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [X] I ran `dotnet test` before commit
- [X] I have made corresponding changes to the API documentation (using `///` style comments)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any poor grammar or misspellings
- [X] I conducted basic QA to assure all features are working
