### PR TITLE
Fixes #2531. Toplevel should redraw only if it's needed.

### DIFF
--- a/Terminal.Gui/Application.cs
+++ b/Terminal.Gui/Application.cs
@@ -999,7 +999,8 @@ namespace Terminal.Gui {
 			if (refreshDriver) {
 				MdiTop?.OnChildLoaded (toplevel);
 				toplevel.OnLoaded ();
-				Redraw (toplevel);
+				toplevel.SetNeedsDisplay ();
+				toplevel.Redraw (toplevel.Bounds);
 				toplevel.PositionCursor ();
 				Driver.Refresh ();
 			}
@@ -1116,13 +1117,6 @@ namespace Terminal.Gui {
 			// gui.cs does no longer process any callbacks. See #1084 for more details:
 			// (https://github.com/gui-cs/Terminal.Gui/issues/1084).
 			SynchronizationContext.SetSynchronizationContext (syncContext: null);
-		}
-
-
-		static void Redraw (View view)
-		{
-			view.Redraw (view.Bounds);
-			Driver.Refresh ();
 		}
 
 		/// <summary>

--- a/Terminal.Gui/View/View.cs
+++ b/Terminal.Gui/View/View.cs
@@ -1807,7 +1807,9 @@ namespace Terminal.Gui {
 				Driver.SetAttribute (GetNormalColor ());
 			}
 
-			Clear (ViewToScreen (bounds));
+			if (SuperView != null) {
+				Clear (ViewToScreen (bounds));
+			}
 
 			// Invoke DrawContentEvent
 			OnDrawContent (bounds);

--- a/Terminal.Gui/Views/Toplevel.cs
+++ b/Terminal.Gui/Views/Toplevel.cs
@@ -765,7 +765,8 @@ namespace Terminal.Gui {
 			}
 
 			if (!_needsDisplay.IsEmpty || _childNeedsDisplay || LayoutNeeded) {
-				Driver.SetAttribute (Enabled ? Colors.Base.Normal : Colors.Base.Disabled);
+				Driver.SetAttribute (GetNormalColor ());
+				Clear (ViewToScreen (bounds));
 				LayoutSubviews ();
 				PositionToplevels ();
 

--- a/Terminal.Gui/Views/Toplevel.cs
+++ b/Terminal.Gui/Views/Toplevel.cs
@@ -787,8 +787,9 @@ namespace Terminal.Gui {
 						view.SetNeedsDisplay (view.Bounds);
 					}
 				}
+
+				base.Redraw (Bounds);
 			}
-			base.Redraw (Bounds);
 		}
 
 		bool OutsideTopFrame (Toplevel top)

--- a/UnitTests/View/ViewTests.cs
+++ b/UnitTests/View/ViewTests.cs
@@ -233,7 +233,7 @@ namespace Terminal.Gui.ViewTests {
 			t.Remove (v);
 			Assert.True (t.Subviews.Count == 0);
 		}
-		
+
 		[Fact]
 		public void Initialized_Event_Comparing_With_Added_Event ()
 		{
@@ -533,8 +533,7 @@ namespace Terminal.Gui.ViewTests {
 					lbl = new Label (text);
 				}
 				Application.Top.Add (lbl);
-				Application.Top.LayoutSubviews ();
-				Application.Top.Redraw (Application.Top.Bounds);
+				Application.Begin (Application.Top);
 
 				// should have the initial text
 				Assert.Equal ('t', driver.Contents [0, 0, 0]);
@@ -558,7 +557,7 @@ namespace Terminal.Gui.ViewTests {
 			var view = new View (rect);
 			var top = Application.Top;
 			top.Add (view);
-			
+
 			Assert.Equal (View.Direction.Forward, view.FocusDirection);
 			view.FocusDirection = View.Direction.Backward;
 			Assert.Equal (View.Direction.Backward, view.FocusDirection);
@@ -623,7 +622,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal (-41, rcol);
 			Assert.Equal (-13, rrow);
 		}
-		
+
 		[Fact]
 		[AutoInitShutdown]
 		public void Visible_Sets_Also_Sets_Subviews ()
@@ -718,7 +717,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal (top1, v1.GetTopSuperView ());
 			Assert.Equal (top2, v2.GetTopSuperView ());
 		}
-		
+
 
 		[Fact, AutoInitShutdown]
 		public void DrawFrame_With_Positive_Positions ()
@@ -919,11 +918,12 @@ namespace Terminal.Gui.ViewTests {
 		public void GetTextFormatterBoundsSize_GetSizeNeededForText_HotKeySpecifier ()
 		{
 			var text = "Say Hello 你";
-			var horizontalView = new View () { 
-				Text = text, 
-				AutoSize = true, 
-				HotKeySpecifier = '_' };
-			
+			var horizontalView = new View () {
+				Text = text,
+				AutoSize = true,
+				HotKeySpecifier = '_'
+			};
+
 			var verticalView = new View () {
 				Text = text,
 				AutoSize = true,
@@ -1010,7 +1010,7 @@ namespace Terminal.Gui.ViewTests {
 └────────────────────────────┘
 ", output);
 		}
-		
+
 		[Fact, AutoInitShutdown]
 		public void DrawContentComplete_Event_Is_Always_Called ()
 		{
@@ -1028,7 +1028,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (viewCalled);
 			Assert.True (tvCalled);
 		}
-		
+
 		[Fact, AutoInitShutdown]
 		public void GetNormalColor_ColorScheme ()
 		{
@@ -1505,7 +1505,7 @@ At 0,0
 			var top = Application.Top;
 
 			top.Add (frame);
-	
+
 			Application.Begin (top);
 
 			top.LayoutComplete += (s, e) => {
@@ -1545,6 +1545,6 @@ At 0,0
 
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 		}
-	
+
 	}
 }

--- a/UnitTests/Views/MenuTests.cs
+++ b/UnitTests/Views/MenuTests.cs
@@ -136,7 +136,7 @@ namespace Terminal.Gui.ViewsTests {
 				if (cancelClosing) {
 					e.Cancel = true;
 					isMenuClosed = false;
-				} else 					isMenuClosed = true;
+				} else isMenuClosed = true;
 			};
 			Application.Top.Add (menu);
 
@@ -318,18 +318,18 @@ Edit
 			Assert.Equal ("_Paste", miCurrent.Title);
 
 			for (int i = 2; i >= -1; i--) {
-				if (i == -1) 					Assert.False (mCurrent.MouseEvent (new MouseEvent () {
-						X = 10,
-						Y = i,
-						Flags = MouseFlags.ReportMousePosition,
-						View = menu
-					}));
-else 					Assert.True (mCurrent.MouseEvent (new MouseEvent () {
-						X = 10,
-						Y = i,
-						Flags = MouseFlags.ReportMousePosition,
-						View = mCurrent
-					}));
+				if (i == -1) Assert.False (mCurrent.MouseEvent (new MouseEvent () {
+					X = 10,
+					Y = i,
+					Flags = MouseFlags.ReportMousePosition,
+					View = menu
+				}));
+				else Assert.True (mCurrent.MouseEvent (new MouseEvent () {
+					X = 10,
+					Y = i,
+					Flags = MouseFlags.ReportMousePosition,
+					View = mCurrent
+				}));
 				Assert.True (menu.IsMenuOpen);
 				if (i == 2) {
 					Assert.Equal ("_Edit", miCurrent.Parent.Title);
@@ -1060,6 +1060,7 @@ else 					Assert.True (mCurrent.MouseEvent (new MouseEvent () {
 			});
 
 			Application.Top.Add (menu);
+			Application.Begin (Application.Top);
 
 			Assert.False (newAction);
 			Assert.False (copyAction);
@@ -1115,7 +1116,7 @@ else 					Assert.True (mCurrent.MouseEvent (new MouseEvent () {
 			public string MenuBarText {
 				get {
 					string txt = string.Empty;
-					foreach (var m in Menus) 
+					foreach (var m in Menus)
 						txt += " " + m.Title.ToString () + " ";
 					return txt;
 				}
@@ -1191,7 +1192,7 @@ else 					Assert.True (mCurrent.MouseEvent (new MouseEvent () {
 			});
 
 			var items = new MenuBarItem [expectedMenu.Menus.Length];
-			for (var i = 0; i < expectedMenu.Menus.Length; i++) 				items [i] = new MenuBarItem (expectedMenu.Menus [i].Title, new MenuItem [] {
+			for (var i = 0; i < expectedMenu.Menus.Length; i++) items [i] = new MenuBarItem (expectedMenu.Menus [i].Title, new MenuItem [] {
 					new MenuItem (expectedMenu.Menus [i].Children [0].Title, "", null)
 				});
 			var menu = new MenuBar (items);
@@ -1474,7 +1475,7 @@ else 					Assert.True (mCurrent.MouseEvent (new MouseEvent () {
 			});
 
 			var items = new MenuBarItem [expectedMenu.Menus.Length];
-			for (var i = 0; i < expectedMenu.Menus.Length; i++) 				items [i] = new MenuBarItem (expectedMenu.Menus [i].Title, expectedMenu.Menus [i].Children.Length > 0
+			for (var i = 0; i < expectedMenu.Menus.Length; i++) items [i] = new MenuBarItem (expectedMenu.Menus [i].Title, expectedMenu.Menus [i].Children.Length > 0
 					? new MenuItem [] {
 						new MenuItem (expectedMenu.Menus [i].Children [0].Title, "", null),
 					}


### PR DESCRIPTION
Fixes #2531 - As @tig stated before `Toplevel` should only redraw if it's needed and only itself and his subviews.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
