### PR TITLE
Some UICatalog scenario code style fixes

### DIFF
--- a/UICatalog/Scenarios/ASCIICustomButton.cs
+++ b/UICatalog/Scenarios/ASCIICustomButton.cs
@@ -7,34 +7,34 @@ namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "ASCIICustomButtonTest", Description: "ASCIICustomButton sample")]
 	[ScenarioCategory ("Controls")]
 	public class ASCIICustomButtonTest : Scenario {
-		private static bool smallerWindow;
-		private ScrollViewTestWindow scrollViewTestWindow;
-		private MenuItem miSmallerWindow;
+		private static bool _smallerWindow;
+		private ScrollViewTestWindow _scrollViewTestWindow;
+		private MenuItem _miSmallerWindow;
 
 		public override void Init ()
 		{
 			Application.Init ();
-			scrollViewTestWindow = new ScrollViewTestWindow ();
+			_scrollViewTestWindow = new ScrollViewTestWindow ();
 			var menu = new MenuBar (new MenuBarItem [] {
 				new MenuBarItem("Window Size", new MenuItem [] {
-					miSmallerWindow = new MenuItem ("Smaller Window", "", ChangeWindowSize) {
+					_miSmallerWindow = new MenuItem ("Smaller Window", "", ChangeWindowSize) {
 						CheckType = MenuItemCheckStyle.Checked
 					},
 					null,
 					new MenuItem("Quit", "",() => Application.RequestStop(),null,null, Application.QuitKey)
 				})
 			});
-			Application.Top.Add (menu, scrollViewTestWindow);
+			Application.Top.Add (menu, _scrollViewTestWindow);
 			Application.Run ();
 		}
 
 		private void ChangeWindowSize ()
 		{
-			smallerWindow = (bool)(miSmallerWindow.Checked = !miSmallerWindow.Checked);
-			scrollViewTestWindow.Dispose ();
-			Application.Top.Remove (scrollViewTestWindow);
-			scrollViewTestWindow = new ScrollViewTestWindow ();
-			Application.Top.Add (scrollViewTestWindow);
+			_smallerWindow = (bool)(_miSmallerWindow.Checked = !_miSmallerWindow.Checked);
+			_scrollViewTestWindow.Dispose ();
+			Application.Top.Remove (_scrollViewTestWindow);
+			_scrollViewTestWindow = new ScrollViewTestWindow ();
+			Application.Top.Add (_scrollViewTestWindow);
 		}
 
 		public override void Run ()
@@ -162,7 +162,7 @@ namespace UICatalog.Scenarios {
 				Title = "ScrollViewTestWindow";
 
 				Label titleLabel = null;
-				if (smallerWindow) {
+				if (_smallerWindow) {
 					Width = 80;
 					Height = 25;
 
@@ -224,7 +224,7 @@ namespace UICatalog.Scenarios {
 					pages++;
 
 				scrollView.ContentSize = new Size (25, pages * BUTTONS_ON_PAGE * BUTTON_HEIGHT);
-				if (smallerWindow) {
+				if (_smallerWindow) {
 					Add (scrollView);
 				} else {
 					Add (titleLabel, scrollView);

--- a/UICatalog/Scenarios/ClassExplorer.cs
+++ b/UICatalog/Scenarios/ClassExplorer.cs
@@ -11,9 +11,9 @@ namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "Class Explorer", Description: "Tree view explorer for classes by namespace based on TreeView.")]
 	[ScenarioCategory ("Controls"), ScenarioCategory ("TreeView")]
 	public class ClassExplorer : Scenario {
-		private TreeView<object> treeView;
-		private TextView textView;
-		private MenuItem miShowPrivate;
+		private TreeView<object> _treeView;
+		private TextView _textView;
+		private MenuItem _miShowPrivate;
 
 		private enum Showable {
 			Properties,
@@ -66,12 +66,12 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Quit", "", () => Quit()),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
-					miShowPrivate = new MenuItem ("_Include Private", "", () => ShowPrivate()){
+					_miShowPrivate = new MenuItem ("_Include Private", "", () => ShowPrivate()){
 						Checked = false,
 						CheckType = MenuItemCheckStyle.Checked
 					},
-					new MenuItem ("_Expand All", "", () => treeView.ExpandAll()),
-					new MenuItem ("_Collapse All", "", () => treeView.CollapseAll())
+					new MenuItem ("_Expand All", "", () => _treeView.ExpandAll()),
+					new MenuItem ("_Collapse All", "", () => _treeView.CollapseAll())
 				}),
 				new MenuBarItem ("_Style", new MenuItem [] {
 					highlightModelTextOnly = new MenuItem ("_Highlight Model Text Only", "", () => OnCheckHighlightModelTextOnly()) {
@@ -81,47 +81,47 @@ namespace UICatalog.Scenarios {
 			});
 			Application.Top.Add (menu);
 
-			treeView = new TreeView<object> () {
+			_treeView = new TreeView<object> () {
 				X = 0,
 				Y = 0,
 				Width = Dim.Percent (50),
 				Height = Dim.Fill (),
 			};
 
-			treeView.AddObjects (AppDomain.CurrentDomain.GetAssemblies ());
-			treeView.AspectGetter = GetRepresentation;
-			treeView.TreeBuilder = new DelegateTreeBuilder<object> (ChildGetter, CanExpand);
-			treeView.SelectionChanged += TreeView_SelectionChanged;
+			_treeView.AddObjects (AppDomain.CurrentDomain.GetAssemblies ());
+			_treeView.AspectGetter = GetRepresentation;
+			_treeView.TreeBuilder = new DelegateTreeBuilder<object> (ChildGetter, CanExpand);
+			_treeView.SelectionChanged += TreeView_SelectionChanged;
 
-			Win.Add (treeView);
+			Win.Add (_treeView);
 
-			textView = new TextView () {
-				X = Pos.Right (treeView),
+			_textView = new TextView () {
+				X = Pos.Right (_treeView),
 				Y = 0,
 				Width = Dim.Fill (),
 				Height = Dim.Fill ()
 			};
 
-			Win.Add (textView);
+			Win.Add (_textView);
 		}
 
 		private void OnCheckHighlightModelTextOnly ()
 		{
-			treeView.Style.HighlightModelTextOnly = !treeView.Style.HighlightModelTextOnly;
-			highlightModelTextOnly.Checked = treeView.Style.HighlightModelTextOnly;
-			treeView.SetNeedsDisplay ();
+			_treeView.Style.HighlightModelTextOnly = !_treeView.Style.HighlightModelTextOnly;
+			highlightModelTextOnly.Checked = _treeView.Style.HighlightModelTextOnly;
+			_treeView.SetNeedsDisplay ();
 		}
 
 		private void ShowPrivate ()
 		{
-			miShowPrivate.Checked = !miShowPrivate.Checked;
-			treeView.RebuildTree ();
-			treeView.SetFocus ();
+			_miShowPrivate.Checked = !_miShowPrivate.Checked;
+			_treeView.RebuildTree ();
+			_treeView.SetFocus ();
 		}
 
 		private BindingFlags GetFlags ()
 		{
-			if (miShowPrivate.Checked == true) {
+			if (_miShowPrivate.Checked == true) {
 				return BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
 			}
 
@@ -131,7 +131,7 @@ namespace UICatalog.Scenarios {
 		private void TreeView_SelectionChanged (object sender, SelectionChangedEventArgs<object> e)
 		{
 			var val = e.NewValue;
-			var all = treeView.GetAllSelectedObjects ().ToArray ();
+			var all = _treeView.GetAllSelectedObjects ().ToArray ();
 
 			if (val == null || val is ShowForType) {
 				return;
@@ -141,7 +141,7 @@ namespace UICatalog.Scenarios {
 
 				if (all.Length > 1) {
 
-					textView.Text = all.Length + " Objects";
+					_textView.Text = all.Length + " Objects";
 				} else {
 					StringBuilder sb = new StringBuilder ();
 
@@ -191,14 +191,14 @@ namespace UICatalog.Scenarios {
 						}
 					}
 
-					textView.Text = sb.ToString ().Replace ("\r\n", "\n");
+					_textView.Text = sb.ToString ().Replace ("\r\n", "\n");
 				}
 
 			} catch (Exception ex) {
 
-				textView.Text = ex.Message;
+				_textView.Text = ex.Message;
 			}
-			textView.SetNeedsDisplay ();
+			_textView.SetNeedsDisplay ();
 		}
 
 		private bool CanExpand (object arg)

--- a/UICatalog/Scenarios/ContextMenus.cs
+++ b/UICatalog/Scenarios/ContextMenus.cs
@@ -7,13 +7,13 @@ namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "ContextMenus", Description: "Context Menu Sample.")]
 	[ScenarioCategory ("Menus")]
 	public class ContextMenus : Scenario {
-		private ContextMenu contextMenu = new ContextMenu ();
-		private readonly List<CultureInfo> cultureInfos = Application.SupportedCultures;
-		private MenuItem miForceMinimumPosToZero;
-		private bool forceMinimumPosToZero = true;
-		private TextField tfTopLeft, tfTopRight, tfMiddle, tfBottomLeft, tfBottomRight;
-		private MenuItem miUseSubMenusSingleFrame;
-		private bool useSubMenusSingleFrame;
+		private ContextMenu _contextMenu = new ContextMenu ();
+		private readonly List<CultureInfo> _cultureInfos = Application.SupportedCultures;
+		private MenuItem _miForceMinimumPosToZero;
+		private bool _forceMinimumPosToZero = true;
+		private TextField _tfTopLeft, _tfTopRight, _tfMiddle, _tfBottomLeft, _tfBottomRight;
+		private MenuItem _miUseSubMenusSingleFrame;
+		private bool _useSubMenusSingleFrame;
 
 		public override void Setup ()
 		{
@@ -25,36 +25,36 @@ namespace UICatalog.Scenarios {
 				Y = 1
 			});
 
-			tfTopLeft = new TextField (text) {
+			_tfTopLeft = new TextField (text) {
 				Width = width
 			};
-			Win.Add (tfTopLeft);
+			Win.Add (_tfTopLeft);
 
-			tfTopRight = new TextField (text) {
+			_tfTopRight = new TextField (text) {
 				X = Pos.AnchorEnd (width),
 				Width = width
 			};
-			Win.Add (tfTopRight);
+			Win.Add (_tfTopRight);
 
-			tfMiddle = new TextField (text) {
+			_tfMiddle = new TextField (text) {
 				X = Pos.Center (),
 				Y = Pos.Center (),
 				Width = width
 			};
-			Win.Add (tfMiddle);
+			Win.Add (_tfMiddle);
 
-			tfBottomLeft = new TextField (text) {
+			_tfBottomLeft = new TextField (text) {
 				Y = Pos.AnchorEnd (1),
 				Width = width
 			};
-			Win.Add (tfBottomLeft);
+			Win.Add (_tfBottomLeft);
 
-			tfBottomRight = new TextField (text) {
+			_tfBottomRight = new TextField (text) {
 				X = Pos.AnchorEnd (width),
 				Y = Pos.AnchorEnd (1),
 				Width = width
 			};
-			Win.Add (tfBottomRight);
+			Win.Add (_tfBottomRight);
 
 			Point mousePos = default;
 
@@ -66,7 +66,7 @@ namespace UICatalog.Scenarios {
 			};
 
 			Win.MouseClick += (s, e) => {
-				if (e.MouseEvent.Flags == contextMenu.MouseFlags) {
+				if (e.MouseEvent.Flags == _contextMenu.MouseFlags) {
 					ShowContextMenu (e.MouseEvent.X, e.MouseEvent.Y);
 					e.Handled = true;
 				}
@@ -89,7 +89,7 @@ namespace UICatalog.Scenarios {
 
 		private void ShowContextMenu (int x, int y)
 		{
-			contextMenu = new ContextMenu (x, y,
+			_contextMenu = new ContextMenu (x, y,
 				new MenuBarItem (new MenuItem [] {
 					new MenuItem ("_Configuration", "Show configuration", () => MessageBox.Query (50, 5, "Info", "This would open settings dialog", "Ok")),
 					new MenuBarItem ("More options", new MenuItem [] {
@@ -97,30 +97,30 @@ namespace UICatalog.Scenarios {
 						new MenuItem ("_Maintenance", "Maintenance mode", () => MessageBox.Query (50, 5, "Info", "This would open maintenance dialog", "Ok")),
 					}),
 					new MenuBarItem ("_Languages", GetSupportedCultures ()),
-					miForceMinimumPosToZero = new MenuItem ("ForceMinimumPosToZero", "", () => {
-						miForceMinimumPosToZero.Checked = forceMinimumPosToZero = !forceMinimumPosToZero;
-						tfTopLeft.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-						tfTopRight.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-						tfMiddle.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-						tfBottomLeft.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-						tfBottomRight.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-					}) { CheckType = MenuItemCheckStyle.Checked, Checked = forceMinimumPosToZero },
-					miUseSubMenusSingleFrame = new MenuItem ("Use_SubMenusSingleFrame", "",
-						() => contextMenu.UseSubMenusSingleFrame = (bool)(miUseSubMenusSingleFrame.Checked = useSubMenusSingleFrame = !useSubMenusSingleFrame)) {
-							CheckType = MenuItemCheckStyle.Checked, Checked = useSubMenusSingleFrame
+					_miForceMinimumPosToZero = new MenuItem ("ForceMinimumPosToZero", "", () => {
+						_miForceMinimumPosToZero.Checked = _forceMinimumPosToZero = !_forceMinimumPosToZero;
+						_tfTopLeft.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+						_tfTopRight.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+						_tfMiddle.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+						_tfBottomLeft.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+						_tfBottomRight.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+					}) { CheckType = MenuItemCheckStyle.Checked, Checked = _forceMinimumPosToZero },
+					_miUseSubMenusSingleFrame = new MenuItem ("Use_SubMenusSingleFrame", "",
+						() => _contextMenu.UseSubMenusSingleFrame = (bool)(_miUseSubMenusSingleFrame.Checked = _useSubMenusSingleFrame = !_useSubMenusSingleFrame)) {
+							CheckType = MenuItemCheckStyle.Checked, Checked = _useSubMenusSingleFrame
 						},
 					null,
 					new MenuItem ("_Quit", "", () => Application.RequestStop ())
 				})
-			) { ForceMinimumPosToZero = forceMinimumPosToZero, UseSubMenusSingleFrame = useSubMenusSingleFrame };
+			) { ForceMinimumPosToZero = _forceMinimumPosToZero, UseSubMenusSingleFrame = _useSubMenusSingleFrame };
 
-			tfTopLeft.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-			tfTopRight.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-			tfMiddle.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-			tfBottomLeft.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
-			tfBottomRight.ContextMenu.ForceMinimumPosToZero = forceMinimumPosToZero;
+			_tfTopLeft.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+			_tfTopRight.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+			_tfMiddle.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+			_tfBottomLeft.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
+			_tfBottomRight.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
 
-			contextMenu.Show ();
+			_contextMenu.Show ();
 		}
 
 		private MenuItem [] GetSupportedCultures ()
@@ -128,7 +128,7 @@ namespace UICatalog.Scenarios {
 			List<MenuItem> supportedCultures = new List<MenuItem> ();
 			var index = -1;
 
-			foreach (var c in cultureInfos) {
+			foreach (var c in _cultureInfos) {
 				var culture = new MenuItem {
 					CheckType = MenuItemCheckStyle.Checked
 				};

--- a/UICatalog/Scenarios/CsvEditor.cs
+++ b/UICatalog/Scenarios/CsvEditor.cs
@@ -21,12 +21,12 @@ namespace UICatalog.Scenarios {
 	[ScenarioCategory ("Files and IO")]
 	public class CsvEditor : Scenario {
 		TableView tableView;
-		private string currentFile;
+		private string _currentFile;
 		DataTable currentTable;
-		private MenuItem miLeft;
-		private MenuItem miRight;
-		private MenuItem miCentered;
-		private TextField selectedCellLabel;
+		private MenuItem _miLeft;
+		private MenuItem _miRight;
+		private MenuItem _miCentered;
+		private TextField _selectedCellLabel;
 
 		public override void Setup ()
 		{
@@ -61,12 +61,12 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Sort Desc", "", () => Sort(false)),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
-					miLeft = new MenuItem ("_Align Left", "", () => Align(TextAlignment.Left)),
-					miRight = new MenuItem ("_Align Right", "", () => Align(TextAlignment.Right)),
-					miCentered = new MenuItem ("_Align Centered", "", () => Align(TextAlignment.Centered)),
+					_miLeft = new MenuItem ("_Align Left", "", () => Align(TextAlignment.Left)),
+					_miRight = new MenuItem ("_Align Right", "", () => Align(TextAlignment.Right)),
+					_miCentered = new MenuItem ("_Align Centered", "", () => Align(TextAlignment.Centered)),
 					
 					// Format requires hard typed data table, when we read a CSV everything is untyped (string) so this only works for new columns in this demo
-					miCentered = new MenuItem ("_Set Format Pattern", "", () => SetFormat()),
+					_miCentered = new MenuItem ("_Set Format Pattern", "", () => SetFormat()),
 				})
 			});
 			Application.Top.Add (menu);
@@ -80,16 +80,16 @@ namespace UICatalog.Scenarios {
 
 			Win.Add (tableView);
 
-			selectedCellLabel = new TextField () {
+			_selectedCellLabel = new TextField () {
 				X = 0,
 				Y = Pos.Bottom (tableView),
 				Text = "0,0",
 				Width = Dim.Fill (),
 				TextAlignment = TextAlignment.Right
 			};
-			selectedCellLabel.TextChanged += SelectedCellLabel_TextChanged;
+			_selectedCellLabel.TextChanged += SelectedCellLabel_TextChanged;
 
-			Win.Add (selectedCellLabel);
+			Win.Add (_selectedCellLabel);
 
 			tableView.SelectedCellChanged += OnSelectedCellChanged;
 			tableView.CellActivated += EditCurrentCell;
@@ -101,11 +101,11 @@ namespace UICatalog.Scenarios {
 		private void SelectedCellLabel_TextChanged (object sender, TextChangedEventArgs e)
 		{
 			// if user is in the text control and editing the selected cell
-			if (!selectedCellLabel.HasFocus)
+			if (!_selectedCellLabel.HasFocus)
 				return;
 
 			// change selected cell to the one the user has typed into the box
-			var match = Regex.Match (selectedCellLabel.Text.ToString (), "^(\\d+),(\\d+)$");
+			var match = Regex.Match (_selectedCellLabel.Text.ToString (), "^(\\d+),(\\d+)$");
 			if (match.Success) {
 
 				tableView.SelectedColumn = int.Parse (match.Groups [1].Value);
@@ -116,17 +116,17 @@ namespace UICatalog.Scenarios {
 		private void OnSelectedCellChanged (object sender, SelectedCellChangedEventArgs e)
 		{
 			// only update the text box if the user is not manually editing it
-			if (!selectedCellLabel.HasFocus)
-				selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";
+			if (!_selectedCellLabel.HasFocus)
+				_selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";
 
 			if (tableView.Table == null || tableView.SelectedColumn == -1)
 				return;
 
 			var style = tableView.Style.GetColumnStyleIfAny (tableView.SelectedColumn);
 
-			miLeft.Checked = style?.Alignment == TextAlignment.Left;
-			miRight.Checked = style?.Alignment == TextAlignment.Right;
-			miCentered.Checked = style?.Alignment == TextAlignment.Centered;
+			_miLeft.Checked = style?.Alignment == TextAlignment.Left;
+			_miRight.Checked = style?.Alignment == TextAlignment.Right;
+			_miCentered.Checked = style?.Alignment == TextAlignment.Centered;
 		}
 
 		private void RenameColumn ()
@@ -272,9 +272,9 @@ namespace UICatalog.Scenarios {
 			var style = tableView.Style.GetOrCreateColumnStyle (tableView.SelectedColumn);
 			style.Alignment = newAlignment;
 
-			miLeft.Checked = style.Alignment == TextAlignment.Left;
-			miRight.Checked = style.Alignment == TextAlignment.Right;
-			miCentered.Checked = style.Alignment == TextAlignment.Centered;
+			_miLeft.Checked = style.Alignment == TextAlignment.Left;
+			_miRight.Checked = style.Alignment == TextAlignment.Right;
+			_miCentered.Checked = style.Alignment == TextAlignment.Centered;
 
 			tableView.Update ();
 		}
@@ -365,12 +365,12 @@ namespace UICatalog.Scenarios {
 
 		private void Save ()
 		{
-			if (tableView.Table == null || string.IsNullOrWhiteSpace (currentFile)) {
+			if (tableView.Table == null || string.IsNullOrWhiteSpace (_currentFile)) {
 				MessageBox.ErrorQuery ("No file loaded", "No file is currently loaded", "Ok");
 				return;
 			}
 			using var writer = new CsvWriter (
-				new StreamWriter (File.OpenWrite (currentFile)),
+				new StreamWriter (File.OpenWrite (_currentFile)),
 				CultureInfo.InvariantCulture);
 
 			foreach (var col in currentTable.Columns.Cast<DataColumn> ().Select (c => c.ColumnName)) {
@@ -406,7 +406,7 @@ namespace UICatalog.Scenarios {
 		{
 
 			int lineNumber = 0;
-			currentFile = null;
+			_currentFile = null;
 
 			try {
 				using var reader = new CsvReader (File.OpenText (filename), CultureInfo.InvariantCulture);
@@ -433,8 +433,8 @@ namespace UICatalog.Scenarios {
 				SetTable(dt);
 
 				// Only set the current filename if we successfully loaded the entire file
-				currentFile = filename;
-				Win.Title = $"{this.GetName ()} - {Path.GetFileName (currentFile)}";
+				_currentFile = filename;
+				Win.Title = $"{this.GetName ()} - {Path.GetFileName (_currentFile)}";
 
 			} catch (Exception ex) {
 				MessageBox.ErrorQuery ("Open Failed", $"Error on line {lineNumber}{Environment.NewLine}{ex.Message}", "Ok");
@@ -442,30 +442,30 @@ namespace UICatalog.Scenarios {
 		}
 		private void SetupScrollBar ()
 		{
-			var _scrollBar = new ScrollBarView (tableView, true);
+			var scrollBar = new ScrollBarView (tableView, true);
 
-			_scrollBar.ChangedPosition += (s, e) => {
-				tableView.RowOffset = _scrollBar.Position;
-				if (tableView.RowOffset != _scrollBar.Position) {
-					_scrollBar.Position = tableView.RowOffset;
+			scrollBar.ChangedPosition += (s, e) => {
+				tableView.RowOffset = scrollBar.Position;
+				if (tableView.RowOffset != scrollBar.Position) {
+					scrollBar.Position = tableView.RowOffset;
 				}
 				tableView.SetNeedsDisplay ();
 			};
 			/*
-			_scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
-				_listView.LeftItem = _scrollBar.OtherScrollBarView.Position;
-				if (_listView.LeftItem != _scrollBar.OtherScrollBarView.Position) {
-					_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
+			scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
+				tableView.LeftItem = scrollBar.OtherScrollBarView.Position;
+				if (tableView.LeftItem != scrollBar.OtherScrollBarView.Position) {
+					scrollBar.OtherScrollBarView.Position = tableView.LeftItem;
 				}
-				_listView.SetNeedsDisplay ();
+				tableView.SetNeedsDisplay ();
 			};*/
 
 			tableView.DrawContent += (s, e) => {
-				_scrollBar.Size = tableView.Table?.Rows ?? 0;
-				_scrollBar.Position = tableView.RowOffset;
-				//	_scrollBar.OtherScrollBarView.Size = _listView.Maxlength - 1;
-				//	_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
-				_scrollBar.Refresh ();
+				scrollBar.Size = tableView.Table?.Rows ?? 0;
+				scrollBar.Position = tableView.RowOffset;
+				//scrollBar.OtherScrollBarView.Size = tableView.Maxlength - 1;
+				//scrollBar.OtherScrollBarView.Position = tableView.LeftItem;
+				scrollBar.Refresh ();
 			};
 
 		}

--- a/UICatalog/Scenarios/HexEditor.cs
+++ b/UICatalog/Scenarios/HexEditor.cs
@@ -14,9 +14,9 @@ namespace UICatalog.Scenarios {
 		private string _fileName = "demo.bin";
 		private HexView _hexView;
 		private bool _saved = true;
-		private MenuItem miAllowEdits;
-		private StatusItem siPositionChanged;
-		private StatusBar statusBar;
+		private MenuItem _miAllowEdits;
+		private StatusItem _siPositionChanged;
+		private StatusBar _statusBar;
 
 		public override void Setup ()
 		{
@@ -49,30 +49,30 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Paste", "", () => Paste())
 				}),
 				new MenuBarItem ("_Options", new MenuItem [] {
-					miAllowEdits = new MenuItem ("_AllowEdits", "", () => ToggleAllowEdits ()){Checked = _hexView.AllowEdits, CheckType = MenuItemCheckStyle.Checked}
+					_miAllowEdits = new MenuItem ("_AllowEdits", "", () => ToggleAllowEdits ()){Checked = _hexView.AllowEdits, CheckType = MenuItemCheckStyle.Checked}
 				})
 			});
 			Application.Top.Add (menu);
 
-			statusBar = new StatusBar (new StatusItem [] {
+			_statusBar = new StatusBar (new StatusItem [] {
 				new StatusItem(Key.F2, "~F2~ Open", () => Open()),
 				new StatusItem(Key.F3, "~F3~ Save", () => Save()),
 				new StatusItem(Application.QuitKey, $"{Application.QuitKey} to Quit", () => Quit()),
-				siPositionChanged = new StatusItem(Key.Null,
+				_siPositionChanged = new StatusItem(Key.Null,
 					$"Position: {_hexView.Position} Line: {_hexView.CursorPosition.Y} Col: {_hexView.CursorPosition.X} Line length: {_hexView.BytesPerLine}", () => {})
 			});
-			Application.Top.Add (statusBar);
+			Application.Top.Add (_statusBar);
 		}
 
 		private void _hexView_PositionChanged (object sender, HexViewEventArgs obj)
 		{
-			siPositionChanged.Title = $"Position: {obj.Position} Line: {obj.CursorPosition.Y} Col: {obj.CursorPosition.X} Line length: {obj.BytesPerLine}";
-			statusBar.SetNeedsDisplay ();
+			_siPositionChanged.Title = $"Position: {obj.Position} Line: {obj.CursorPosition.Y} Col: {obj.CursorPosition.X} Line length: {obj.BytesPerLine}";
+			_statusBar.SetNeedsDisplay ();
 		}
 
 		private void ToggleAllowEdits ()
 		{
-			_hexView.AllowEdits = (bool)(miAllowEdits.Checked = !miAllowEdits.Checked);
+			_hexView.AllowEdits = (bool)(_miAllowEdits.Checked = !_miAllowEdits.Checked);
 		}
 
 		private void _hexView_Edited (object sender, HexViewEditEventArgs e)

--- a/UICatalog/Scenarios/ListViewWithSelection.cs
+++ b/UICatalog/Scenarios/ListViewWithSelection.cs
@@ -60,40 +60,40 @@ namespace UICatalog.Scenarios {
 			_listView.RowRender += ListView_RowRender;
 			Win.Add (_listView);
 
-			var _scrollBar = new ScrollBarView (_listView, true);
+			var scrollBar = new ScrollBarView (_listView, true);
 
-			_scrollBar.ChangedPosition += (s,e) => {
-				_listView.TopItem = _scrollBar.Position;
-				if (_listView.TopItem != _scrollBar.Position) {
-					_scrollBar.Position = _listView.TopItem;
+			scrollBar.ChangedPosition += (s,e) => {
+				_listView.TopItem = scrollBar.Position;
+				if (_listView.TopItem != scrollBar.Position) {
+					scrollBar.Position = _listView.TopItem;
 				}
 				_listView.SetNeedsDisplay ();
 			};
 
-			_scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
-				_listView.LeftItem = _scrollBar.OtherScrollBarView.Position;
-				if (_listView.LeftItem != _scrollBar.OtherScrollBarView.Position) {
-					_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
+			scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
+				_listView.LeftItem = scrollBar.OtherScrollBarView.Position;
+				if (_listView.LeftItem != scrollBar.OtherScrollBarView.Position) {
+					scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
 				}
 				_listView.SetNeedsDisplay ();
 			};
 
 			_listView.DrawContent += (s,e) => {
-				_scrollBar.Size = _listView.Source.Count - 1;
-				_scrollBar.Position = _listView.TopItem;
-				_scrollBar.OtherScrollBarView.Size = _listView.Maxlength - 1;
-				_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
-				_scrollBar.Refresh ();
+				scrollBar.Size = _listView.Source.Count - 1;
+				scrollBar.Position = _listView.TopItem;
+				scrollBar.OtherScrollBarView.Size = _listView.Maxlength - 1;
+				scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
+				scrollBar.Refresh ();
 			};
 
 			_listView.SetSource (_scenarios);
 
 			var k = "Keep Content Always In Viewport";
-			var keepCheckBox = new CheckBox (k, _scrollBar.AutoHideScrollBars) {
+			var keepCheckBox = new CheckBox (k, scrollBar.AutoHideScrollBars) {
 				X = Pos.AnchorEnd (k.Length + 3),
 				Y = 0,
 			};
-			keepCheckBox.Toggled += (s,e) => _scrollBar.KeepContentAlwaysInViewport = (bool)keepCheckBox.Checked;
+			keepCheckBox.Toggled += (s,e) => scrollBar.KeepContentAlwaysInViewport = (bool)keepCheckBox.Checked;
 			Win.Add (keepCheckBox);
 		}
 

--- a/UICatalog/Scenarios/ListsAndCombos.cs
+++ b/UICatalog/Scenarios/ListsAndCombos.cs
@@ -39,30 +39,30 @@ namespace UICatalog.Scenarios {
 			listview.SelectedItemChanged += (object s, ListViewItemEventArgs e) => lbListView.Text = items [listview.SelectedItem];
 			Win.Add (lbListView, listview);
 
-			var _scrollBar = new ScrollBarView (listview, true);
+			var scrollBar = new ScrollBarView (listview, true);
 
-			_scrollBar.ChangedPosition += (s,e) => {
-				listview.TopItem = _scrollBar.Position;
-				if (listview.TopItem != _scrollBar.Position) {
-					_scrollBar.Position = listview.TopItem;
+			scrollBar.ChangedPosition += (s,e) => {
+				listview.TopItem = scrollBar.Position;
+				if (listview.TopItem != scrollBar.Position) {
+					scrollBar.Position = listview.TopItem;
 				}
 				listview.SetNeedsDisplay ();
 			};
 
-			_scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
-				listview.LeftItem = _scrollBar.OtherScrollBarView.Position;
-				if (listview.LeftItem != _scrollBar.OtherScrollBarView.Position) {
-					_scrollBar.OtherScrollBarView.Position = listview.LeftItem;
+			scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
+				listview.LeftItem = scrollBar.OtherScrollBarView.Position;
+				if (listview.LeftItem != scrollBar.OtherScrollBarView.Position) {
+					scrollBar.OtherScrollBarView.Position = listview.LeftItem;
 				}
 				listview.SetNeedsDisplay ();
 			};
 
 			listview.DrawContent += (s,e) => {
-				_scrollBar.Size = listview.Source.Count - 1;
-				_scrollBar.Position = listview.TopItem;
-				_scrollBar.OtherScrollBarView.Size = listview.Maxlength - 1;
-				_scrollBar.OtherScrollBarView.Position = listview.LeftItem;
-				_scrollBar.Refresh ();
+				scrollBar.Size = listview.Source.Count - 1;
+				scrollBar.Position = listview.TopItem;
+				scrollBar.OtherScrollBarView.Size = listview.Maxlength - 1;
+				scrollBar.OtherScrollBarView.Position = listview.LeftItem;
+				scrollBar.Refresh ();
 			};
 
 			// ComboBox

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -17,20 +17,20 @@ namespace UICatalog.Scenarios {
 	public class TableEditor : Scenario {
 		TableView tableView;
 		DataTable currentTable;
-		private MenuItem miShowHeaders;
-		private MenuItem miAlwaysShowHeaders;
-		private MenuItem miHeaderOverline;
-		private MenuItem miHeaderMidline;
-		private MenuItem miHeaderUnderline;
-		private MenuItem miShowHorizontalScrollIndicators;
-		private MenuItem miCellLines;
-		private MenuItem miFullRowSelect;
-		private MenuItem miExpandLastColumn;
-		private MenuItem miAlwaysUseNormalColorForVerticalCellLines;
-		private MenuItem miSmoothScrolling;
-		private MenuItem miAlternatingColors;
-		private MenuItem miCursor;
-		private MenuItem miBottomline;
+		private MenuItem _miShowHeaders;
+		private MenuItem _miAlwaysShowHeaders;
+		private MenuItem _miHeaderOverline;
+		private MenuItem _miHeaderMidline;
+		private MenuItem _miHeaderUnderline;
+		private MenuItem _miShowHorizontalScrollIndicators;
+		private MenuItem _miCellLines;
+		private MenuItem _miFullRowSelect;
+		private MenuItem _miExpandLastColumn;
+		private MenuItem _miAlwaysUseNormalColorForVerticalCellLines;
+		private MenuItem _miSmoothScrolling;
+		private MenuItem _miAlternatingColors;
+		private MenuItem _miCursor;
+		private MenuItem _miBottomline;
 
 		ColorScheme redColorScheme;
 		ColorScheme redColorSchemeAlt;
@@ -59,22 +59,22 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Quit", "", () => Quit()),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
-					miShowHeaders = new MenuItem ("_ShowHeaders", "", () => ToggleShowHeaders()){Checked = tableView.Style.ShowHeaders, CheckType = MenuItemCheckStyle.Checked },
-					miAlwaysShowHeaders = new MenuItem ("_AlwaysShowHeaders", "", () => ToggleAlwaysShowHeaders()){Checked = tableView.Style.AlwaysShowHeaders, CheckType = MenuItemCheckStyle.Checked },
-					miHeaderOverline = new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()){Checked = tableView.Style.ShowHorizontalHeaderOverline, CheckType = MenuItemCheckStyle.Checked },
-					miHeaderMidline = new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()){Checked = tableView.Style.ShowVerticalHeaderLines, CheckType = MenuItemCheckStyle.Checked },
-					miHeaderUnderline = new MenuItem ("_HeaderUnderLine", "", () => ToggleUnderline()){Checked = tableView.Style.ShowHorizontalHeaderUnderline, CheckType = MenuItemCheckStyle.Checked },
-					miBottomline = new MenuItem ("_BottomLine", "", () => ToggleBottomline()){Checked = tableView.Style.ShowHorizontalBottomline, CheckType = MenuItemCheckStyle.Checked },
-					miShowHorizontalScrollIndicators = new MenuItem ("_HorizontalScrollIndicators", "", () => ToggleHorizontalScrollIndicators()){Checked = tableView.Style.ShowHorizontalScrollIndicators, CheckType = MenuItemCheckStyle.Checked },
-					miFullRowSelect =new MenuItem ("_FullRowSelect", "", () => ToggleFullRowSelect()){Checked = tableView.FullRowSelect, CheckType = MenuItemCheckStyle.Checked },
-					miCellLines =new MenuItem ("_CellLines", "", () => ToggleCellLines()){Checked = tableView.Style.ShowVerticalCellLines, CheckType = MenuItemCheckStyle.Checked },
-					miExpandLastColumn = new MenuItem ("_ExpandLastColumn", "", () => ToggleExpandLastColumn()){Checked = tableView.Style.ExpandLastColumn, CheckType = MenuItemCheckStyle.Checked },
-					miAlwaysUseNormalColorForVerticalCellLines = new MenuItem ("_AlwaysUseNormalColorForVerticalCellLines", "", () => ToggleAlwaysUseNormalColorForVerticalCellLines()){Checked = tableView.Style.AlwaysUseNormalColorForVerticalCellLines, CheckType = MenuItemCheckStyle.Checked },
-					miSmoothScrolling = new MenuItem ("_SmoothHorizontalScrolling", "", () => ToggleSmoothScrolling()){Checked = tableView.Style.SmoothHorizontalScrolling, CheckType = MenuItemCheckStyle.Checked },
+					_miShowHeaders = new MenuItem ("_ShowHeaders", "", () => ToggleShowHeaders()){Checked = tableView.Style.ShowHeaders, CheckType = MenuItemCheckStyle.Checked },
+					_miAlwaysShowHeaders = new MenuItem ("_AlwaysShowHeaders", "", () => ToggleAlwaysShowHeaders()){Checked = tableView.Style.AlwaysShowHeaders, CheckType = MenuItemCheckStyle.Checked },
+					_miHeaderOverline = new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()){Checked = tableView.Style.ShowHorizontalHeaderOverline, CheckType = MenuItemCheckStyle.Checked },
+					_miHeaderMidline = new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()){Checked = tableView.Style.ShowVerticalHeaderLines, CheckType = MenuItemCheckStyle.Checked },
+					_miHeaderUnderline = new MenuItem ("_HeaderUnderLine", "", () => ToggleUnderline()){Checked = tableView.Style.ShowHorizontalHeaderUnderline, CheckType = MenuItemCheckStyle.Checked },
+					_miBottomline = new MenuItem ("_BottomLine", "", () => ToggleBottomline()){Checked = tableView.Style.ShowHorizontalBottomline, CheckType = MenuItemCheckStyle.Checked },
+					_miShowHorizontalScrollIndicators = new MenuItem ("_HorizontalScrollIndicators", "", () => ToggleHorizontalScrollIndicators()){Checked = tableView.Style.ShowHorizontalScrollIndicators, CheckType = MenuItemCheckStyle.Checked },
+					_miFullRowSelect =new MenuItem ("_FullRowSelect", "", () => ToggleFullRowSelect()){Checked = tableView.FullRowSelect, CheckType = MenuItemCheckStyle.Checked },
+					_miCellLines =new MenuItem ("_CellLines", "", () => ToggleCellLines()){Checked = tableView.Style.ShowVerticalCellLines, CheckType = MenuItemCheckStyle.Checked },
+					_miExpandLastColumn = new MenuItem ("_ExpandLastColumn", "", () => ToggleExpandLastColumn()){Checked = tableView.Style.ExpandLastColumn, CheckType = MenuItemCheckStyle.Checked },
+					_miAlwaysUseNormalColorForVerticalCellLines = new MenuItem ("_AlwaysUseNormalColorForVerticalCellLines", "", () => ToggleAlwaysUseNormalColorForVerticalCellLines()){Checked = tableView.Style.AlwaysUseNormalColorForVerticalCellLines, CheckType = MenuItemCheckStyle.Checked },
+					_miSmoothScrolling = new MenuItem ("_SmoothHorizontalScrolling", "", () => ToggleSmoothScrolling()){Checked = tableView.Style.SmoothHorizontalScrolling, CheckType = MenuItemCheckStyle.Checked },
 					new MenuItem ("_AllLines", "", () => ToggleAllCellLines()),
 					new MenuItem ("_NoLines", "", () => ToggleNoCellLines()),
-					miAlternatingColors = new MenuItem ("Alternating Colors", "", () => ToggleAlternatingColors()){CheckType = MenuItemCheckStyle.Checked},
-					miCursor = new MenuItem ("Invert Selected Cell First Character", "", () => ToggleInvertSelectedCellFirstCharacter()){Checked = tableView.Style.InvertSelectedCellFirstCharacter,CheckType = MenuItemCheckStyle.Checked},
+					_miAlternatingColors = new MenuItem ("Alternating Colors", "", () => ToggleAlternatingColors()){CheckType = MenuItemCheckStyle.Checked},
+					_miCursor = new MenuItem ("Invert Selected Cell First Character", "", () => ToggleInvertSelectedCellFirstCharacter()){Checked = tableView.Style.InvertSelectedCellFirstCharacter,CheckType = MenuItemCheckStyle.Checked},
 					new MenuItem ("_ClearColumnStyles", "", () => ClearColumnStyles()),
 					new MenuItem ("Sho_w All Columns", "", ()=>ShowAllColumns())
 				}),
@@ -325,30 +325,30 @@ namespace UICatalog.Scenarios {
 
 		private void SetupScrollBar ()
 		{
-			var _scrollBar = new ScrollBarView (tableView, true);
+			var scrollBar = new ScrollBarView (tableView, true);
 
-			_scrollBar.ChangedPosition += (s,e) => {
-				tableView.RowOffset = _scrollBar.Position;
-				if (tableView.RowOffset != _scrollBar.Position) {
-					_scrollBar.Position = tableView.RowOffset;
+			scrollBar.ChangedPosition += (s,e) => {
+				tableView.RowOffset = scrollBar.Position;
+				if (tableView.RowOffset != scrollBar.Position) {
+					scrollBar.Position = tableView.RowOffset;
 				}
 				tableView.SetNeedsDisplay ();
 			};
 			/*
-			_scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
-				_listView.LeftItem = _scrollBar.OtherScrollBarView.Position;
-				if (_listView.LeftItem != _scrollBar.OtherScrollBarView.Position) {
-					_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
+			scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
+				tableView.LeftItem = scrollBar.OtherScrollBarView.Position;
+				if (tableView.LeftItem != scrollBar.OtherScrollBarView.Position) {
+					scrollBar.OtherScrollBarView.Position = tableView.LeftItem;
 				}
-				_listView.SetNeedsDisplay ();
+				tableView.SetNeedsDisplay ();
 			};*/
 
 			tableView.DrawContent += (s,e) => {
-				_scrollBar.Size = tableView.Table?.Rows ?? 0;
-				_scrollBar.Position = tableView.RowOffset;
-				//	_scrollBar.OtherScrollBarView.Size = _listView.Maxlength - 1;
-				//	_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
-				_scrollBar.Refresh ();
+				scrollBar.Size = tableView.Table?.Rows ?? 0;
+				scrollBar.Position = tableView.RowOffset;
+				//scrollBar.OtherScrollBarView.Size = tableView.Maxlength - 1;
+				//scrollBar.OtherScrollBarView.Position = tableView.LeftItem;
+				scrollBar.Refresh ();
 			};
 
 		}
@@ -383,59 +383,59 @@ namespace UICatalog.Scenarios {
 
 		private void ToggleShowHeaders ()
 		{
-			miShowHeaders.Checked = !miShowHeaders.Checked;
-			tableView.Style.ShowHeaders = (bool)miShowHeaders.Checked;
+			_miShowHeaders.Checked = !_miShowHeaders.Checked;
+			tableView.Style.ShowHeaders = (bool)_miShowHeaders.Checked;
 			tableView.Update ();
 		}
 
 		private void ToggleAlwaysShowHeaders ()
 		{
-			miAlwaysShowHeaders.Checked = !miAlwaysShowHeaders.Checked;
-			tableView.Style.AlwaysShowHeaders = (bool)miAlwaysShowHeaders.Checked;
+			_miAlwaysShowHeaders.Checked = !_miAlwaysShowHeaders.Checked;
+			tableView.Style.AlwaysShowHeaders = (bool)_miAlwaysShowHeaders.Checked;
 			tableView.Update ();
 		}
 
 		private void ToggleOverline ()
 		{
-			miHeaderOverline.Checked = !miHeaderOverline.Checked;
-			tableView.Style.ShowHorizontalHeaderOverline = (bool)miHeaderOverline.Checked;
+			_miHeaderOverline.Checked = !_miHeaderOverline.Checked;
+			tableView.Style.ShowHorizontalHeaderOverline = (bool)_miHeaderOverline.Checked;
 			tableView.Update ();
 		}
 		private void ToggleHeaderMidline ()
 		{
-			miHeaderMidline.Checked = !miHeaderMidline.Checked;
-			tableView.Style.ShowVerticalHeaderLines = (bool)miHeaderMidline.Checked;
+			_miHeaderMidline.Checked = !_miHeaderMidline.Checked;
+			tableView.Style.ShowVerticalHeaderLines = (bool)_miHeaderMidline.Checked;
 			tableView.Update ();
 		}
 		private void ToggleUnderline ()
 		{
-			miHeaderUnderline.Checked = !miHeaderUnderline.Checked;
-			tableView.Style.ShowHorizontalHeaderUnderline = (bool)miHeaderUnderline.Checked;
+			_miHeaderUnderline.Checked = !_miHeaderUnderline.Checked;
+			tableView.Style.ShowHorizontalHeaderUnderline = (bool)_miHeaderUnderline.Checked;
 			tableView.Update ();
 		}
 		private void ToggleBottomline()
 		{
-			miBottomline.Checked = !miBottomline.Checked;
-			tableView.Style.ShowHorizontalBottomline = (bool)miBottomline.Checked;
+			_miBottomline.Checked = !_miBottomline.Checked;
+			tableView.Style.ShowHorizontalBottomline = (bool)_miBottomline.Checked;
 			tableView.Update ();
 		}
 		private void ToggleHorizontalScrollIndicators ()
 		{
-			miShowHorizontalScrollIndicators.Checked = !miShowHorizontalScrollIndicators.Checked;
-			tableView.Style.ShowHorizontalScrollIndicators = (bool)miShowHorizontalScrollIndicators.Checked;
+			_miShowHorizontalScrollIndicators.Checked = !_miShowHorizontalScrollIndicators.Checked;
+			tableView.Style.ShowHorizontalScrollIndicators = (bool)_miShowHorizontalScrollIndicators.Checked;
 			tableView.Update ();
 		}
 		private void ToggleFullRowSelect ()
 		{
-			miFullRowSelect.Checked = !miFullRowSelect.Checked;
-			tableView.FullRowSelect = (bool)miFullRowSelect.Checked;
+			_miFullRowSelect.Checked = !_miFullRowSelect.Checked;
+			tableView.FullRowSelect = (bool)_miFullRowSelect.Checked;
 			tableView.Update ();
 		}
 
 		private void ToggleExpandLastColumn ()
 		{
-			miExpandLastColumn.Checked = !miExpandLastColumn.Checked;
-			tableView.Style.ExpandLastColumn = (bool)miExpandLastColumn.Checked;
+			_miExpandLastColumn.Checked = !_miExpandLastColumn.Checked;
+			tableView.Style.ExpandLastColumn = (bool)_miExpandLastColumn.Checked;
 
 			tableView.Update ();
 
@@ -443,23 +443,23 @@ namespace UICatalog.Scenarios {
 
 		private void ToggleAlwaysUseNormalColorForVerticalCellLines()
 		{
-			miAlwaysUseNormalColorForVerticalCellLines.Checked = !miAlwaysUseNormalColorForVerticalCellLines.Checked;
-			tableView.Style.AlwaysUseNormalColorForVerticalCellLines = (bool)miAlwaysUseNormalColorForVerticalCellLines.Checked;
+			_miAlwaysUseNormalColorForVerticalCellLines.Checked = !_miAlwaysUseNormalColorForVerticalCellLines.Checked;
+			tableView.Style.AlwaysUseNormalColorForVerticalCellLines = (bool)_miAlwaysUseNormalColorForVerticalCellLines.Checked;
 
 			tableView.Update ();
 		}
 		private void ToggleSmoothScrolling ()
 		{
-			miSmoothScrolling.Checked = !miSmoothScrolling.Checked;
-			tableView.Style.SmoothHorizontalScrolling = (bool)miSmoothScrolling.Checked;
+			_miSmoothScrolling.Checked = !_miSmoothScrolling.Checked;
+			tableView.Style.SmoothHorizontalScrolling = (bool)_miSmoothScrolling.Checked;
 
 			tableView.Update ();
 
 		}
 		private void ToggleCellLines ()
 		{
-			miCellLines.Checked = !miCellLines.Checked;
-			tableView.Style.ShowVerticalCellLines = (bool)miCellLines.Checked;
+			_miCellLines.Checked = !_miCellLines.Checked;
+			tableView.Style.ShowVerticalCellLines = (bool)_miCellLines.Checked;
 			tableView.Update ();
 		}
 		private void ToggleAllCellLines ()
@@ -469,10 +469,10 @@ namespace UICatalog.Scenarios {
 			tableView.Style.ShowHorizontalHeaderUnderline = true;
 			tableView.Style.ShowVerticalCellLines = true;
 
-			miHeaderOverline.Checked = true;
-			miHeaderMidline.Checked = true;
-			miHeaderUnderline.Checked = true;
-			miCellLines.Checked = true;
+			_miHeaderOverline.Checked = true;
+			_miHeaderMidline.Checked = true;
+			_miHeaderUnderline.Checked = true;
+			_miCellLines.Checked = true;
 
 			tableView.Update ();
 		}
@@ -483,10 +483,10 @@ namespace UICatalog.Scenarios {
 			tableView.Style.ShowHorizontalHeaderUnderline = false;
 			tableView.Style.ShowVerticalCellLines = false;
 
-			miHeaderOverline.Checked = false;
-			miHeaderMidline.Checked = false;
-			miHeaderUnderline.Checked = false;
-			miCellLines.Checked = false;
+			_miHeaderOverline.Checked = false;
+			_miHeaderMidline.Checked = false;
+			_miHeaderUnderline.Checked = false;
+			_miCellLines.Checked = false;
 
 			tableView.Update ();
 		}
@@ -494,9 +494,9 @@ namespace UICatalog.Scenarios {
 		private void ToggleAlternatingColors ()
 		{
 			//toggle menu item
-			miAlternatingColors.Checked = !miAlternatingColors.Checked;
+			_miAlternatingColors.Checked = !_miAlternatingColors.Checked;
 
-			if (miAlternatingColors.Checked == true) {
+			if (_miAlternatingColors.Checked == true) {
 				tableView.Style.RowColorGetter = (a) => { return a.RowIndex % 2 == 0 ? alternatingColorScheme : null; };
 			} else {
 				tableView.Style.RowColorGetter = null;
@@ -507,8 +507,8 @@ namespace UICatalog.Scenarios {
 		private void ToggleInvertSelectedCellFirstCharacter ()
 		{
 			//toggle menu item
-			miCursor.Checked = !miCursor.Checked;
-			tableView.Style.InvertSelectedCellFirstCharacter = (bool)miCursor.Checked;
+			_miCursor.Checked = !_miCursor.Checked;
+			tableView.Style.InvertSelectedCellFirstCharacter = (bool)_miCursor.Checked;
 			tableView.SetNeedsDisplay ();
 		}
 		private void CloseExample ()
@@ -763,7 +763,7 @@ namespace UICatalog.Scenarios {
 
 				ColorGetter = (a) => a.CellValue is double d ?
 								// color 0 and negative values red
-								d <= 0.0000001 ? a.RowIndex % 2 == 0 && miAlternatingColors.Checked == true ? redColorSchemeAlt : redColorScheme :
+								d <= 0.0000001 ? a.RowIndex % 2 == 0 && _miAlternatingColors.Checked == true ? redColorSchemeAlt : redColorScheme :
 								// use normal scheme for positive values
 								null :
 								// not a double

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -15,20 +15,20 @@ namespace UICatalog.Scenarios {
 		TreeView<FileSystemInfo> treeViewFiles;
 
 		MenuItem miShowLines;
-		private MenuItem miPlusMinus;
-		private MenuItem miArrowSymbols;
-		private MenuItem miNoSymbols;
-		private MenuItem miColoredSymbols;
-		private MenuItem miInvertSymbols;
-		private MenuItem miUnicodeSymbols;
-		private MenuItem miFullPaths;
-		private MenuItem miLeaveLastRow;
-		private MenuItem miHighlightModelTextOnly;
-		private MenuItem miCustomColors;
-		private MenuItem miCursor;
-		private MenuItem miMultiSelect;
+		private MenuItem _miPlusMinus;
+		private MenuItem _miArrowSymbols;
+		private MenuItem _miNoSymbols;
+		private MenuItem _miColoredSymbols;
+		private MenuItem _miInvertSymbols;
+		private MenuItem _miUnicodeSymbols;
+		private MenuItem _miFullPaths;
+		private MenuItem _miLeaveLastRow;
+		private MenuItem _miHighlightModelTextOnly;
+		private MenuItem _miCustomColors;
+		private MenuItem _miCursor;
+		private MenuItem _miMultiSelect;
 
-		private DetailsFrame detailsFrame;
+		private DetailsFrame _detailsFrame;
 
 		public override void Setup ()
 		{
@@ -42,28 +42,28 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Quit", $"{Application.QuitKey}", () => Quit()),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
-					miFullPaths = new MenuItem ("_Full Paths", "", () => SetFullName()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
-					miMultiSelect = new MenuItem ("_Multi Select", "", () => SetMultiSelect()){Checked = true, CheckType = MenuItemCheckStyle.Checked},
+					_miFullPaths = new MenuItem ("_Full Paths", "", () => SetFullName()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
+					_miMultiSelect = new MenuItem ("_Multi Select", "", () => SetMultiSelect()){Checked = true, CheckType = MenuItemCheckStyle.Checked},
 				}),
 				new MenuBarItem ("_Style", new MenuItem [] {
 					miShowLines = new MenuItem ("_Show Lines", "", () => ShowLines()){
 					Checked = true, CheckType = MenuItemCheckStyle.Checked
 						},
 					null /*separator*/,
-					miPlusMinus = new MenuItem ("_Plus Minus Symbols", "+ -", () => SetExpandableSymbols('+','-')){Checked = true, CheckType = MenuItemCheckStyle.Radio},
-					miArrowSymbols = new MenuItem ("_Arrow Symbols", "> v", () => SetExpandableSymbols('>','v')){Checked = false, CheckType = MenuItemCheckStyle.Radio},
-					miNoSymbols = new MenuItem ("_No Symbols", "", () => SetExpandableSymbols(null,null)){Checked = false, CheckType = MenuItemCheckStyle.Radio},
-					miUnicodeSymbols = new MenuItem ("_Unicode", "ஹ ﷽", () => SetExpandableSymbols('ஹ','﷽')){Checked = false, CheckType = MenuItemCheckStyle.Radio},
+					_miPlusMinus = new MenuItem ("_Plus Minus Symbols", "+ -", () => SetExpandableSymbols('+','-')){Checked = true, CheckType = MenuItemCheckStyle.Radio},
+					_miArrowSymbols = new MenuItem ("_Arrow Symbols", "> v", () => SetExpandableSymbols('>','v')){Checked = false, CheckType = MenuItemCheckStyle.Radio},
+					_miNoSymbols = new MenuItem ("_No Symbols", "", () => SetExpandableSymbols(null,null)){Checked = false, CheckType = MenuItemCheckStyle.Radio},
+					_miUnicodeSymbols = new MenuItem ("_Unicode", "ஹ ﷽", () => SetExpandableSymbols('ஹ','﷽')){Checked = false, CheckType = MenuItemCheckStyle.Radio},
 					null /*separator*/,
-					miColoredSymbols = new MenuItem ("_Colored Symbols", "", () => ShowColoredExpandableSymbols()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
-					miInvertSymbols = new MenuItem ("_Invert Symbols", "", () => InvertExpandableSymbols()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
+					_miColoredSymbols = new MenuItem ("_Colored Symbols", "", () => ShowColoredExpandableSymbols()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
+					_miInvertSymbols = new MenuItem ("_Invert Symbols", "", () => InvertExpandableSymbols()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
 					null /*separator*/,
-					miLeaveLastRow = new MenuItem ("_Leave Last Row", "", () => SetLeaveLastRow()){Checked = true, CheckType = MenuItemCheckStyle.Checked},
-					miHighlightModelTextOnly = new MenuItem ("_Highlight Model Text Only", "", () => SetCheckHighlightModelTextOnly()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
+					_miLeaveLastRow = new MenuItem ("_Leave Last Row", "", () => SetLeaveLastRow()){Checked = true, CheckType = MenuItemCheckStyle.Checked},
+					_miHighlightModelTextOnly = new MenuItem ("_Highlight Model Text Only", "", () => SetCheckHighlightModelTextOnly()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
 					null /*separator*/,
-					miCustomColors = new MenuItem ("C_ustom Colors Hidden Files", "Yellow/Red", () => SetCustomColors()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
+					_miCustomColors = new MenuItem ("C_ustom Colors Hidden Files", "Yellow/Red", () => SetCustomColors()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
 					null /*separator*/,
-					miCursor = new MenuItem ("Curs_or (MultiSelect only)", "", () => SetCursor()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
+					_miCursor = new MenuItem ("Curs_or (MultiSelect only)", "", () => SetCursor()){Checked = false, CheckType = MenuItemCheckStyle.Checked},
 				}),
 			});
 			Application.Top.Add (menu);
@@ -75,14 +75,14 @@ namespace UICatalog.Scenarios {
 				Height = Dim.Fill (),
 			};
 
-			detailsFrame = new DetailsFrame () {
+			_detailsFrame = new DetailsFrame () {
 				X = Pos.Right (treeViewFiles),
 				Y = 0,
 				Width = Dim.Fill (),
 				Height = Dim.Fill (),
 			};
 
-			Win.Add (detailsFrame);
+			Win.Add (_detailsFrame);
 			treeViewFiles.MouseClick += TreeViewFiles_MouseClick;
 			treeViewFiles.KeyPress += TreeViewFiles_KeyPress;
 			treeViewFiles.SelectionChanged += TreeViewFiles_SelectionChanged;
@@ -192,7 +192,7 @@ namespace UICatalog.Scenarios {
 
 		private void ShowPropertiesOf (FileSystemInfo fileSystemInfo)
 		{
-			detailsFrame.FileInfo = fileSystemInfo;
+			_detailsFrame.FileInfo = fileSystemInfo;
 		}
 
 		private void SetupScrollBar ()
@@ -200,30 +200,30 @@ namespace UICatalog.Scenarios {
 			// When using scroll bar leave the last row of the control free (for over-rendering with scroll bar)
 			treeViewFiles.Style.LeaveLastRow = true;
 
-			var _scrollBar = new ScrollBarView (treeViewFiles, true);
+			var scrollBar = new ScrollBarView (treeViewFiles, true);
 
-			_scrollBar.ChangedPosition += (s,e) => {
-				treeViewFiles.ScrollOffsetVertical = _scrollBar.Position;
-				if (treeViewFiles.ScrollOffsetVertical != _scrollBar.Position) {
-					_scrollBar.Position = treeViewFiles.ScrollOffsetVertical;
+			scrollBar.ChangedPosition += (s,e) => {
+				treeViewFiles.ScrollOffsetVertical = scrollBar.Position;
+				if (treeViewFiles.ScrollOffsetVertical != scrollBar.Position) {
+					scrollBar.Position = treeViewFiles.ScrollOffsetVertical;
 				}
 				treeViewFiles.SetNeedsDisplay ();
 			};
 
-			_scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
-				treeViewFiles.ScrollOffsetHorizontal = _scrollBar.OtherScrollBarView.Position;
-				if (treeViewFiles.ScrollOffsetHorizontal != _scrollBar.OtherScrollBarView.Position) {
-					_scrollBar.OtherScrollBarView.Position = treeViewFiles.ScrollOffsetHorizontal;
+			scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
+				treeViewFiles.ScrollOffsetHorizontal = scrollBar.OtherScrollBarView.Position;
+				if (treeViewFiles.ScrollOffsetHorizontal != scrollBar.OtherScrollBarView.Position) {
+					scrollBar.OtherScrollBarView.Position = treeViewFiles.ScrollOffsetHorizontal;
 				}
 				treeViewFiles.SetNeedsDisplay ();
 			};
 
 			treeViewFiles.DrawContent += (s,e) => {
-				_scrollBar.Size = treeViewFiles.ContentHeight;
-				_scrollBar.Position = treeViewFiles.ScrollOffsetVertical;
-				_scrollBar.OtherScrollBarView.Size = treeViewFiles.GetContentWidth (true);
-				_scrollBar.OtherScrollBarView.Position = treeViewFiles.ScrollOffsetHorizontal;
-				_scrollBar.Refresh ();
+				scrollBar.Size = treeViewFiles.ContentHeight;
+				scrollBar.Position = treeViewFiles.ScrollOffsetVertical;
+				scrollBar.OtherScrollBarView.Size = treeViewFiles.GetContentWidth (true);
+				scrollBar.OtherScrollBarView.Position = treeViewFiles.ScrollOffsetHorizontal;
+				scrollBar.Refresh ();
 			};
 		}
 
@@ -255,10 +255,10 @@ namespace UICatalog.Scenarios {
 
 		private void SetExpandableSymbols (Rune? expand, Rune? collapse)
 		{
-			miPlusMinus.Checked = expand == '+';
-			miArrowSymbols.Checked = expand == '>';
-			miNoSymbols.Checked = expand == null;
-			miUnicodeSymbols.Checked = expand == 'ஹ';
+			_miPlusMinus.Checked = expand == '+';
+			_miArrowSymbols.Checked = expand == '>';
+			_miNoSymbols.Checked = expand == null;
+			_miUnicodeSymbols.Checked = expand == 'ஹ';
 
 			treeViewFiles.Style.ExpandableSymbol = expand;
 			treeViewFiles.Style.CollapseableSymbol = collapse;
@@ -266,24 +266,24 @@ namespace UICatalog.Scenarios {
 		}
 		private void ShowColoredExpandableSymbols ()
 		{
-			miColoredSymbols.Checked = !miColoredSymbols.Checked;
+			_miColoredSymbols.Checked = !_miColoredSymbols.Checked;
 
-			treeViewFiles.Style.ColorExpandSymbol = (bool)miColoredSymbols.Checked;
+			treeViewFiles.Style.ColorExpandSymbol = (bool)_miColoredSymbols.Checked;
 			treeViewFiles.SetNeedsDisplay ();
 		}
 		private void InvertExpandableSymbols ()
 		{
-			miInvertSymbols.Checked = !miInvertSymbols.Checked;
+			_miInvertSymbols.Checked = !_miInvertSymbols.Checked;
 
-			treeViewFiles.Style.InvertExpandSymbolColors = (bool)miInvertSymbols.Checked;
+			treeViewFiles.Style.InvertExpandSymbolColors = (bool)_miInvertSymbols.Checked;
 			treeViewFiles.SetNeedsDisplay ();
 		}
 
 		private void SetFullName ()
 		{
-			miFullPaths.Checked = !miFullPaths.Checked;
+			_miFullPaths.Checked = !_miFullPaths.Checked;
 
-			if (miFullPaths.Checked == true) {
+			if (_miFullPaths.Checked == true) {
 				treeViewFiles.AspectGetter = (f) => f.FullName;
 			} else {
 				treeViewFiles.AspectGetter = (f) => f.Name;
@@ -293,18 +293,18 @@ namespace UICatalog.Scenarios {
 
 		private void SetLeaveLastRow ()
 		{
-			miLeaveLastRow.Checked = !miLeaveLastRow.Checked;
-			treeViewFiles.Style.LeaveLastRow = (bool)miLeaveLastRow.Checked;
+			_miLeaveLastRow.Checked = !_miLeaveLastRow.Checked;
+			treeViewFiles.Style.LeaveLastRow = (bool)_miLeaveLastRow.Checked;
 		}
 		private void SetCursor ()
 		{
-			miCursor.Checked = !miCursor.Checked;
-			treeViewFiles.DesiredCursorVisibility = miCursor.Checked == true ? CursorVisibility.Default : CursorVisibility.Invisible;
+			_miCursor.Checked = !_miCursor.Checked;
+			treeViewFiles.DesiredCursorVisibility = _miCursor.Checked == true ? CursorVisibility.Default : CursorVisibility.Invisible;
 		}
 		private void SetMultiSelect ()
 		{
-			miMultiSelect.Checked = !miMultiSelect.Checked;
-			treeViewFiles.MultiSelect = (bool)miMultiSelect.Checked;
+			_miMultiSelect.Checked = !_miMultiSelect.Checked;
+			treeViewFiles.MultiSelect = (bool)_miMultiSelect.Checked;
 		}
 
 		private void SetCustomColors ()
@@ -314,9 +314,9 @@ namespace UICatalog.Scenarios {
 				Normal = new Terminal.Gui.Attribute (Color.BrightYellow, treeViewFiles.ColorScheme.Normal.Background),
 			};
 
-			miCustomColors.Checked = !miCustomColors.Checked;
+			_miCustomColors.Checked = !_miCustomColors.Checked;
 
-			if (miCustomColors.Checked == true) {
+			if (_miCustomColors.Checked == true) {
 				treeViewFiles.ColorGetter = (m) => {
 					if (m is DirectoryInfo && m.Attributes.HasFlag (FileAttributes.Hidden)) return hidden;
 					if (m is FileInfo && m.Attributes.HasFlag (FileAttributes.Hidden)) return hidden;
@@ -331,7 +331,7 @@ namespace UICatalog.Scenarios {
 		private void SetCheckHighlightModelTextOnly ()
 		{
 			treeViewFiles.Style.HighlightModelTextOnly = !treeViewFiles.Style.HighlightModelTextOnly;
-			miHighlightModelTextOnly.Checked = treeViewFiles.Style.HighlightModelTextOnly;
+			_miHighlightModelTextOnly.Checked = treeViewFiles.Style.HighlightModelTextOnly;
 			treeViewFiles.SetNeedsDisplay ();
 		}
 


### PR DESCRIPTION
Several scenarios have either missing or incorrect underscore prefixes for field names as discussed in #2603

## Pull Request checklist:

- [X] I've named my PR in the form of "Fixes #issue. Terse description."
- [X] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [X] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [X] I ran `dotnet test` before commit
- [X] I have made corresponding changes to the API documentation (using `///` style comments)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any poor grammar or misspellings
- [X] I conducted basic QA to assure all features are working
