### PR TITLE
Fixes #2655. Should be avoid cast to char on a Rune ctor which always fallback for a UTF16 char.

### DIFF
--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -332,7 +332,7 @@ class CharMap : ScrollView {
 	}
 
 	private void CopyCodePoint () => Clipboard.Contents = $"U+{SelectedCodePoint:x5}";
-	private void CopyGlyph () => Clipboard.Contents = $"{new Rune ((char)SelectedCodePoint)}";
+	private void CopyGlyph () => Clipboard.Contents = $"{new Rune (SelectedCodePoint)}";
 
 	public override void OnDrawContent (Rect contentArea)
 	{
@@ -553,7 +553,7 @@ class CharMap : ScrollView {
 				//}
 			}
 
-			var title = $"{ToCamelCase (name)} - {new Rune ((char)SelectedCodePoint)} U+{SelectedCodePoint:x4}";
+			var title = $"{ToCamelCase (name)} - {new Rune (SelectedCodePoint)} U+{SelectedCodePoint:x4}";
 			switch (MessageBox.Query (title, decResponse, "Copy _Glyph", "Copy Code _Point", "Cancel")) {
 			case 0:
 				CopyGlyph ();

--- a/UnitTests/Text/RuneTests.cs
+++ b/UnitTests/Text/RuneTests.cs
@@ -711,4 +711,13 @@ public class RuneTests {
 		Assert.Equal (utf16Length, r.Utf16SequenceLength);
 		Assert.Equal (utf8Length, r.Utf8SequenceLength);
 	}
+
+	[Fact]
+	public void Cast_To_Char_Durrogate_Pair_Return_UTF16 ()
+	{
+		Assert.NotEqual ("𝔹", $"{new Rune (unchecked((char)0x1d539))}");
+		Assert.Equal ("픹", $"{new Rune (unchecked((char)0x1d539))}");
+		Assert.Equal ("픹", $"{new Rune (0xd539)}");
+		Assert.Equal ("𝔹", $"{new Rune (0x1d539)}");
+	}
 }


### PR DESCRIPTION
Fixes #2655 - If we need to deal with non-Bmp we mustn't use `char` cast in `Rune`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
