### PR TITLE
Fixes #2539. Menu should use Frame instead of DrawFrame.

### DIFF
--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -477,6 +477,9 @@ namespace Terminal.Gui {
 				WantMousePositionReports = host.WantMousePositionReports;
 			}
 
+			BorderFrame.Thickness = new Thickness (1);
+			BorderFrame.BorderStyle = LineStyle.Single;
+
 			if (Application.Current != null) {
 				Application.Current.DrawContentComplete += Current_DrawContentComplete;
 			}
@@ -534,19 +537,14 @@ namespace Terminal.Gui {
 
 		public override void Redraw (Rect bounds)
 		{
-		}
-
-		// Draws the Menu, within the Frame
-		private void Current_DrawContentComplete (object sender, DrawEventArgs e)
-		{
 			if (barItems.Children == null) {
 				return;
 			}
-			var savedClip = Driver.Clip;
+			var savedClip = Application.Driver.Clip;
 			Application.Driver.Clip = Application.Top.Frame;
 
 			Driver.SetAttribute (GetNormalColor ());
-			DrawFrame (Bounds, padding: 0, fill: true);
+			OnDrawFrames (Frame);
 
 			for (int i = Bounds.Y; i < barItems.Children.Length; i++) {
 				if (i < 0)
@@ -555,10 +553,11 @@ namespace Terminal.Gui {
 				Driver.SetAttribute (item == null ? GetNormalColor ()
 					: i == current ? ColorScheme.Focus : GetNormalColor ());
 				if (item == null) {
-					Move (0, i + 1);
+					Move (-1, i);
 					Driver.AddRune (Driver.LeftTee);
-				} else if (Frame.X + 1 < Driver.Cols)
-					Move (1, i + 1);
+				} else if (Frame.X < Driver.Cols) {
+					Move (0, i);
+				}
 
 				Driver.SetAttribute (DetermineColorSchemeFor (item, i));
 				for (int p = Bounds.X; p < Frame.Width - 2; p++) { // This - 2 is for the border
@@ -576,8 +575,8 @@ namespace Terminal.Gui {
 				}
 
 				if (item == null) {
-					if (SuperView?.Frame.Right - Frame.X > Frame.Width - 1) {
-						Move (Frame.Width - 1, i + 1);
+					if (SuperView?.Frame.Right - Frame.X > Frame.Width) {
+						Move (Frame.Width - 2, i);
 						Driver.AddRune (Driver.RightTee);
 					}
 					continue;
@@ -604,9 +603,9 @@ namespace Terminal.Gui {
 					textToDraw = item.Title;
 				}
 
-				ViewToScreen (2, i + 1, out int vtsCol, out _, false);
+				ViewToScreen (0, i, out int vtsCol, out _, false);
 				if (vtsCol < Driver.Cols) {
-					Move (2, i + 1);
+					Move (1, i);
 					if (!item.IsEnabled ()) {
 						DrawHotString (textToDraw, ColorScheme.Disabled, ColorScheme.Disabled);
 					} else if (i == 0 && host.UseSubMenusSingleFrame && item.Parent.Parent != null) {
@@ -616,7 +615,7 @@ namespace Terminal.Gui {
 							Text = textToDraw
 						};
 						// The -3 is left/right border + one space (not sure what for)
-						tf.Draw (ViewToScreen (new Rect (2, i + 1, Frame.Width - 3, 1)),
+						tf.Draw (ViewToScreen (new Rect (1, i, Frame.Width - 3, 1)),
 							i == current ? ColorScheme.Focus : GetNormalColor (),
 							i == current ? ColorScheme.HotFocus : ColorScheme.HotNormal,
 							SuperView == null ? default : SuperView.ViewToScreen (SuperView.Bounds));
@@ -628,16 +627,16 @@ namespace Terminal.Gui {
 
 					// The help string
 					var l = item.ShortcutTag.ConsoleWidth == 0 ? item.Help.ConsoleWidth : item.Help.ConsoleWidth + item.ShortcutTag.ConsoleWidth + 2;
-					var col = Frame.Width - l - 2;
-					ViewToScreen (col, i + 1, out vtsCol, out _, false);
+					var col = Frame.Width - l - 3;
+					ViewToScreen (col, i, out vtsCol, out _, false);
 					if (vtsCol < Driver.Cols) {
-						Move (col, 1 + i);
+						Move (col, i);
 						Driver.AddStr (item.Help);
 
 						// The shortcut tag string
 						if (!item.ShortcutTag.IsEmpty) {
 							l = item.ShortcutTag.ConsoleWidth;
-							Move (Frame.Width - l - 2, 1 + i);
+							Move (Frame.Width - l - 3, i);
 							Driver.AddStr (item.ShortcutTag);
 						}
 					}
@@ -646,6 +645,11 @@ namespace Terminal.Gui {
 			Driver.Clip = savedClip;
 
 			PositionCursor ();
+		}
+
+		private void Current_DrawContentComplete (object sender, DrawEventArgs e)
+		{
+			Redraw (e.Rect);
 		}
 
 		public override void PositionCursor ()
@@ -692,7 +696,7 @@ namespace Terminal.Gui {
 		public override bool ProcessHotKey (KeyEvent keyEvent)
 		{
 			// To ncurses simulate a AltMask key pressing Alt+Space because
-			// it can�t detect an alone special key down was pressed.
+			// it can't detect an alone special key down was pressed.
 			if (keyEvent.IsAlt && keyEvent.Key == Key.AltMask) {
 				OnKeyDown (keyEvent);
 				return true;

--- a/UnitTests/Views/MenuTests.cs
+++ b/UnitTests/Views/MenuTests.cs
@@ -1818,5 +1818,31 @@ Edit
 			mi.CheckType = MenuItemCheckStyle.Radio;
 			Assert.Throws<InvalidOperationException> (mi.ToggleChecked);
 		}
+
+
+		[Fact, AutoInitShutdown]
+		public void Menu_With_Separator ()
+		{
+			var menu = new MenuBar (new MenuBarItem [] {
+				new MenuBarItem("File",new MenuItem [] {
+					new MenuItem("_Open", "Open a file", () => { }, null, null, Key.CtrlMask | Key.O),
+					null,
+					new MenuItem("_Quit","",null)
+				})
+			});
+
+			Application.Top.Add (menu);
+			Application.Begin (Application.Top);
+
+			menu.OpenMenu ();
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+ File                         
+┌────────────────────────────┐
+│ Open   Open a file  Ctrl+O │
+├────────────────────────────┤
+│ Quit                       │
+└────────────────────────────┘", output);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2539 - Include a terse summary of the change or which issue is fixed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
