### PR TITLE
Make DataTable public in DataTableSource

### DIFF
--- a/Terminal.Gui/Views/TableView/DataTableSource.cs
+++ b/Terminal.Gui/Views/TableView/DataTableSource.cs
@@ -5,11 +5,14 @@ namespace Terminal.Gui {
 	/// <summary>
 	/// <see cref="ITableSource"/> implementation that wraps 
 	/// a <see cref="System.Data.DataTable"/>.  This class is
-	/// mutable: changes are permitted to the wrapped <see cref="DataTable"/>.
+	/// mutable: changes are permitted to the wrapped <see cref="System.Data.DataTable"/>.
 	/// </summary>
 	public class DataTableSource : ITableSource
 	{
-		private readonly DataTable table;
+		/// <summary>
+		/// The data table this source wraps.
+		/// </summary>
+		public DataTable DataTable { get; private set; }
 
 		/// <summary>
 		/// Creates a new instance based on the data in <paramref name="table"/>.
@@ -17,19 +20,19 @@ namespace Terminal.Gui {
 		/// <param name="table"></param>
 		public DataTableSource(DataTable table)
 		{
-			this.table = table;
+			this.DataTable = table;
 		}
 
 		/// <inheritdoc/>
-		public object this [int row, int col] => table.Rows[row][col];
+		public object this [int row, int col] => DataTable.Rows[row][col];
 
 		/// <inheritdoc/>
-		public int Rows => table.Rows.Count;
+		public int Rows => DataTable.Rows.Count;
 
 		/// <inheritdoc/>
-		public int Columns => table.Columns.Count;
+		public int Columns => DataTable.Columns.Count;
 
 		/// <inheritdoc/>
-		public string [] ColumnNames => table.Columns.Cast<DataColumn>().Select (c => c.ColumnName).ToArray ();
+		public string [] ColumnNames => DataTable.Columns.Cast<DataColumn>().Select (c => c.ColumnName).ToArray ();
 	}
 }


### PR DESCRIPTION
This is a small quality of life change that makes porting old code to 2.0 easier too.

In 1.0 the user could do:

```csharp
DataTable dt = myTableView.Table;
```

But in `v2_develop` there is no way to get back to the `DataTable` if your code didn't store it.  This change lets you do the (somewhat hacky) thing of:

```csharp
DataTable dt = ((DataTableSource)myTableView.Table).DataTable;
```
