### PR TITLE
Fixes #2551 Adds ShowHorizontalBottomline

### DIFF
--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -278,8 +278,17 @@ namespace Terminal.Gui {
 				var rowToRender = RowOffset + (line - headerLinesConsumed);
 
 				//if we have run off the end of the table
-				if (TableIsNullOrInvisible () || rowToRender >= Table.Rows.Count || rowToRender < 0)
+				if (TableIsNullOrInvisible () || rowToRender < 0)
 					continue;
+
+				// No more data
+				if(rowToRender >= Table.Rows.Count) {
+
+					if(rowToRender == Table.Rows.Count && Style.ShowHorizontalBottomline) {
+						RenderBottomLine (line, bounds.Width, columnsToRender);
+					}
+					continue;
+				}
 
 				RenderRow (line, rowToRender, columnsToRender);
 			}
@@ -473,6 +482,43 @@ namespace Terminal.Gui {
 				AddRuneAt (Driver, c, row, rune);
 			}
 
+		}
+
+		private void RenderBottomLine (int row, int availableWidth, ColumnToRender [] columnsToRender)
+		{
+			// Renders a line at the bottom of the table after all the data like:
+			// └─────────────────────────────────┴──────────┴──────┴──────────┴────────┴────────────────────────────────────────────┘
+
+			for (int c = 0; c < availableWidth; c++) {
+
+				// Start by assuming we just draw a straight line the
+				// whole way but update to instead draw BottomTee / Corner etc
+				var rune = Driver.HLine;
+
+				if (Style.ShowVerticalCellLines) {
+					if (c == 0) {
+						// for first character render line
+						rune = Driver.LLCorner;
+
+					}
+					// if the next column is the start of a header
+					else if (columnsToRender.Any (r => r.X == c + 1)) {
+						rune =  Driver.BottomTee;
+					} else if (c == availableWidth - 1) {
+
+						// for the last character in the table
+						rune = Driver.LRCorner;
+
+					}
+					  // if the next console column is the lastcolumns end
+					  else if (Style.ExpandLastColumn == false &&
+							  columnsToRender.Any (r => r.IsVeryLast && r.X + r.Width - 1 == c)) {
+						rune = Driver.BottomTee;
+					}
+				}
+
+				AddRuneAt (Driver, c, row, rune);
+			}
 		}
 		private void RenderRow (int row, int rowToRender, ColumnToRender [] columnsToRender)
 		{
@@ -1786,6 +1832,13 @@ namespace Terminal.Gui {
 			/// Defaults to true
 			/// </summary>
 			public bool ShowHorizontalScrollIndicators { get; set; } = true;
+
+			
+			/// <summary>
+			/// Gets or sets a flag indicating whether there should be a horizontal line after all the data
+			/// in the table. Defaults to <see langword="false"/>.
+			/// </summary>
+			public bool ShowHorizontalBottomline { get; set; } = false;
 
 			/// <summary>
 			/// True to invert the colors of the first symbol of the selected cell in the <see cref="TableView"/>.

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -27,6 +27,7 @@ namespace UICatalog.Scenarios {
 		private MenuItem miSmoothScrolling;
 		private MenuItem miAlternatingColors;
 		private MenuItem miCursor;
+		private MenuItem miBottomline;
 
 		ColorScheme redColorScheme;
 		ColorScheme redColorSchemeAlt;
@@ -59,6 +60,7 @@ namespace UICatalog.Scenarios {
 					miHeaderOverline = new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()){Checked = tableView.Style.ShowHorizontalHeaderOverline, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderMidline = new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()){Checked = tableView.Style.ShowVerticalHeaderLines, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderUnderline = new MenuItem ("_HeaderUnderLine", "", () => ToggleUnderline()){Checked = tableView.Style.ShowHorizontalHeaderUnderline, CheckType = MenuItemCheckStyle.Checked },
+					miBottomline = new MenuItem ("_BottomLine", "", () => ToggleBottomline()){Checked = tableView.Style.ShowHorizontalBottomline, CheckType = MenuItemCheckStyle.Checked },
 					miShowHorizontalScrollIndicators = new MenuItem ("_HorizontalScrollIndicators", "", () => ToggleHorizontalScrollIndicators()){Checked = tableView.Style.ShowHorizontalScrollIndicators, CheckType = MenuItemCheckStyle.Checked },
 					miFullRowSelect =new MenuItem ("_FullRowSelect", "", () => ToggleFullRowSelect()){Checked = tableView.FullRowSelect, CheckType = MenuItemCheckStyle.Checked },
 					miCellLines =new MenuItem ("_CellLines", "", () => ToggleCellLines()){Checked = tableView.Style.ShowVerticalCellLines, CheckType = MenuItemCheckStyle.Checked },
@@ -395,6 +397,12 @@ namespace UICatalog.Scenarios {
 		{
 			miHeaderUnderline.Checked = !miHeaderUnderline.Checked;
 			tableView.Style.ShowHorizontalHeaderUnderline = (bool)miHeaderUnderline.Checked;
+			tableView.Update ();
+		}
+		private void ToggleBottomline()
+		{
+			miBottomline.Checked = !miBottomline.Checked;
+			tableView.Style.ShowHorizontalBottomline = (bool)miBottomline.Checked;
 			tableView.Update ();
 		}
 		private void ToggleHorizontalScrollIndicators ()

--- a/UnitTests/Views/TableViewTests.cs
+++ b/UnitTests/Views/TableViewTests.cs
@@ -1991,6 +1991,68 @@ namespace Terminal.Gui.ViewsTests {
 
 		}
 
+
+		[Fact, AutoInitShutdown]
+		public void ShowHorizontalBottomLine_WithVerticalCellLines ()
+		{
+			var tableView = GetABCDEFTableView(out _);
+			tableView.BeginInit (); tableView.EndInit ();
+
+			tableView.ColorScheme = Colors.TopLevel;
+
+			// 3 columns are visibile
+			tableView.Bounds = new Rect (0, 0, 7, 5);
+			tableView.Style.ShowHorizontalHeaderUnderline = true;
+			tableView.Style.ShowHorizontalHeaderOverline = false;
+			tableView.Style.AlwaysShowHeaders = true;
+			tableView.Style.SmoothHorizontalScrolling = true;
+			tableView.Style.ShowHorizontalBottomline = true;
+						
+			tableView.Redraw (tableView.Bounds);
+
+			// user can only scroll right so sees right indicator
+			// Because first column in table is A
+			string expected =
+				@"
+│A│B│C│
+├─┼─┼─►
+│1│2│3│
+└─┴─┴─┘";
+
+			TestHelpers.AssertDriverContentsAre (expected, output);
+		}
+		[Fact, AutoInitShutdown]
+		public void ShowHorizontalBottomLine_NoCellLines ()
+		{
+			var tableView = GetABCDEFTableView (out _);
+			tableView.BeginInit (); tableView.EndInit ();
+
+			tableView.ColorScheme = Colors.TopLevel;
+
+			// 3 columns are visibile
+			tableView.Bounds = new Rect (0, 0, 7, 5);
+			tableView.Style.ShowHorizontalHeaderUnderline = true;
+			tableView.Style.ShowHorizontalHeaderOverline = false;
+			tableView.Style.AlwaysShowHeaders = true;
+			tableView.Style.SmoothHorizontalScrolling = true;
+			tableView.Style.ShowHorizontalBottomline = true;
+			tableView.Style.ShowVerticalCellLines = false;
+
+			tableView.Redraw (tableView.Bounds);
+
+			// user can only scroll right so sees right indicator
+			// Because first column in table is A
+			string expected =
+				@"
+│A│B│C│
+└─┴─┴─►
+ 1 2 3
+───────";
+
+			TestHelpers.AssertDriverContentsAre (expected, output);
+		}
+
+
 		/// <summary>
 		/// Builds a simple table of string columns with the requested number of columns and rows
 		/// </summary>


### PR DESCRIPTION
Fixes #2551 - Adds ability to have a horizontal line at the bottom of a `TableView` after the data.

I know this adds more line drawing code to `TableView` that might one day disapear into `LineCanvas` but I don't think we are ready to port to pure `LineCanvas` yet.  Therefore this PR follows the established approach in `TableView`

If the full table is visible then the bottom line works nicely.  If a large table is present no bottom line is rendered (because there is more data available).

In `TableView` you scroll by moving the active cell (or using the mouse wheel).  You cannot move the active cell to the 'Bottomline' or Headers.  Therefore for large tables you will only see the Bottomline if you mouse wheel scroll.

![bottom-line](https://user-images.githubusercontent.com/31306100/232184389-60845b95-48f5-4620-9d86-0791feb82c41.gif)
_Toggling the Bottomline style in TableEditor Scenario_


## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
