### PR TITLE
Fixes #2601 - Adds ability to filter TreeView branches/leaves

### DIFF
--- a/Terminal.Gui/Views/ITreeViewFilter.cs
+++ b/Terminal.Gui/Views/ITreeViewFilter.cs
@@ -1,0 +1,14 @@
+namespace Terminal.Gui {
+
+	/// <summary>
+	/// Provides filtering for a <see cref="TreeView"/>.
+	/// </summary>
+	public interface ITreeViewFilter<T> where T : class {
+
+		/// <summary>
+		/// Return <see langword="true"/> if the <paramref name="model"/> should
+		/// be included in the tree.
+		/// </summary>
+		bool IsMatch (T model);
+	}
+}

--- a/Terminal.Gui/Views/TreeViewTextFilter.cs
+++ b/Terminal.Gui/Views/TreeViewTextFilter.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace Terminal.Gui {
+
+	/// <summary>
+	/// <see cref="ITreeViewFilter{T}"/> implementation which searches the
+	/// <see cref="TreeView{T}.AspectGetter"/> of the model for the given
+	/// <see cref="Text"/>.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class TreeViewTextFilter<T> : ITreeViewFilter<T> where T : class {
+		readonly TreeView<T> _forTree;
+
+		/// <summary>
+		/// Creates a new instance of the filter for use with <paramref name="forTree"/>.
+		/// Set <see cref="Text"/> to begin filtering.
+		/// </summary>
+		/// <param name="forTree"></param>
+		/// <exception cref="ArgumentNullException"></exception>
+		public TreeViewTextFilter (TreeView<T> forTree)
+		{
+			_forTree = forTree ?? throw new ArgumentNullException (nameof (forTree));
+		}
+
+		/// <summary>
+		/// The case sensitivity of the search match. 
+		/// Defaults to <see cref="StringComparison.OrdinalIgnoreCase"/>.
+		/// </summary>
+		public StringComparison Comparer { get; set; } = StringComparison.OrdinalIgnoreCase;
+		private string text;
+
+		/// <summary>
+		/// The text that will be searched for in the <see cref="TreeView{T}"/>
+		/// </summary>
+		public string Text {
+			get { return text; }
+			set {
+				text = value;
+				RefreshTreeView ();
+			}
+		}
+
+		private void RefreshTreeView ()
+		{
+			_forTree.InvalidateLineMap ();
+			_forTree.SetNeedsDisplay ();
+		}
+
+		/// <summary>
+		/// Returns <typeparamref name="T"/> if there is no <see cref="Text"/> or
+		/// the text matches the <see cref="TreeView{T}.AspectGetter"/> of the
+		/// <paramref name="model"/>.
+		/// </summary>
+		/// <param name="model"></param>
+		/// <returns></returns>
+		public bool IsMatch (T model)
+		{
+			if (string.IsNullOrWhiteSpace (Text)) {
+				return true;
+			}
+
+			return _forTree.AspectGetter (model)?.IndexOf (Text, Comparer) != -1;
+		}
+	}
+}

--- a/UICatalog/Scenarios/ClassExplorer.cs
+++ b/UICatalog/Scenarios/ClassExplorer.cs
@@ -84,9 +84,28 @@ namespace UICatalog.Scenarios {
 
 			treeView = new TreeView<object> () {
 				X = 0,
-				Y = 0,
+				Y = 1,
 				Width = Dim.Percent (50),
 				Height = Dim.Fill (),
+			};
+
+			var lblSearch = new Label("Search");
+			var tfSearch = new TextField(){
+				Width = 20,
+				X = Pos.Right(lblSearch),
+			};
+
+			Win.Add(lblSearch);
+			Win.Add(tfSearch);
+
+			var filter = new TreeViewTextFilter<object>(treeView);
+			treeView.Filter = filter;
+			tfSearch.TextChanged += (s)=>{
+				filter.Text = tfSearch.Text.ToString();
+				if(treeView.SelectedObject != null)
+				{
+					treeView.EnsureVisible(treeView.SelectedObject);
+				}
 			};
 
 			treeView.AddObjects (AppDomain.CurrentDomain.GetAssemblies ());

--- a/UnitTests/Views/TreeViewTests.cs
+++ b/UnitTests/Views/TreeViewTests.cs
@@ -909,6 +909,74 @@ namespace Terminal.Gui.ViewTests {
 		}
 
 		[Fact, AutoInitShutdown]
+		public void TestTreeView_Filter ()
+		{
+			var tv = new TreeView { Width = 20, Height = 10 };
+
+			var n1 = new TreeNode ("root one");
+			var n1_1 = new TreeNode ("leaf 1");
+			var n1_2 = new TreeNode ("leaf 2");
+			n1.Children.Add (n1_1);
+			n1.Children.Add (n1_2);
+
+			var n2 = new TreeNode ("root two");
+			tv.AddObject (n1);
+			tv.AddObject (n2);
+			tv.Expand (n1);
+
+			tv.ColorScheme = new ColorScheme ();
+			tv.Redraw (tv.Bounds);
+
+			// Normal drawing of the tree view
+			TestHelpers.AssertDriverContentsAre (
+@"
+├-root one
+│ ├─leaf 1
+│ └─leaf 2
+└─root two
+", output);
+			var filter = new TreeViewTextFilter<ITreeNode> (tv);
+			tv.Filter = filter;
+
+			// matches nothing
+			filter.Text = "asdfjhasdf";
+			tv.Redraw (tv.Bounds);
+			// Normal drawing of the tree view
+			TestHelpers.AssertDriverContentsAre (
+@"", output);
+
+
+			// Matches everything
+			filter.Text = "root";
+			tv.Redraw (tv.Bounds);
+			TestHelpers.AssertDriverContentsAre (
+@"
+├-root one
+│ ├─leaf 1
+│ └─leaf 2
+└─root two
+", output);
+			// Matches 2 leaf nodes
+			filter.Text = "leaf";
+			tv.Redraw (tv.Bounds);
+			TestHelpers.AssertDriverContentsAre (
+@"
+├-root one
+│ ├─leaf 1
+│ └─leaf 2
+", output);
+
+			// Matches 1 leaf nodes
+			filter.Text = "leaf 1";
+			tv.Redraw (tv.Bounds);
+			TestHelpers.AssertDriverContentsAre (
+@"
+├-root one
+│ ├─leaf 1
+", output);
+		}
+
+		[Fact, AutoInitShutdown]
 		public void DesiredCursorVisibility_MultiSelect ()
 		{
 			var tv = new TreeView { Width = 20, Height = 10 };


### PR DESCRIPTION
Fixes #2601 - Adds ability to filter TreeView branches/leaves (e.g. free text search).

I've created this targeting `develop` as it has quite a small footprint and its a really nice to have core feature I think.

It should be pretty easy to cherry pick to `v2_develop`

Because a tree is hierarchical its important to consider whether a filter matches the parent or child too.  I went for greatest matching so:

- If a branch matches then all sub branches/leaves show even if they don't match the filter
- If a leaf/branch matches all its parents are automatically shown (to expose the matching child)

As with all things in `TableView` it is only the expanded nodes that get processed.  If a node is not expanded its children are unknown (so not considered for matching).  This is because of how the table builds itself as the user expands rather than loading everything up front (which can be impossible for some data structures - e.g. file system).

![filter](https://user-images.githubusercontent.com/31306100/236625763-53f95e4e-995c-4816-9d74-5b650f6c6bc9.gif)

Draft as now so I can write some tests

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
