### PR TITLE
Fixes #2550 - Fix LineDrawing scenario 

### DIFF
--- a/UICatalog/Scenarios/LineDrawing.cs
+++ b/UICatalog/Scenarios/LineDrawing.cs
@@ -27,7 +27,7 @@ namespace UICatalog.Scenarios {
 			};
 
 			tools.ColorChanged += (c) => canvas.SetColor (c);
-			tools.SetStyle += (b) => canvas.BorderStyle = b;
+			tools.SetStyle += (b) => canvas.LineStyle = b;
 
 			Win.Add (canvas);
 			Win.Add (tools);
@@ -52,17 +52,19 @@ namespace UICatalog.Scenarios {
 			{
 				grid = new LineCanvas ();
 
-				grid.AddLine (new Point (0, 0), int.MaxValue, Orientation.Vertical, LineStyle.Single);
-				grid.AddLine (new Point (0, 0), width, Orientation.Horizontal, LineStyle.Single);
-				grid.AddLine (new Point (width, 0), int.MaxValue, Orientation.Vertical, LineStyle.Single);
+				int maxHeight = 10000;
 
-				grid.AddLine (new Point (0, 2), width, Orientation.Horizontal, LineStyle.Single);
+				grid.AddLine (new Point (0, 0), maxHeight, Orientation.Vertical, LineStyle.Single);
+				grid.AddLine (new Point (0, 0), width+1, Orientation.Horizontal, LineStyle.Single);
+				grid.AddLine (new Point (width, 0), maxHeight, Orientation.Vertical, LineStyle.Single);
 
-				grid.AddLine (new Point (2, 0), int.MaxValue, Orientation.Vertical, LineStyle.Single);
-				grid.AddLine (new Point (4, 0), int.MaxValue, Orientation.Vertical, LineStyle.Single);
-				grid.AddLine (new Point (6, 0), int.MaxValue, Orientation.Vertical, LineStyle.Single);
+				grid.AddLine (new Point (0, 2), width + 1, Orientation.Horizontal, LineStyle.Single);
 
-				grid.AddLine (new Point (0, 4), width, Orientation.Horizontal, LineStyle.Single);
+				grid.AddLine (new Point (2, 0), maxHeight, Orientation.Vertical, LineStyle.Single);
+				grid.AddLine (new Point (4, 0), maxHeight, Orientation.Vertical, LineStyle.Single);
+				grid.AddLine (new Point (6, 0), maxHeight, Orientation.Vertical, LineStyle.Single);
+
+				grid.AddLine (new Point (0, 4), width + 1, Orientation.Horizontal, LineStyle.Single);
 			}
 			public override void Redraw (Rect bounds)
 			{
@@ -128,6 +130,7 @@ namespace UICatalog.Scenarios {
 			int currentColor;
 
 			Point? currentLineStart = null;
+			public LineStyle LineStyle { get; set; }
 
 			public DrawingArea ()
 			{
@@ -182,11 +185,19 @@ namespace UICatalog.Scenarios {
 							length = end.X - start.X;
 						}
 
+						if(length > 0) {
+							length++;
+						}
+						else {
+							length--;
+						}
+						
+
 						canvases [currentColor].AddLine (
 							start,
 							length,
 							orientation,
-							BorderStyle);
+							LineStyle);
 
 						currentLineStart = null;
 						SetNeedsDisplay ();


### PR DESCRIPTION
Fixes #2550 LineDrawing:

- Clicking a line style no longer magically creates a border on the canvas!
- All line lengths now match the new API expectations (1 longer)
- Switch to 10,000 height instead of int.MaxValue for tools pane*

\* There is a TODO around `Dictionary<Point, Rune> GetMap (Rect inArea)` auto calculating its own line area.  If this change happens in future then it means no longer using max value and trusting clip to cut off at a sensible place.

![line-drawing-fixed](https://user-images.githubusercontent.com/31306100/232181511-e986f1f4-746d-4893-9ff2-32300db9cb8e.gif)
_After applying fixes_

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
