### PR TITLE
Fixes #2717. Label not display fully when resizing terminal.

### DIFF
--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -1176,15 +1176,13 @@ namespace Terminal.Gui {
 			}
 
 			var isVertical = IsVerticalDirection (textDirection);
-			var savedClip = Application.Driver?.Clip;
-			var maxBounds = bounds;
-			if (Application.Driver != null) {
-				Application.Driver.Clip = maxBounds = containerBounds == default
-					? bounds
-					: new Rect (Math.Max (containerBounds.X, bounds.X),
+			var maxBounds = containerBounds == default
+				? bounds
+				: new Rect (Math.Max (containerBounds.X, bounds.X),
 					Math.Max (containerBounds.Y, bounds.Y),
-					Math.Max (Math.Min (containerBounds.Width, containerBounds.Right - bounds.Left), 0),
-					Math.Max (Math.Min (containerBounds.Height, containerBounds.Bottom - bounds.Top), 0));
+					Math.Max (Math.Max (containerBounds.Width, containerBounds.Right - bounds.Left), 0),
+					Math.Max (Math.Max (containerBounds.Height, containerBounds.Bottom - bounds.Top), 0));
+
 			int boundsStart = 0;
 			if (isVertical) {
 				if (bounds.X < 0) {
@@ -1195,7 +1193,6 @@ namespace Terminal.Gui {
 					boundsStart = bounds.Y;
 				}
 			}
-
 			for (int line = 0; line < linesFormated.Count; line++) {
 				if (boundsStart < 0) {
 					boundsStart++;
@@ -1292,7 +1289,7 @@ namespace Terminal.Gui {
 					} else if (!fillRemaining && idx > runes.Length - 1) {
 						break;
 					}
-					if ((!isVertical && idx > maxBounds.Left + maxBounds.Width - bounds.X) || (isVertical && idx > maxBounds.Top + maxBounds.Height - bounds.Y))
+					if ((!isVertical && idx >= maxBounds.Left + maxBounds.Width - bounds.X) || (isVertical && idx >= maxBounds.Top + maxBounds.Height - bounds.Y))
 						break;
 
 					var rune = (Rune)' ';
@@ -1330,8 +1327,6 @@ namespace Terminal.Gui {
 					}
 				}
 			}
-			if (Application.Driver != null)
-				Application.Driver.Clip = (Rect)savedClip;
 		}
 	}
 }

--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -1185,15 +1185,29 @@ namespace Terminal.Gui {
 					Math.Max (containerBounds.Y, bounds.Y),
 					Math.Max (Math.Min (containerBounds.Width, containerBounds.Right - bounds.Left), 0),
 					Math.Max (Math.Min (containerBounds.Height, containerBounds.Bottom - bounds.Top), 0));
+			int boundsStart = 0;
+			if (isVertical) {
+				if (bounds.X < 0) {
+					boundsStart = bounds.X;
+				}
+			} else {
+				if (bounds.Y < 0) {
+					boundsStart = bounds.Y;
+				}
 			}
 
 			for (int line = 0; line < linesFormated.Count; line++) {
-				if ((isVertical && line > bounds.Width) || (!isVertical && line > bounds.Height))
+				if (boundsStart < 0) {
+					boundsStart++;
 					continue;
+				}
+				if ((isVertical && line > bounds.Width) || (!isVertical && line > bounds.Height)) {
+					continue;
+				}
 				if ((isVertical && line >= maxBounds.Left + maxBounds.Width)
-					|| (!isVertical && line >= maxBounds.Top + maxBounds.Height))
-
+					|| (!isVertical && line >= maxBounds.Top + maxBounds.Height)) {
 					break;
+				}
 
 				var runes = lines [line].ToRunes ();
 

--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -1289,8 +1289,9 @@ namespace Terminal.Gui {
 					} else if (!fillRemaining && idx > runes.Length - 1) {
 						break;
 					}
-					if ((!isVertical && idx >= maxBounds.Left + maxBounds.Width - bounds.X) || (isVertical && idx >= maxBounds.Top + maxBounds.Height - bounds.Y))
+					if ((!isVertical && idx >= maxBounds.Left + maxBounds.Width - bounds.X) || (isVertical && idx >= maxBounds.Top + maxBounds.Height - bounds.Y)) {
 						break;
+					}
 
 					var rune = (Rune)' ';
 					if (isVertical) {

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1143,7 +1143,7 @@ namespace Terminal.Gui {
 		/// <param name="rcol">Absolute column; screen-relative.</param>
 		/// <param name="rrow">Absolute row; screen-relative.</param>
 		/// <param name="clipped">Whether to clip the result of the ViewToScreen method, if set to <see langword="true"/>, the rcol, rrow values are clamped to the screen (terminal) dimensions (0..TerminalDim-1).</param>
-		internal void ViewToScreen (int col, int row, out int rcol, out int rrow, bool clipped = true)
+		internal void ViewToScreen (int col, int row, out int rcol, out int rrow, bool clipped = false)
 		{
 			// Computes the real row, col relative to the screen.
 			rrow = row + frame.Y;
@@ -1283,7 +1283,7 @@ namespace Terminal.Gui {
 		/// <param name="row">Row.</param>
 		/// <param name="clipped">Whether to clip the result of the ViewToScreen method,
 		///  if set to <see langword="true"/>, the col, row values are clamped to the screen (terminal) dimensions (0..TerminalDim-1).</param>
-		public void Move (int col, int row, bool clipped = true)
+		public void Move (int col, int row, bool clipped = false)
 		{
 			if (Driver.Rows == 0) {
 				return;

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -4519,5 +4519,26 @@ At 0,0
 222";
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void Move_And_ViewToScreen_Should_Not_Use_Clipped_Parameter_As_True_By_Default_But_Only_For_Cursor ()
+		{
+			var container = new View () { Width = 10, Height = 2 };
+			var top = new View () { Width = 10, Height = 1 };
+			var label = new Label ("Label");
+			top.Add (label);
+			var bottom = new View () { Y = 1, Width = 10, Height = 1 };
+			container.Add (top, bottom);
+			Application.Top.Add (container);
+			Application.Begin (Application.Top);
+
+			TestHelpers.AssertDriverContentsAre (@"
+Label", output);
+
+			((FakeDriver)Application.Driver).SetBufferSize (10, 1);
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsAre (@"
+Label", output);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2717 - The negative location must be take on consideration to ignore his content.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
