### PR TITLE
Fixes #2626. ScrollView contentBottomRightCorner isn't set to false if not needed.

### DIFF
--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -256,6 +256,8 @@ namespace Terminal.Gui {
 			}
 		}
 
+		View _contentBottomRightCorner;
+
 		/// <summary>
 		/// Adds the view to the scrollview.
 		/// </summary>
@@ -263,6 +265,7 @@ namespace Terminal.Gui {
 		public override void Add (View view)
 		{
 			if (view.Id == "contentBottomRightCorner") {
+				_contentBottomRightCorner = view;
 				base.Add (view);
 			} else {
 				if (!IsOverridden (view, "MouseEvent")) {
@@ -365,27 +368,36 @@ namespace Terminal.Gui {
 
 			contentView.Draw ();
 
+			DrawScrollBars ();
+
+			Driver.Clip = savedClip;
+		}
+
+		private void DrawScrollBars ()
+		{
 			if (autoHideScrollBars) {
 				ShowHideScrollBars ();
 			} else {
 				if (ShowVerticalScrollIndicator) {
-					//vertical.SetRelativeLayout (Bounds);
 					vertical.Draw ();
 				}
-
 				if (ShowHorizontalScrollIndicator) {
-					//horizontal.SetRelativeLayout (Bounds);
 					horizontal.Draw ();
 				}
+				if (ShowVerticalScrollIndicator && ShowHorizontalScrollIndicator) {
+					SetContentBottomRightCornerVisibility ();
+					_contentBottomRightCorner.Draw ();
+				}
 			}
+		}
 
-			// Fill in the bottom left corner. Note we don't rely on ScrollBarView.contentBottomRightCorner here
-			// because that only applies when ScrollBarView is hosted.
-			if (ShowVerticalScrollIndicator && ShowHorizontalScrollIndicator) {
-				AddRune (Bounds.Width - 1, Bounds.Height - 1, ' ');
+		private void SetContentBottomRightCornerVisibility ()
+		{
+			if (showHorizontalScrollIndicator && showVerticalScrollIndicator) {
+				_contentBottomRightCorner.Visible = true;
+			} else {
+				_contentBottomRightCorner.Visible = false;
 			}
-			Driver.SetAttribute (GetNormalColor ());
-			Driver.Clip = savedClip;
 		}
 
 		void ShowHideScrollBars ()
@@ -447,6 +459,11 @@ namespace Terminal.Gui {
 			if (h) {
 				horizontal.SetRelativeLayout (Bounds);
 				horizontal.Draw ();
+			}
+			SetContentBottomRightCornerVisibility ();
+			if (v && h) {
+				_contentBottomRightCorner.SetRelativeLayout (Bounds);
+				_contentBottomRightCorner.Draw ();
 			}
 		}
 


### PR DESCRIPTION
Fixes #2626 - Now `ScrollView`  handles the `contentBottomRightCorner` properly.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
