### PR TITLE
Fixes #2517. ListView EnsureSelectedItemVisible isn't working at load.

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -736,12 +736,21 @@ namespace Terminal.Gui {
 		/// </summary>
 		public void EnsureSelectedItemVisible ()
 		{
-			SuperView?.LayoutSubviews ();
-			if (selected < top) {
-				top = Math.Max (selected, 0);
-			} else if (Frame.Height > 0 && selected >= top + Frame.Height) {
-				top = Math.Max (selected - Frame.Height + 1, 0);
+			if (SuperView?.IsInitialized == true) {
+				if (selected < top) {
+					top = Math.Max (selected, 0);
+				} else if (Frame.Height > 0 && selected >= top + Frame.Height) {
+					top = Math.Max (selected - Frame.Height + 1, 0);
+				}
+				LayoutStarted -= ListView_LayoutStarted;
+			} else {
+				LayoutStarted += ListView_LayoutStarted;
 			}
+		}
+
+		private void ListView_LayoutStarted (object sender, LayoutEventArgs e)
+		{
+			EnsureSelectedItemVisible ();
 		}
 
 		///<inheritdoc/>

--- a/Terminal.Gui/Views/Toplevel.cs
+++ b/Terminal.Gui/Views/Toplevel.cs
@@ -732,7 +732,7 @@ namespace Terminal.Gui {
 			}
 
 			// TODO: v2 - This is a hack to get the StatusBar to be positioned correctly.
-			if (sb != null && ny + top.Frame.Height != superView.Frame.Height - (sb.Visible ? 1 : 0)
+			if (sb != null && !top.Subviews.Contains (sb) && ny + top.Frame.Height != superView.Frame.Height - (sb.Visible ? 1 : 0)
 				&& top.Height is Dim.DimFill && -top.Height.Anchor (0) < 1) {
 
 				top.Height = Dim.Fill (sb.Visible ? 1 : 0);


### PR DESCRIPTION
Fixes #2517 - Even if `IsInitialized` is `true` the frame is still empty and thus is impossible to layout.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
