### PR TITLE
Fixes #2641. ContentBottomRightCorner should only draw his background with a empty.

### DIFF
--- a/Terminal.Gui/Views/ScrollBarView.cs
+++ b/Terminal.Gui/Views/ScrollBarView.cs
@@ -119,7 +119,7 @@ namespace Terminal.Gui {
 			if (Host != null && (_contentBottomRightCorner == null && OtherScrollBarView == null
 				|| (_contentBottomRightCorner == null && OtherScrollBarView != null && OtherScrollBarView._contentBottomRightCorner == null))) {
 
-				_contentBottomRightCorner = new View (" ") {
+				_contentBottomRightCorner = new View () {
 					Id = "contentBottomRightCorner",
 					Visible = Host.Visible,
 					ClearOnVisibleFalse = false,
@@ -135,7 +135,13 @@ namespace Terminal.Gui {
 				_contentBottomRightCorner.Width = 1;
 				_contentBottomRightCorner.Height = 1;
 				_contentBottomRightCorner.MouseClick += ContentBottomRightCorner_MouseClick;
+				_contentBottomRightCorner.DrawContent += _contentBottomRightCorner_DrawContent;
 			}
+		}
+
+		private void _contentBottomRightCorner_DrawContent (object sender, DrawEventArgs e)
+		{
+			Driver.SetAttribute (Host.HasFocus ? ColorScheme.Focus : GetNormalColor ());
 		}
 
 		private void Host_VisibleChanged (object sender, EventArgs e)


### PR DESCRIPTION
Fixes #2641- It's enough set the `Width` and the `Height` properties and a empty `Text`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

![imagem](https://github.com/gui-cs/Terminal.Gui/assets/13117724/6aa2b4c5-5646-4fdc-bcd7-1bb00b3b818d)
![imagem](https://github.com/gui-cs/Terminal.Gui/assets/13117724/886782a2-d212-42d3-b84a-5923e8fd34fb)
