### PR TITLE
Change AutoSpin from a method to a property

### DIFF
--- a/Terminal.Gui/Views/SpinnerView/SpinnerView.cs
+++ b/Terminal.Gui/Views/SpinnerView/SpinnerView.cs
@@ -190,9 +190,23 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Automates spinning
+		/// Gets or sets whether spinning should occur automatically or be manually
+		/// triggered (e.g. from a background task).
 		/// </summary>
-		public void AutoSpin ()
+		public bool AutoSpin {
+			get {
+				return _timeout != null;
+			}
+			set {
+				if (value) {
+					AddAutoSpinTimeout ();
+				} else {
+					RemoveAutoSpinTimeout ();
+				}
+			}
+		}
+
+		private void AddAutoSpinTimeout ()
 		{
 			if (_timeout != null) {
 				return;
@@ -205,13 +219,22 @@ namespace Terminal.Gui {
 				});
 		}
 
-		/// <inheritdoc/>
-		protected override void Dispose (bool disposing)
+
+		private void RemoveAutoSpinTimeout ()
 		{
 			if (_timeout != null) {
 				Application.MainLoop.RemoveTimeout (_timeout);
 				_timeout = null;
 			}
+		}
+
+
+
+
+		/// <inheritdoc/>
+		protected override void Dispose (bool disposing)
+		{
+			RemoveAutoSpinTimeout ();
 
 			base.Dispose (disposing);
 		}

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -516,7 +516,7 @@ class CharMap : ScrollView {
 			Style = new SpinnerStyle.Aesthetic (),
 
 		};
-		spinner.AutoSpin ();
+		spinner.AutoSpin = true;
 		waitIndicator.Add (errorLabel);
 		waitIndicator.Add (spinner);
 		waitIndicator.Ready += async (s, a) => {

--- a/UICatalog/Scenarios/SpinnerStyles.cs
+++ b/UICatalog/Scenarios/SpinnerStyles.cs
@@ -39,7 +39,7 @@ namespace UICatalog.Scenarios {
 				Y = 0
 			};
 			preview.Add (spinner);
-			spinner.AutoSpin ();
+			spinner.AutoSpin = true;
 
 			var ckbAscii = new CheckBox ("Ascii Only", false) {
 				X = Pos.Center () - 7,

--- a/UnitTests/Views/SpinnerViewTests.cs
+++ b/UnitTests/Views/SpinnerViewTests.cs
@@ -13,24 +13,33 @@ namespace Terminal.Gui.ViewsTests {
 			this.output = output;
 		}
 
-		[Fact, AutoInitShutdown]
-		public void TestSpinnerView_AutoSpin()
+		[Theory, AutoInitShutdown]
+		[InlineData(true)]
+		[InlineData(false)]
+		public void TestSpinnerView_AutoSpin(bool callStop)
 		{
 			var view = GetSpinnerView ();
 
 			Assert.Empty (Application.MainLoop.timeouts);
-			view.AutoSpin ();
+			view.AutoSpin = true;
 			Assert.NotEmpty (Application.MainLoop.timeouts);
 
 			//More calls to AutoSpin do not add more timeouts
 			Assert.Single (Application.MainLoop.timeouts);
-			view.AutoSpin ();
-			view.AutoSpin ();
-			view.AutoSpin ();
+			view.AutoSpin = true;
+			view.AutoSpin = true;
+			view.AutoSpin = true;
 			Assert.Single (Application.MainLoop.timeouts);
 
+			if(callStop) {
+				view.AutoSpin = false;
+				Assert.Empty (Application.MainLoop.timeouts);
+			}
+			else {
+				Assert.NotEmpty (Application.MainLoop.timeouts);
+			}
+
 			// Dispose clears timeout
-			Assert.NotEmpty (Application.MainLoop.timeouts);
 			view.Dispose ();
 			Assert.Empty (Application.MainLoop.timeouts);
 		}

--- a/UnitTests/Views/SpinnerViewTests.cs
+++ b/UnitTests/Views/SpinnerViewTests.cs
@@ -14,9 +14,9 @@ namespace Terminal.Gui.ViewsTests {
 		}
 
 		[Theory, AutoInitShutdown]
-		[InlineData(true)]
-		[InlineData(false)]
-		public void TestSpinnerView_AutoSpin(bool callStop)
+		[InlineData (true)]
+		[InlineData (false)]
+		public void TestSpinnerView_AutoSpin (bool callStop)
 		{
 			var view = GetSpinnerView ();
 
@@ -31,11 +31,10 @@ namespace Terminal.Gui.ViewsTests {
 			view.AutoSpin = true;
 			Assert.Single (Application.MainLoop.timeouts);
 
-			if(callStop) {
+			if (callStop) {
 				view.AutoSpin = false;
 				Assert.Empty (Application.MainLoop.timeouts);
-			}
-			else {
+			} else {
 				Assert.NotEmpty (Application.MainLoop.timeouts);
 			}
 
@@ -66,7 +65,7 @@ namespace Terminal.Gui.ViewsTests {
 			expected = @"\";
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
-			Task.Delay (400).Wait();
+			Task.Delay (400).Wait ();
 
 			view.SetNeedsDisplay ();
 			view.Draw ();

--- a/UnitTests/Views/SpinnerViewTests.cs
+++ b/UnitTests/Views/SpinnerViewTests.cs
@@ -23,17 +23,20 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.Empty (Application.MainLoop.timeouts);
 			view.AutoSpin = true;
 			Assert.NotEmpty (Application.MainLoop.timeouts);
+			Assert.True (view.AutoSpin);
 
 			//More calls to AutoSpin do not add more timeouts
 			Assert.Single (Application.MainLoop.timeouts);
 			view.AutoSpin = true;
 			view.AutoSpin = true;
 			view.AutoSpin = true;
+			Assert.True (view.AutoSpin);
 			Assert.Single (Application.MainLoop.timeouts);
 
 			if (callStop) {
 				view.AutoSpin = false;
 				Assert.Empty (Application.MainLoop.timeouts);
+				Assert.False (view.AutoSpin);
 			} else {
 				Assert.NotEmpty (Application.MainLoop.timeouts);
 			}


### PR DESCRIPTION
This is a simple change to `SpinnerView` that changes AutoSpin from a one off method you can call to a settable property.  This lets the user turn it on/off at will.

`SpinnerView` is only in v2 so I haven't created a ticket as this will be non breaking (hasn't been released yet).

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
