### PR TITLE
Fixes #2554 FileDialog collection navigator now works on all fields

### DIFF
--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -546,7 +546,9 @@ namespace Terminal.Gui {
 				.Table
 				.Rows
 				.Cast<DataRow> ()
-				.Select ((o, idx) => style.GetRepresentation (o [0]))
+				.Select ((o, idx) => col == 0 ? 
+					RowToStats(idx).FileSystemInfo.Name :
+					style.GetRepresentation (o [0])?.TrimStart('.'))
 				.ToArray ();
 
 			collectionNavigator = new CollectionNavigator (collection);

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -537,13 +537,16 @@ namespace Terminal.Gui {
 
 		private void UpdateCollectionNavigator ()
 		{
+			tableView.EnsureValidSelection ();
+			var col = tableView.SelectedColumn;
+			var style = tableView.Style.GetColumnStyleIfAny (tableView.Table.Columns [col]);
+
 
 			var collection = tableView
 				.Table
 				.Rows
 				.Cast<DataRow> ()
-				.Select ((o, idx) => RowToStats (idx))
-				.Select (s => s.FileSystemInfo.Name)
+				.Select ((o, idx) => style.GetRepresentation (o [0]))
 				.ToArray ();
 
 			collectionNavigator = new CollectionNavigator (collection);
@@ -909,6 +912,10 @@ namespace Terminal.Gui {
 			} finally {
 
 				this.pushingState = false;
+			}
+
+			if (obj.NewCol != obj.OldCol) {
+				UpdateCollectionNavigator ();
 			}
 		}
 


### PR DESCRIPTION
Fixes #2554 - In FileDialog when pressing a alphanumerical key the selection cycles to the next item beginning with that letter in the selected column.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
