### PR TITLE
Fixes #2571. Wizards background shifts to gray when focusing, looks bad.

### DIFF
--- a/Terminal.Gui/Views/TabView.cs
+++ b/Terminal.Gui/Views/TabView.cs
@@ -22,11 +22,13 @@ namespace Terminal.Gui {
 		/// </summary>
 		TabRowView tabsBar;
 
+		private class TabContentView : View { }
+
 		/// <summary>
 		/// This sub view is the main client area of the current tab.  It hosts the <see cref="Tab.View"/> 
 		/// of the tab, the <see cref="SelectedTab"/>
 		/// </summary>
-		View contentView;
+		TabContentView contentView;
 		private List<Tab> tabs = new List<Tab> ();
 
 		/// <summary>
@@ -75,7 +77,13 @@ namespace Terminal.Gui {
 
 					if (selectedTab.View != null) {
 						// remove old content
-						contentView.Remove (selectedTab.View);
+						if (selectedTab.View.Subviews.Count == 0) {
+							contentView.Remove (selectedTab.View);
+						} else {
+							foreach (var view in selectedTab.View.Subviews) {
+								contentView.Remove (view);
+							}
+						}
 					}
 				}
 
@@ -85,7 +93,13 @@ namespace Terminal.Gui {
 
 					// add new content
 					if (selectedTab.View != null) {
-						contentView.Add (selectedTab.View);
+						if (selectedTab.View.Subviews.Count == 0) {
+							contentView.Add (selectedTab.View);
+						} else {
+							foreach (var view in selectedTab.View.Subviews) {
+								contentView.Add (view);
+							}
+						}
 					}
 				}
 
@@ -94,7 +108,6 @@ namespace Terminal.Gui {
 				if (old != value) {
 					OnSelectedTabChanged (old, value);
 				}
-
 			}
 		}
 
@@ -111,7 +124,7 @@ namespace Terminal.Gui {
 		public TabView () : base ()
 		{
 			CanFocus = true;
-			contentView = new View ();
+			contentView = new TabContentView ();
 			tabsBar = new TabRowView (this);
 
 			ApplyStyleChanges ();
@@ -195,7 +208,7 @@ namespace Terminal.Gui {
 				int startAtY = Math.Max (0, GetTabHeight (true) - 1);
 
 				DrawFrame (new Rect (0, startAtY, bounds.Width,
-			       Math.Max (bounds.Height - spaceAtBottom - startAtY, 0)), 0, true);
+					Math.Max (bounds.Height - spaceAtBottom - startAtY, 0)), 0, true);
 			}
 
 			if (Tabs.Any ()) {
@@ -222,7 +235,6 @@ namespace Terminal.Gui {
 				if (!Equals (SelectedTab, tab)) {
 					tab.View?.Dispose ();
 				}
-
 			}
 		}
 

--- a/Terminal.Gui/Views/TabView.cs
+++ b/Terminal.Gui/Views/TabView.cs
@@ -228,13 +228,9 @@ namespace Terminal.Gui {
 		{
 			base.Dispose (disposing);
 
-			// The selected tab will automatically be disposed but
-			// any tabs not visible will need to be manually disposed
-
+			// Manually dispose all tabs
 			foreach (var tab in Tabs) {
-				if (!Equals (SelectedTab, tab)) {
-					tab.View?.Dispose ();
-				}
+				tab.View?.Dispose ();
 			}
 		}
 

--- a/Terminal.Gui/Windows/Dialog.cs
+++ b/Terminal.Gui/Windows/Dialog.cs
@@ -187,7 +187,7 @@ namespace Terminal.Gui {
 						if (i == 0) {
 							// first (leftmost) button - always hard flush left
 							var left = Bounds.Width - ((Border.DrawMarginFrame ? 2 : 0) + Border.BorderThickness.Left + Border.BorderThickness.Right);
-							button.X = Pos.AnchorEnd (left);
+							button.X = Pos.AnchorEnd (Math.Max (left, 0));
 						} else {
 							shiftLeft += button.Frame.Width + (spacing);
 							button.X = Pos.AnchorEnd (shiftLeft);

--- a/Terminal.Gui/Windows/Wizard.cs
+++ b/Terminal.Gui/Windows/Wizard.cs
@@ -158,8 +158,14 @@ namespace Terminal.Gui {
 			/// </summary>
 			public event Action<TitleEventArgs> TitleChanged;
 
-			// The contentView works like the ContentView in FrameView.
-			private View contentView = new View () { Data = "WizardContentView" };
+			/// <summary>
+			/// WizardContentView is an internal implementation detail of Window. It is used to host Views added with <see cref="Add(View)"/>. 
+			/// Its ONLY reason for being is to provide a simple way for Window to expose to those SubViews that the Window's Bounds 
+			/// are actually deflated due to the border. 
+			/// </summary>
+			class WizardContentView : View { }
+
+			private WizardContentView contentView = new WizardContentView ();
 
 			/// <summary>
 			/// Sets or gets help text for the <see cref="WizardStep"/>.If <see cref="WizardStep.HelpText"/> is empty
@@ -383,6 +389,7 @@ namespace Terminal.Gui {
 				AddKeyBinding (Key.Esc, Command.QuitToplevel);
 			}
 
+			Initialized += (s, e) => Wizard_Loaded ();
 		}
 
 		private void Wizard_Loaded ()


### PR DESCRIPTION
Fixes #2571 - The contentView was clearing and change it to a derived class fixed the issue. Also the `CurrentStep` on a disabled Modal is always null and the first step was never selected.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
