### PR TITLE
Fixes #415. Colors: The native method "COLOR_PAIRS" does not exist

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/binding.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/binding.cs
@@ -43,6 +43,7 @@
 //
 using System;
 using System.Runtime.InteropServices;
+using Terminal.Gui;
 
 namespace Unix.Terminal {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -93,7 +94,8 @@ namespace Unix.Terminal {
 
 					if (attempts == 1) {
 						attempts++;
-						if (Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystem.Contains ("opensuse")) {
+						var (exitCode, result) = ClipboardProcessRunner.Bash ("cat /etc/os-release", waitForOutput: true);
+						if (exitCode == 0 && result.Contains ("opensuse")) {
 							libs [0] = "libncursesw.so.5";
 						}
 					} else {

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -16,8 +16,6 @@
     <InformationalVersion>1.0</InformationalVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="NStack.Core" Version="1.0.7" />
     <InternalsVisibleTo Include="UnitTests" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #415 - This fix reduces dependencies from nuget packages and use bash runner to get the OS name with the command `cat /etc/os-release` which is supported on all `Linux` machine, I think.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
