### PR TITLE
Fixes #1683. The application freezes while resizing the terminal on MacOS

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -98,7 +98,7 @@ namespace Terminal.Gui {
 			this.mainLoop = mainLoop;
 			pipe (wakeupPipes);
 			AddWatch (wakeupPipes [0], Condition.PollIn, ml => {
-				var result = read (wakeupPipes [0], ignore, readHandle);
+				read (wakeupPipes [0], ignore, readHandle);
 				return true;
 			});
 		}

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -82,6 +82,7 @@ namespace Terminal.Gui {
 		bool poll_dirty = true;
 		int [] wakeupPipes = new int [2];
 		static IntPtr ignore = Marshal.AllocHGlobal (1);
+		static IntPtr readHandle = Marshal.AllocHGlobal (1);
 		MainLoop mainLoop;
 		bool winChanged;
 
@@ -97,7 +98,7 @@ namespace Terminal.Gui {
 			this.mainLoop = mainLoop;
 			pipe (wakeupPipes);
 			AddWatch (wakeupPipes [0], Condition.PollIn, ml => {
-				read (wakeupPipes [0], ignore, (IntPtr)1);
+				var result = read (wakeupPipes [0], ignore, readHandle);
 				return true;
 			});
 		}


### PR DESCRIPTION
Fixes #1683 - The app was hanging on the read method after resizing the terminal.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
