### PR TITLE
Fixes #2686. Border color doesn't change when changing color scheme.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -873,7 +873,7 @@ namespace Terminal.Gui {
 						keyUpHandler (new KeyEvent (map, keyModifiers));
 					}
 				}
-				if (!inputEvent.KeyEvent.bKeyDown && (inputEvent.KeyEvent.dwControlKeyState == 0 || inputEvent.KeyEvent.dwControlKeyState == WindowsConsole.ControlKeyState.EnhancedKey)) {
+				if (!inputEvent.KeyEvent.bKeyDown) {
 					keyModifiers = null;
 				}
 				break;

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -873,7 +873,7 @@ namespace Terminal.Gui {
 						keyUpHandler (new KeyEvent (map, keyModifiers));
 					}
 				}
-				if (!inputEvent.KeyEvent.bKeyDown && inputEvent.KeyEvent.dwControlKeyState == 0) {
+				if (!inputEvent.KeyEvent.bKeyDown && (inputEvent.KeyEvent.dwControlKeyState == 0 || inputEvent.KeyEvent.dwControlKeyState == WindowsConsole.ControlKeyState.EnhancedKey)) {
 					keyModifiers = null;
 				}
 				break;
@@ -908,6 +908,7 @@ namespace Terminal.Gui {
 				break;
 
 			case WindowsConsole.EventType.Focus:
+				keyModifiers = null;
 				break;
 			}
 		}

--- a/Terminal.Gui/Core/Border.cs
+++ b/Terminal.Gui/Core/Border.cs
@@ -168,7 +168,6 @@ namespace Terminal.Gui {
 				if (border == null) {
 					Border = new Border () {
 						BorderStyle = BorderStyle.Single,
-						BorderBrush = ColorScheme.Normal.Background,
 						Title = (ustring)title
 					};
 				} else {
@@ -318,8 +317,8 @@ namespace Terminal.Gui {
 		private BorderStyle borderStyle;
 		private bool drawMarginFrame;
 		private Thickness borderThickness;
-		private Color borderBrush;
-		private Color background;
+		private Color? borderBrush;
+		private Color? background;
 		private Thickness padding;
 		private bool effect3D;
 		private Point effect3DOffset = new Point (1, 1);
@@ -374,7 +373,7 @@ namespace Terminal.Gui {
 		/// Gets or sets the <see cref="Color"/> that draws the outer border color.
 		/// </summary>
 		public Color BorderBrush {
-			get => borderBrush;
+			get => borderBrush != null ? (Color)borderBrush : (Color)(-1);
 			set {
 				borderBrush = value;
 				OnBorderChanged ();
@@ -385,7 +384,7 @@ namespace Terminal.Gui {
 		/// Gets or sets the <see cref="Color"/> that fills the area between the bounds of a <see cref="Border"/>.
 		/// </summary>
 		public Color Background {
-			get => background;
+			get => background != null ? (Color)background : (Color)(-1);
 			set {
 				background = value;
 				OnBorderChanged ();
@@ -439,7 +438,6 @@ namespace Terminal.Gui {
 			set {
 				child = value;
 				if (child != null && Parent != null) {
-					Parent.Initialized += Parent_Initialized;
 					Parent.Removed += Parent_Removed;
 				}
 			}
@@ -450,30 +448,6 @@ namespace Terminal.Gui {
 			BorderBrush = default;
 			Background = default;
 			child.Removed -= Parent_Removed;
-		}
-
-		private void Parent_Initialized (object s, EventArgs e)
-		{
-			SetMarginFrameTitleBrush ();
-			child.Initialized -= Parent_Initialized;
-		}
-
-		private void SetMarginFrameTitleBrush ()
-		{
-			if (child != null) {
-				var view = Parent?.Border != null ? Parent : child;
-				if (view.ColorScheme != null) {
-					if (borderBrush == default) {
-						BorderBrush = view.GetNormalColor ().Foreground;
-					}
-					if (background == default) {
-						Background = view.GetNormalColor ().Background;
-					}
-					return;
-				}
-			}
-			BorderBrush = default;
-			Background = default;
 		}
 
 		/// <summary>
@@ -609,7 +583,8 @@ namespace Terminal.Gui {
 			}
 
 			// Draw border thickness
-			driver.SetAttribute (new Attribute (BorderBrush));
+			SetBorderBrush (driver);
+
 			Child.Clear (borderRect);
 
 			borderRect = new Rect () {
@@ -624,7 +599,7 @@ namespace Terminal.Gui {
 				Child.Clear (borderRect);
 			}
 
-			driver.SetAttribute (new Attribute (BorderBrush, Background));
+			SetBorderBrushBackground (driver);
 
 			// Draw margin frame
 			if (DrawMarginFrame) {
@@ -661,7 +636,7 @@ namespace Terminal.Gui {
 
 			var savedAttribute = driver.GetAttribute ();
 
-			driver.SetAttribute (new Attribute (BorderBrush));
+			SetBorderBrush (driver);
 
 			// Draw the upper BorderThickness
 			for (int r = frame.Y - drawMarginFrame - sumThickness.Top;
@@ -703,7 +678,7 @@ namespace Terminal.Gui {
 				}
 			}
 
-			driver.SetAttribute (new Attribute (Background));
+			SetBackground (driver);
 
 			// Draw the upper Padding
 			for (int r = frame.Y - drawMarginFrame - padding.Top;
@@ -745,7 +720,7 @@ namespace Terminal.Gui {
 				}
 			}
 
-			driver.SetAttribute (new Attribute (BorderBrush, Background));
+			SetBorderBrushBackground (driver);
 
 			// Draw the MarginFrame
 			if (DrawMarginFrame) {
@@ -816,7 +791,7 @@ namespace Terminal.Gui {
 
 			var savedAttribute = driver.GetAttribute ();
 
-			driver.SetAttribute (new Attribute (BorderBrush));
+			SetBorderBrush (driver);
 
 			// Draw the upper BorderThickness
 			for (int r = frame.Y;
@@ -858,7 +833,7 @@ namespace Terminal.Gui {
 				}
 			}
 
-			driver.SetAttribute (new Attribute (Background));
+			SetBackground (driver);
 
 			// Draw the upper Padding
 			for (int r = frame.Y + borderThickness.Top;
@@ -900,7 +875,7 @@ namespace Terminal.Gui {
 				}
 			}
 
-			driver.SetAttribute (new Attribute (BorderBrush, Background));
+			SetBorderBrushBackground (driver);
 
 			// Draw the MarginFrame
 			if (DrawMarginFrame) {
@@ -962,6 +937,37 @@ namespace Terminal.Gui {
 			driver.SetAttribute (savedAttribute);
 		}
 
+		private void SetBorderBrushBackground (ConsoleDriver driver)
+		{
+			if (borderBrush != null && background != null) {
+				driver.SetAttribute (new Attribute (BorderBrush, Background));
+			} else if (borderBrush != null && background == null) {
+				driver.SetAttribute (new Attribute (BorderBrush, Parent.ColorScheme.Normal.Background));
+			} else if (borderBrush == null && background != null) {
+				driver.SetAttribute (new Attribute (Parent.ColorScheme.Normal.Foreground, Background));
+			} else {
+				driver.SetAttribute (Parent.ColorScheme.Normal);
+			}
+		}
+
+		private void SetBackground (ConsoleDriver driver)
+		{
+			if (background != null) {
+				driver.SetAttribute (new Attribute (Background));
+			} else {
+				driver.SetAttribute (new Attribute (Parent.ColorScheme.Normal.Background));
+			}
+		}
+
+		private void SetBorderBrush (ConsoleDriver driver)
+		{
+			if (borderBrush != null) {
+				driver.SetAttribute (new Attribute (BorderBrush));
+			} else {
+				driver.SetAttribute (new Attribute (Parent.ColorScheme.Normal.Foreground));
+			}
+		}
+
 		private Attribute GetEffect3DBrush ()
 		{
 			return Effect3DBrush == null
@@ -989,9 +995,8 @@ namespace Terminal.Gui {
 		{
 			var driver = Application.Driver;
 			if (DrawMarginFrame) {
-				driver.SetAttribute (new Attribute (BorderBrush, Background));
-				if (view.HasFocus)
-					driver.SetAttribute (new Attribute (Child.ColorScheme.HotNormal.Foreground, Background));
+				SetBorderBrushBackground (driver);
+				SetHotNormalBackground (view, driver);
 				var padding = view.Border.GetSumThickness ();
 				Rect scrRect;
 				if (view == Child) {
@@ -1007,6 +1012,17 @@ namespace Terminal.Gui {
 			driver.SetAttribute (Child.GetNormalColor ());
 		}
 
+		private void SetHotNormalBackground (View view, ConsoleDriver driver)
+		{
+			if (view.HasFocus) {
+				if (background != null) {
+					driver.SetAttribute (new Attribute (Child.ColorScheme.HotNormal.Foreground, Background));
+				} else {
+					driver.SetAttribute (Child.ColorScheme.HotNormal);
+				}
+			}
+		}
+
 		/// <summary>
 		/// Draws the <see cref="View.Text"/> to the screen.
 		/// </summary>
@@ -1016,10 +1032,8 @@ namespace Terminal.Gui {
 		{
 			var driver = Application.Driver;
 			if (DrawMarginFrame) {
-				driver.SetAttribute (new Attribute (BorderBrush, Background));
-				if (view.HasFocus) {
-					driver.SetAttribute (new Attribute (view.ColorScheme.HotNormal.Foreground, Background));
-				}
+				SetBorderBrushBackground (driver);
+				SetHotNormalBackground (view, driver);
 				var padding = Parent.Border.GetSumThickness ();
 				var scrRect = Parent.ViewToScreen (new Rect (0, 0, rect.Width, rect.Height));
 				driver.DrawWindowTitle (scrRect, view.Text,

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -2693,8 +2693,9 @@ namespace Terminal.Gui {
 			} else if (currentRow - topRow + BottomOffset >= Frame.Height + offB.height) {
 				topRow = Math.Min (Math.Max (currentRow - Frame.Height + 1 + BottomOffset, 0), currentRow);
 				need = true;
-			} else if (topRow > 0 && currentRow == topRow) {
+			} else if (topRow > 0 && currentRow < topRow) {
 				topRow = Math.Max (topRow - 1, 0);
+				need = true;
 			}
 			if (need) {
 				if (wrapNeeded) {
@@ -4107,6 +4108,7 @@ namespace Terminal.Gui {
 			leftColumn = 0;
 			TrackColumn ();
 			PositionCursor ();
+			SetNeedsDisplay ();
 		}
 
 		bool MoveNext (ref int col, ref int row, out Rune rune)

--- a/UnitTests/Core/BorderTests.cs
+++ b/UnitTests/Core/BorderTests.cs
@@ -20,8 +20,8 @@ namespace Terminal.Gui.CoreTests {
 			Assert.Equal (BorderStyle.None, b.BorderStyle);
 			Assert.False (b.DrawMarginFrame);
 			Assert.Equal (default, b.BorderThickness);
-			Assert.Equal (default, b.BorderBrush);
-			Assert.Equal (default, b.Background);
+			Assert.Equal ((Color)(-1), b.BorderBrush);
+			Assert.Equal ((Color)(-1), b.Background);
 			Assert.Equal (default, b.Padding);
 			Assert.Equal (0, b.ActualWidth);
 			Assert.Equal (0, b.ActualHeight);
@@ -574,7 +574,7 @@ namespace Terminal.Gui.CoreTests {
 			var lblTop = new Label ("At 0,0");
 			var lblFrame = new Label ("Centered") { X = Pos.Center (), Y = Pos.Center () };
 			var frame = new FrameView () { Y = 1, Width = 20, Height = 3 };
-			var lblFill = new Label () { Width = Dim.Fill(),Height = Dim.Fill(), Visible = false };
+			var lblFill = new Label () { Width = Dim.Fill (), Height = Dim.Fill (), Visible = false };
 			var fillText = new System.Text.StringBuilder ();
 			for (int i = 0; i < frame.Bounds.Height; i++) {
 				if (i > 0) {

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -56,6 +56,5 @@
     <IncludeTestAssembly>
       False
     </IncludeTestAssembly>
-    <RunSettingsFilePath>C:\Users\charlie\s\gui-cs\Terminal.Gui\UnitTests\bin\Debug\net7.0\fine-code-coverage\coverage-tool-output\UnitTests-fcc-mscodecoverage-generated.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #2686 - The trick was changing the private members colors to nullable.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
