### PR TITLE
Fixes #2643 - Make AllowedType more permissive in file matching

### DIFF
--- a/Terminal.Gui/FileServices/AllowedType.cs
+++ b/Terminal.Gui/FileServices/AllowedType.cs
@@ -94,6 +94,10 @@ namespace Terminal.Gui {
 		/// <inheritdoc/>
 		public bool IsAllowed(string path)
 		{
+			if(string.IsNullOrWhiteSpace(path)) {
+				return false;
+			}
+
 			var extension = Path.GetExtension (path);
 
 			if(this.Extensions.Any(e=>path.EndsWith(e, StringComparison.InvariantCultureIgnoreCase))) {

--- a/Terminal.Gui/FileServices/AllowedType.cs
+++ b/Terminal.Gui/FileServices/AllowedType.cs
@@ -96,12 +96,16 @@ namespace Terminal.Gui {
 		{
 			var extension = Path.GetExtension (path);
 
+			if(this.Extensions.Any(e=>path.EndsWith(e, StringComparison.InvariantCultureIgnoreCase))) {
+				return true;
+			}
+
 			// There is a requirement to have a particular extension and we have none
 			if (string.IsNullOrEmpty (extension)) {
 				return false;
 			}
 
-			return this.Extensions.Any (e => e.Equals (extension));
+			return this.Extensions.Any (e => e.Equals (extension, StringComparison.InvariantCultureIgnoreCase));
 		}
 	}
 	

--- a/UnitTests/FileServices/FileDialogTests.cs
+++ b/UnitTests/FileServices/FileDialogTests.cs
@@ -481,6 +481,35 @@ namespace Terminal.Gui.FileServicesTests {
 			};
 		}
 
+		[Theory]
+		[InlineData (".csv", "c:\\MyFile.csv", true)]
+		[InlineData (".csv", "c:\\MyFile.CSV", true)]
+		[InlineData (".csv", "c:\\MyFile.csv.bak", false)]
+		public void TestAllowedType_Basic(string allowed, string candidate, bool expected)
+		{
+			Assert.Equal (expected, new AllowedType ("Test", allowed).IsAllowed (candidate));
+		}
+
+		[Theory]
+		[InlineData ("Dockerfile", "c:\\temp\\Dockerfile", true)]
+		[InlineData ("Dockerfile", "Dockerfile", true)]
+		[InlineData ("Dockerfile", "someimg.Dockerfile", true)]
+		public void TestAllowedType_SpecificFile(string allowed, string candidate, bool expected)
+		{
+			Assert.Equal (expected, new AllowedType ("Test", allowed).IsAllowed (candidate));
+		}
+
+		[Theory]
+		[InlineData (".Designer.cs", "c:\\MyView.Designer.cs", true)]
+		[InlineData (".Designer.cs", "c:\\temp/MyView.Designer.cs", true)]
+		[InlineData(".Designer.cs","MyView.Designer.cs",true)]
+		[InlineData (".Designer.cs", "c:\\MyView.DESIGNER.CS", true)]
+		[InlineData (".Designer.cs", "MyView.cs", false)]
+		public void TestAllowedType_DoubleBarreled (string allowed, string candidate, bool expected)
+		{
+			Assert.Equal (expected, new AllowedType ("Test", allowed).IsAllowed (candidate));
+		}
+
 		[Theory, AutoInitShutdown]
 		[InlineData (true)]
 		[InlineData (false)]

--- a/UnitTests/FileServices/FileDialogTests.cs
+++ b/UnitTests/FileServices/FileDialogTests.cs
@@ -482,6 +482,8 @@ namespace Terminal.Gui.FileServicesTests {
 		}
 
 		[Theory]
+		[InlineData (".csv", null, false)]
+		[InlineData (".csv", "", false)]
 		[InlineData (".csv", "c:\\MyFile.csv", true)]
 		[InlineData (".csv", "c:\\MyFile.CSV", true)]
 		[InlineData (".csv", "c:\\MyFile.csv.bak", false)]


### PR DESCRIPTION
Fixes #2643 - Extensions passed to `AllowedType` now support double barreled extensions properly (e.g. `.Designer.cs`).  Also you can now pass things like `Dockerfile` even though its not an extension.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
