### PR TITLE
Add table example check to prevent crashes

### DIFF
--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -250,6 +250,11 @@ namespace UICatalog.Scenarios {
 
 		private void SetMinAcceptableWidthToOne ()
 		{
+			var columns = tableView?.Table?.Columns;
+			if (columns is null) {
+				MessageBox.ErrorQuery ("No Table", "No table is currently loaded", "Ok");
+				return;
+			}
 			foreach (DataColumn c in tableView.Table.Columns) 
 			{
 				var style = tableView.Style.GetOrCreateColumnStyle (c);
@@ -276,6 +281,10 @@ namespace UICatalog.Scenarios {
 
 		private void RunColumnWidthDialog (DataColumn col, string prompt, Action<ColumnStyle,int> setter,Func<ColumnStyle,int> getter)
 		{
+			if (col is null) {
+				MessageBox.ErrorQuery ("No Table", "No table is currently loaded", "Ok");
+				return;
+			}
 			var accepted = false;
 			var ok = new Button ("Ok", is_default: true);
 			ok.Clicked += () => { accepted = true; Application.RequestStop (); };


### PR DESCRIPTION
Fixes #2690. UICatalog - TableEditor crashes when accessing closed table
## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
