### PR TITLE
Fixes #2750. MenuBar (without children) causes stack overflow when shortcut is pressed.

### DIFF
--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -1671,7 +1671,7 @@ namespace Terminal.Gui {
 					}
 					return true;
 				}
-				if (mi is MenuBarItem menuBarItem && !menuBarItem.IsTopLevel && FindAndOpenMenuByShortcut (kb, menuBarItem.Children)) {
+				if (mi is MenuBarItem menuBarItem && menuBarItem.Children != null && !menuBarItem.IsTopLevel && FindAndOpenMenuByShortcut (kb, menuBarItem.Children)) {
 					return true;
 				}
 			}

--- a/UnitTests/Menus/MenuTests.cs
+++ b/UnitTests/Menus/MenuTests.cs
@@ -1734,5 +1734,17 @@ Edit
 │                                      │
 └──────────────────────────────────────┘", output);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void MenuBarItem_Children_Null_Does_Not_Throw ()
+		{
+			var menu = new MenuBar (new MenuBarItem [] {
+				new MenuBarItem("Test", "", null)
+			});
+			Application.Top.Add (menu);
+
+			var exception = Record.Exception (() => menu.ProcessColdKey (new KeyEvent (Key.Space, new KeyModifiers ())));
+			Assert.Null (exception);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2750 - When calling FindAndOpenMenuByShortcut method recursively the `MenuBarItem` `Children` mustn't be null.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
