### PR TITLE
Fixes #2739. UICatalog Text Editor Column / Row not be updated when c…ursor moving

### DIFF
--- a/UICatalog/Scenarios/Editor.cs
+++ b/UICatalog/Scenarios/Editor.cs
@@ -57,12 +57,6 @@ namespace UICatalog.Scenarios {
 
 			CreateDemoFile (_fileName);
 
-			var siCursorPosition = new StatusItem (Key.Null, "", null);
-
-			_textView.UnwrappedCursorPosition += (e) => {
-				siCursorPosition.Title = $"Ln {e.Y + 1}, Col {e.X + 1}";
-			};
-
 			LoadFile ();
 
 			Win.Add (_textView);
@@ -116,6 +110,8 @@ namespace UICatalog.Scenarios {
 
 			Application.Top.Add (menu);
 
+			var siCursorPosition = new StatusItem (Key.Null, "", null);
+
 			var statusBar = new StatusBar (new StatusItem [] {
 				siCursorPosition,
 				new StatusItem(Key.F2, "~F2~ Open", () => Open()),
@@ -124,6 +120,12 @@ namespace UICatalog.Scenarios {
 				new StatusItem(Key.CtrlMask | Key.Q, "~^Q~ Quit", () => Quit()),
 				new StatusItem(Key.Null, $"OS Clipboard IsSupported : {Clipboard.IsSupported}", null)
 			});
+
+			_textView.UnwrappedCursorPosition += (e) => {
+				siCursorPosition.Title = $"Ln {e.Y + 1}, Col {e.X + 1}";
+				statusBar.SetNeedsDisplay ();
+			};
+
 			Application.Top.Add (statusBar);
 
 			_scrollBar = new ScrollBarView (_textView, true);


### PR DESCRIPTION
Fixes #2739- Added `SetNeedsDisplay` to the status bar.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
