### PR TITLE
Ensure unit test process dies; Back ported non-threaded `FakeMainLoop` from v2

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeMainLoop.cs
@@ -1,97 +1,34 @@
 ﻿using System;
-using System.Threading;
 
 namespace Terminal.Gui {
-	/// <summary>
-	/// Mainloop intended to be used with the .NET System.Console API, and can
-	/// be used on Windows and Unix, it is cross platform but lacks things like
-	/// file descriptor monitoring.
-	/// </summary>
-	/// <remarks>
-	/// This implementation is used for FakeDriver.
-	/// </remarks>
-	public class FakeMainLoop : IMainLoopDriver {
-		AutoResetEvent keyReady = new AutoResetEvent (false);
-		AutoResetEvent waitForProbe = new AutoResetEvent (false);
-		ConsoleKeyInfo? keyResult = null;
-		MainLoop mainLoop;
-		Func<ConsoleKeyInfo> consoleKeyReaderFn = () => FakeConsole.ReadKey (true);
+	internal class FakeMainLoop : IMainLoopDriver {
 
-		/// <summary>
-		/// Invoked when a Key is pressed.
-		/// </summary>
 		public Action<ConsoleKeyInfo> KeyPressed;
 
-		/// <summary>
-		/// Creates an instance of the FakeMainLoop. <paramref name="consoleDriver"/> is not used.
-		/// </summary>
-		/// <param name="consoleDriver"></param>
 		public FakeMainLoop (ConsoleDriver consoleDriver = null)
 		{
 			// consoleDriver is not needed/used in FakeConsole
 		}
 
-		void WindowsKeyReader ()
-		{
-			while (true) {
-				waitForProbe.WaitOne ();
-				keyResult = consoleKeyReaderFn ();
-				keyReady.Set ();
-			}
-		}
-
-		void IMainLoopDriver.Setup (MainLoop mainLoop)
-		{
-			this.mainLoop = mainLoop;
-			Thread readThread = new Thread (WindowsKeyReader);
-			readThread.Start ();
-		}
-
-		void IMainLoopDriver.Wakeup ()
+		public void Setup (MainLoop mainLoop)
 		{
 		}
 
-		bool IMainLoopDriver.EventsPending (bool wait)
+		public void Wakeup ()
 		{
-			keyResult = null;
-			waitForProbe.Set ();
-
-			if (CheckTimers (wait, out var waitTimeout)) {
-				return true;
-			}
-
-			keyReady.WaitOne (waitTimeout);
-			return keyResult.HasValue;
+			// No implementation needed for FakeMainLoop
 		}
 
-		bool CheckTimers (bool wait, out int waitTimeout)
+		public bool EventsPending (bool wait)
 		{
-			long now = DateTime.UtcNow.Ticks;
-
-			if (mainLoop.timeouts.Count > 0) {
-				waitTimeout = (int)((mainLoop.timeouts.Keys [0] - now) / TimeSpan.TicksPerMillisecond);
-				if (waitTimeout < 0)
-					return true;
-			} else {
-				waitTimeout = -1;
-			}
-
-			if (!wait)
-				waitTimeout = 0;
-
-			int ic;
-			lock (mainLoop.idleHandlers) {
-				ic = mainLoop.idleHandlers.Count;
-			}
-
-			return ic > 0;
+			// Always return true for FakeMainLoop
+			return true;
 		}
 
-		void IMainLoopDriver.MainIteration ()
+		public void MainIteration ()
 		{
-			if (keyResult.HasValue) {
-				KeyPressed?.Invoke (keyResult.Value);
-				keyResult = null;
+			if (FakeConsole.MockKeyPresses.Count > 0) {
+				KeyPressed?.Invoke (FakeConsole.MockKeyPresses.Pop ());
 			}
 		}
 	}


### PR DESCRIPTION
When using ReSharper's unit test explorer, it becomes obvious that the unit test process is not getting killed correctly.

The problem is the threads created in FakeMainLoop don't get cleaned up. 

It turns out the thread created wasn't actually needed, so the fix is just to remove it. This not only simplifies the implementation but makes the unit tests much more reliable. 