### PR TITLE
Fixes #2636 - Move unicode file/folder icons to Glyphs

### DIFF
--- a/Terminal.Gui/Drawing/Glyphs.cs
+++ b/Terminal.Gui/Drawing/Glyphs.cs
@@ -143,6 +143,16 @@ namespace Terminal.Gui {
 
 		#endregion
 
+		/// <summary>
+		/// Folder icon.  Defaults to ꤉ (Kayah Li Digit Nine)
+		/// </summary>
+		public Rune Folder { get; set; } = '꤉';
+
+		/// <summary>
+		/// File icon.  Defaults to ☰ (Trigram For Heaven)
+		/// </summary>
+		public Rune File { get; set; } = '☰';
+
 		#region ----------------- Lines -----------------
 		/// <summary>
 		/// Box Drawings Horizontal Line - Light (U+2500) - ─

--- a/Terminal.Gui/FileServices/FileDialogStyle.cs
+++ b/Terminal.Gui/FileServices/FileDialogStyle.cs
@@ -237,10 +237,10 @@ namespace Terminal.Gui {
 			var file = args.File;
 
 			if (file is IDirectoryInfo) {
-				return UseUnicodeCharacters ? "\ua909 " : "\\";
+				return UseUnicodeCharacters ? ConfigurationManager.Glyphs.Folder + " " : "\\";
 			}
 
-			return UseUnicodeCharacters ? "\u2630 " : "";
+			return UseUnicodeCharacters ?  ConfigurationManager.Glyphs.File + " " : "";
 
 		}
 

--- a/Terminal.Gui/FileServices/FileDialogStyle.cs
+++ b/Terminal.Gui/FileServices/FileDialogStyle.cs
@@ -237,7 +237,7 @@ namespace Terminal.Gui {
 			var file = args.File;
 
 			if (file is IDirectoryInfo) {
-				return UseUnicodeCharacters ? ConfigurationManager.Glyphs.Folder + " " : "\\";
+				return UseUnicodeCharacters ? ConfigurationManager.Glyphs.Folder + " " : Path.DirectorySeparatorChar.ToString();
 			}
 
 			return UseUnicodeCharacters ?  ConfigurationManager.Glyphs.File + " " : "";

--- a/UnitTests/FileServices/FileDialogTests.cs
+++ b/UnitTests/FileServices/FileDialogTests.cs
@@ -392,7 +392,7 @@ namespace Terminal.Gui.FileServicesTests {
  ││Filename (▲)│Size      │Modified                      │Type     ││
  │├────────────┼──────────┼──────────────────────────────┼─────────┤│
  ││..          │          │                              │dir      ││
- ││\subfolder  │          │2002-01-01T22:42:10           │dir      ││
+ ││/subfolder  │          │2002-01-01T22:42:10           │dir      ││
  ││image.gif   │4.00 bytes│2002-01-01T22:42:10           │.gif     ││
  ││jQuery.js   │7.00 bytes│2001-01-01T11:44:42           │.js      ││
  │                                                                  │


### PR DESCRIPTION
Fixes #2636 - Move unicode file/folder icons to Glyphs.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
