### PR TITLE
Fixes #2546 Fix Snake for new lengths in LineCanvas

### DIFF
--- a/UICatalog/Scenarios/Snake.cs
+++ b/UICatalog/Scenarios/Snake.cs
@@ -87,10 +87,10 @@ namespace UICatalog.Scenarios {
 
 				var canvas = new LineCanvas ();
 
-				canvas.AddLine (new Point (0, 0), State.Width - 1, Orientation.Horizontal, LineStyle.Double);
-				canvas.AddLine (new Point (0, 0), State.Height - 1, Orientation.Vertical, LineStyle.Double);
-				canvas.AddLine (new Point (0, State.Height - 1), State.Width - 1, Orientation.Horizontal, LineStyle.Double);
-				canvas.AddLine (new Point (State.Width - 1, 0), State.Height - 1, Orientation.Vertical, LineStyle.Double);
+				canvas.AddLine (new Point (0, 0), State.Width, Orientation.Horizontal, LineStyle.Double);
+				canvas.AddLine (new Point (0, 0), State.Height, Orientation.Vertical, LineStyle.Double);
+				canvas.AddLine (new Point (0, State.Height - 1), State.Width, Orientation.Horizontal, LineStyle.Double);
+				canvas.AddLine (new Point (State.Width - 1, 0), State.Height, Orientation.Vertical, LineStyle.Double);
 
 				for (int i = 1; i < State.Snake.Count; i++) {
 
@@ -99,8 +99,8 @@ namespace UICatalog.Scenarios {
 
 					var orientation = pt1.X == pt2.X ? Orientation.Vertical : Orientation.Horizontal;
 					var length = orientation == Orientation.Horizontal
-						? pt1.X > pt2.X ? 1 : -1
-						: pt1.Y > pt2.Y ? 1 : -1;
+						? pt1.X > pt2.X ? 2 : -2
+						: pt1.Y > pt2.Y ? 2 : -2;
 
 					canvas.AddLine (
 						pt2,


### PR DESCRIPTION
Fixes #2546 - All lengths of LineCanvas are now 1 more than previously coded.  This increases the lengths of lines to match the new design for the Snake scenario.


## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
