### PR TITLE
Fixes #2646. CharacterMap scenario is throwing exception with surrogate code points.

### DIFF
--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -403,8 +403,12 @@ class CharMap : ScrollView {
 				if (cursorRow + ContentOffset.Y + 1 == y && cursorCol + ContentOffset.X + firstColumnX + 1 == x && !HasFocus) {
 					Driver.SetAttribute (GetFocusColor ());
 				}
-				
-				Driver.AddRune (new Rune (val + col));
+
+				if (char.IsSurrogate ((char)(val + col))) {
+					Driver.AddRune (Rune.ReplacementChar);
+				} else {
+					Driver.AddRune (new Rune (val + col));
+				}
 
 				if (cursorRow + ContentOffset.Y + 1 == y && cursorCol + ContentOffset.X + firstColumnX + 1 == x && !HasFocus) {
 					Driver.SetAttribute (GetNormalColor ());

--- a/UnitTests/Configuration/RuneJsonConverterTests.cs
+++ b/UnitTests/Configuration/RuneJsonConverterTests.cs
@@ -26,7 +26,7 @@ public class RunJsonConverterTests {
 		// Act
 		var json = JsonSerializer.Serialize (rune, ConfigurationManager._serializerOptions);
 		var deserialized = JsonSerializer.Deserialize<Rune> (json, ConfigurationManager._serializerOptions);
-		
+
 		// Assert
 		Assert.Equal (expected, deserialized.ToString ());
 	}
@@ -39,7 +39,8 @@ public class RunJsonConverterTests {
 	[InlineData ("🍎🍎")]
 	[InlineData ("U+FFF1F34E")]
 	[InlineData ("\\UFFF1F34E")]
-	[InlineData ("\\ud83d")] // not printable
+	[InlineData ("\\ud83d")] // not printable "high surrogate"
+	[InlineData ("\\udc3d")] // not printable "low surrogate"
 	[InlineData ("\\ud83d \\u1c69")]  // bad surrogate pair
 	[InlineData ("\\ud83ddc69")]
 	// Emoji - Family Unit:


### PR DESCRIPTION
Fixes #2646 - They should be replaces by a valid rune, like the `Rune.ReplacementChar` or other valid rune.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
