### PR TITLE
Add DrawLine event to TreeView for advanced rendering manipulation

### DIFF
--- a/Terminal.Gui/Views/TreeView/Branch.cs
+++ b/Terminal.Gui/Views/TreeView/Branch.cs
@@ -65,11 +65,10 @@ namespace Terminal.Gui {
 
 			if (Depth >= tree.MaxDepth) {
 				children = Enumerable.Empty<T> ();
-			}
-			else {
+			} else {
 				children = tree.TreeBuilder.GetChildren (this.Model) ?? Enumerable.Empty<T> ();
 			}
-			
+
 			this.ChildBranches = children.ToDictionary (k => k, val => new Branch<T> (tree, this, val));
 		}
 
@@ -95,10 +94,10 @@ namespace Terminal.Gui {
 		/// <param name="availableWidth"></param>
 		public virtual void Draw (ConsoleDriver driver, ColorScheme colorScheme, int y, int availableWidth)
 		{
-			var cells = new List<RuneCell>();
+			var cells = new List<RuneCell> ();
 			int? indexOfExpandCollapseSymbol = null;
 			int indexOfModelText;
-			
+
 
 			// true if the current line of the tree is the selected one and control has focus
 			bool isSelected = tree.IsSelected (Model);
@@ -123,7 +122,7 @@ namespace Terminal.Gui {
 				if (toSkip > 0) {
 					toSkip--;
 				} else {
-					cells.Add(NewRuneCell(attr,r));
+					cells.Add (NewRuneCell (attr, r));
 					availableWidth -= r.GetColumns ();
 				}
 			}
@@ -153,13 +152,13 @@ namespace Terminal.Gui {
 				toSkip--;
 			} else {
 				indexOfExpandCollapseSymbol = cells.Count;
-				cells.Add(NewRuneCell(attr,expansion));
+				cells.Add (NewRuneCell (attr, expansion));
 				availableWidth -= expansion.GetColumns ();
 			}
 
 			// horizontal scrolling has already skipped the prefix but now must also skip some of the line body
 			if (toSkip > 0) {
-				
+
 				// For the event record a negative location for where model text starts since it
 				// is pushed off to the left because of scrolling
 				indexOfModelText = -toSkip;
@@ -169,9 +168,7 @@ namespace Terminal.Gui {
 				} else {
 					lineBody = lineBody.Substring (toSkip);
 				}
-			}
-			else
-			{
+			} else {
 				indexOfModelText = cells.Count;
 			}
 
@@ -202,18 +199,18 @@ namespace Terminal.Gui {
 			}
 
 			attr = modelColor;
-			cells.AddRange(lineBody.Select(r=>NewRuneCell(attr,new Rune(r))));
+			cells.AddRange (lineBody.Select (r => NewRuneCell (attr, new Rune (r))));
 
 			if (availableWidth > 0) {
 				attr = symbolColor;
-				cells.AddRange(
-					Enumerable.Repeat(
-						NewRuneCell(attr,new Rune(' ')),
+				cells.AddRange (
+					Enumerable.Repeat (
+						NewRuneCell (attr, new Rune (' ')),
 						availableWidth
 						));
 			}
 
-			var e = new DrawTreeViewLineEventArgs<T>{
+			var e = new DrawTreeViewLineEventArgs<T> {
 				Model = Model,
 				Y = y,
 				RuneCells = cells,
@@ -221,14 +218,12 @@ namespace Terminal.Gui {
 				IndexOfExpandCollapseSymbol = indexOfExpandCollapseSymbol,
 				IndexOfModelText = indexOfModelText,
 			};
-			tree.OnDrawLine(e);
+			tree.OnDrawLine (e);
 
-			if(!e.Handled)
-			{	
-				foreach(var cell in cells)
-				{
-					driver.SetAttribute(cell.ColorScheme.Normal);
-					driver.AddRune(cell.Rune);
+			if (!e.Handled) {
+				foreach (var cell in cells) {
+					driver.SetAttribute (cell.ColorScheme.Normal);
+					driver.AddRune (cell.Rune);
 				}
 			}
 
@@ -237,9 +232,9 @@ namespace Terminal.Gui {
 
 		private static RuneCell NewRuneCell (Attribute attr, Rune r)
 		{
-			return new RuneCell{
+			return new RuneCell {
 				Rune = r,
-				ColorScheme = new ColorScheme(attr)
+				ColorScheme = new ColorScheme (attr)
 			};
 		}
 

--- a/Terminal.Gui/Views/TreeView/Branch.cs
+++ b/Terminal.Gui/Views/TreeView/Branch.cs
@@ -201,10 +201,21 @@ namespace Terminal.Gui {
 						));
 			}
 
-			foreach(var cell in cells)
-			{
-				driver.SetAttribute(cell.ColorScheme.Normal);
-				driver.AddRune(cell.Rune);
+			var e = new DrawTreeViewLineEventArgs<T>{
+				Model = Model,
+				Y = y,
+				RuneCells = cells,
+				Tree = tree
+			};
+			tree.OnDrawLine(e);
+
+			if(!e.Handled)
+			{	
+				foreach(var cell in cells)
+				{
+					driver.SetAttribute(cell.ColorScheme.Normal);
+					driver.AddRune(cell.Rune);
+				}
 			}
 
 			driver.SetAttribute (colorScheme.Normal);

--- a/Terminal.Gui/Views/TreeView/Branch.cs
+++ b/Terminal.Gui/Views/TreeView/Branch.cs
@@ -96,6 +96,9 @@ namespace Terminal.Gui {
 		public virtual void Draw (ConsoleDriver driver, ColorScheme colorScheme, int y, int availableWidth)
 		{
 			var cells = new List<RuneCell>();
+			int? indexOfExpandCollapseSymbol = null;
+			int indexOfModelText;
+			
 
 			// true if the current line of the tree is the selected one and control has focus
 			bool isSelected = tree.IsSelected (Model);
@@ -149,18 +152,27 @@ namespace Terminal.Gui {
 			if (toSkip > 0) {
 				toSkip--;
 			} else {
-
+				indexOfExpandCollapseSymbol = cells.Count;
 				cells.Add(NewRuneCell(attr,expansion));
 				availableWidth -= expansion.GetColumns ();
 			}
 
 			// horizontal scrolling has already skipped the prefix but now must also skip some of the line body
 			if (toSkip > 0) {
+				
+				// For the event record a negative location for where model text starts since it
+				// is pushed off to the left because of scrolling
+				indexOfModelText = -toSkip;
+
 				if (toSkip > lineBody.Length) {
 					lineBody = "";
 				} else {
 					lineBody = lineBody.Substring (toSkip);
 				}
+			}
+			else
+			{
+				indexOfModelText = cells.Count;
 			}
 
 			// If body of line is too long
@@ -205,7 +217,9 @@ namespace Terminal.Gui {
 				Model = Model,
 				Y = y,
 				RuneCells = cells,
-				Tree = tree
+				Tree = tree,
+				IndexOfExpandCollapseSymbol = indexOfExpandCollapseSymbol,
+				IndexOfModelText = indexOfModelText,
 			};
 			tree.OnDrawLine(e);
 

--- a/Terminal.Gui/Views/TreeView/DrawTreeViewLineEventArgs.cs
+++ b/Terminal.Gui/Views/TreeView/DrawTreeViewLineEventArgs.cs
@@ -1,0 +1,66 @@
+﻿// This code is based on http://objectlistview.sourceforge.net (GPLv3 tree/list controls 
+// by phillip.piper@gmail.com). Phillip has explicitly granted permission for his design
+// and code to be used in this library under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Terminal.Gui {
+	/// <summary>
+	/// Event args for the <see cref="TreeView{T}.DrawLine"/> event
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class DrawTreeViewLineEventArgs<T> where T : class {
+
+		/// <summary>
+		/// The object at this line in the tree
+		/// </summary>
+		public T Model { get; init; }
+
+		/// <summary>
+		/// The <see cref="TreeView{T}"/> that is performing the
+		/// rendering.
+		/// </summary>
+		public TreeView<T> Tree { get; init; }
+
+		/// <summary>
+		/// The line within tree view bounds that is being rendered
+		/// </summary>
+		public int Y { get; init; }
+
+		/// <summary>
+		/// Set to true to cancel drawing (e.g. if you have already manually
+		/// drawn content).
+		/// </summary>
+		public bool Handled { get; set; }
+
+		/// <summary>
+		/// The rune and color of each symbol that will be rendered.  Note
+		/// that only <see cref="ColorScheme.Normal"/> is respected.  You
+		/// can modify these to change what is rendered.
+		/// </summary>
+		/// <remarks>
+		/// Changing the length of this collection may result in corrupt rendering
+		/// </remarks>
+		public List<RuneCell> RuneCells { get; init; }
+
+		/// <summary>
+		/// The notional index in <see cref="RuneCells"/> which contains the first
+		/// character of the <see cref="TreeView{T}.AspectGetter"/> text (i.e.
+		/// after all branch lines and expansion/collapse sybmols).
+		/// </summary>
+		/// <remarks>
+		/// May be negative or outside of bounds of <see cref="RuneCells"/> if the view
+		/// has been scrolled horizontally.
+		/// </remarks>
+
+		public int IndexOfModelText { get; init; }
+
+		/// <summary>
+		/// If line contains a branch that can be expanded/collapsed then this is
+		/// the index in <see cref="RuneCells"/> at which the symbol is (or null for
+		/// leaf elements).
+		/// </summary>
+		public int? IndexOfExpandCollapseSymbol { get; init; }
+
+	}
+}

--- a/Terminal.Gui/Views/TreeView/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView/TreeView.cs
@@ -563,10 +563,9 @@ namespace Terminal.Gui {
 			List<Branch<T>> toReturn = new List<Branch<T>> ();
 
 			foreach (var root in roots.Values) {
-				
+
 				var toAdd = AddToLineMap (root, false, out var isMatch);
-				if(isMatch)
-				{
+				if (isMatch) {
 					toReturn.AddRange (toAdd);
 				}
 			}
@@ -580,41 +579,38 @@ namespace Terminal.Gui {
 
 		private bool IsFilterMatch (Branch<T> branch)
 		{
-			return Filter?.IsMatch(branch.Model) ?? true;
+			return Filter?.IsMatch (branch.Model) ?? true;
 		}
 
-		private IEnumerable<Branch<T>> AddToLineMap (Branch<T> currentBranch,bool parentMatches, out bool match)
+		private IEnumerable<Branch<T>> AddToLineMap (Branch<T> currentBranch, bool parentMatches, out bool match)
 		{
-			bool weMatch = IsFilterMatch(currentBranch);
+			bool weMatch = IsFilterMatch (currentBranch);
 			bool anyChildMatches = false;
-			
-			var toReturn = new List<Branch<T>>();
-			var children = new List<Branch<T>>();
+
+			var toReturn = new List<Branch<T>> ();
+			var children = new List<Branch<T>> ();
 
 			if (currentBranch.IsExpanded) {
 				foreach (var subBranch in currentBranch.ChildBranches.Values) {
 
 					foreach (var sub in AddToLineMap (subBranch, weMatch, out var childMatch)) {
-						
-						if(childMatch)
-						{
-							children.Add(sub);
+
+						if (childMatch) {
+							children.Add (sub);
 							anyChildMatches = true;
 						}
 					}
 				}
 			}
 
-			if(parentMatches || weMatch || anyChildMatches)
-			{
+			if (parentMatches || weMatch || anyChildMatches) {
 				match = true;
-				toReturn.Add(currentBranch);
-			}
-			else{
+				toReturn.Add (currentBranch);
+			} else {
 				match = false;
 			}
-			
-			toReturn.AddRange(children);
+
+			toReturn.AddRange (children);
 			return toReturn;
 		}
 
@@ -1434,71 +1430,10 @@ namespace Terminal.Gui {
 		/// <param name="e"></param>
 		internal void OnDrawLine (DrawTreeViewLineEventArgs<T> e)
 		{
-			DrawLine?.Invoke(this,e);
+			DrawLine?.Invoke (this, e);
 		}
 
 	}
-
-	/// <summary>
-	/// Event args for the <see cref="TreeView{T}.DrawLine"/> event
-	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	public class DrawTreeViewLineEventArgs<T> where T : class{
-
-		/// <summary>
-		/// The object at this line in the tree
-		/// </summary>
-		public T Model {get;init;}
-
-		/// <summary>
-		/// The <see cref="TreeView{T}"/> that is performing the
-		/// rendering.
-		/// </summary>
-		public TreeView<T> Tree {get; init;}
-
-		/// <summary>
-		/// The line within tree view bounds that is being rendered
-		/// </summary>
-		public int Y {get;init;}
-
-		/// <summary>
-		/// Set to true to cancel drawing (e.g. if you have already manually
-		/// drawn content).
-		/// </summary>
-		public bool Handled {get;set;}
-
-		/// <summary>
-		/// The rune and color of each symbol that will be rendered.  Note
-		/// that only <see cref="ColorScheme.Normal"/> is respected.  You
-		/// can modify these to change what is rendered.
-		/// </summary>
-		/// <remarks>
-		/// Changing the length of this collection may result in corrupt rendering
-		/// </remarks>
-		public List<RuneCell> RuneCells {get; init;}
-
-		/// <summary>
-		/// The notional index in <see cref="RuneCells"/> which contains the first
-		/// character of the <see cref="TreeView{T}.AspectGetter"/> text (i.e.
-		/// after all branch lines and expansion/collapse sybmols).
-		/// </summary>
-		/// <remarks>
-		/// May be negative or outside of bounds of <see cref="RuneCells"/> if the view
-		/// has been scrolled horizontally.
-		/// </remarks>
-
-		public int IndexOfModelText {get;init;}
-
-		/// <summary>
-		/// If line contains a branch that can be expanded/collapsed then this is
-		/// the index in <see cref="RuneCells"/> at which the symbol is (or null for
-		/// leaf elements).
-		/// </summary>
-		public int? IndexOfExpandCollapseSymbol {get;init;}
-
-	}
-
-
 	class TreeSelection<T> where T : class {
 
 		public Branch<T> Origin { get; }

--- a/Terminal.Gui/Views/TreeView/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView/TreeView.cs
@@ -1476,6 +1476,26 @@ namespace Terminal.Gui {
 		/// Changing the length of this collection may result in corrupt rendering
 		/// </remarks>
 		public List<RuneCell> RuneCells {get; init;}
+
+		/// <summary>
+		/// The notional index in <see cref="RuneCells"/> which contains the first
+		/// character of the <see cref="TreeView{T}.AspectGetter"/> text (i.e.
+		/// after all branch lines and expansion/collapse sybmols).
+		/// </summary>
+		/// <remarks>
+		/// May be negative or outside of bounds of <see cref="RuneCells"/> if the view
+		/// has been scrolled horizontally.
+		/// </remarks>
+
+		public int IndexOfModelText {get;init;}
+
+		/// <summary>
+		/// If line contains a branch that can be expanded/collapsed then this is
+		/// the index in <see cref="RuneCells"/> at which the symbol is (or null for
+		/// leaf elements).
+		/// </summary>
+		public int? IndexOfExpandCollapseSymbol {get;init;}
+
 	}
 
 

--- a/Terminal.Gui/Views/TreeView/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView/TreeView.cs
@@ -170,6 +170,12 @@ namespace Terminal.Gui {
 		public event EventHandler<SelectionChangedEventArgs<T>> SelectionChanged;
 
 		/// <summary>
+		/// Called once for each visible row during rendering.  Can be used
+		/// to make last minute changes to color or text rendered
+		/// </summary>
+		public event EventHandler<DrawTreeViewLineEventArgs<T>> DrawLine;
+
+		/// <summary>
 		/// The root objects in the tree, note that this collection is of root objects only.
 		/// </summary>
 		public IEnumerable<T> Objects { get => roots.Keys; }
@@ -1421,7 +1427,57 @@ namespace Terminal.Gui {
 		{
 			SelectionChanged?.Invoke (this, e);
 		}
+
+		/// <summary>
+		/// Raises the DrawLine event
+		/// </summary>
+		/// <param name="e"></param>
+		internal void OnDrawLine (DrawTreeViewLineEventArgs<T> e)
+		{
+			DrawLine?.Invoke(this,e);
+		}
+
 	}
+
+	/// <summary>
+	/// Event args for the <see cref="TreeView{T}.DrawLine"/> event
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public class DrawTreeViewLineEventArgs<T> where T : class{
+
+		/// <summary>
+		/// The object at this line in the tree
+		/// </summary>
+		public T Model {get;init;}
+
+		/// <summary>
+		/// The <see cref="TreeView{T}"/> that is performing the
+		/// rendering.
+		/// </summary>
+		public TreeView<T> Tree {get; init;}
+
+		/// <summary>
+		/// The line within tree view bounds that is being rendered
+		/// </summary>
+		public int Y {get;init;}
+
+		/// <summary>
+		/// Set to true to cancel drawing (e.g. if you have already manually
+		/// drawn content).
+		/// </summary>
+		public bool Handled {get;set;}
+
+		/// <summary>
+		/// The rune and color of each symbol that will be rendered.  Note
+		/// that only <see cref="ColorScheme.Normal"/> is respected.  You
+		/// can modify these to change what is rendered.
+		/// </summary>
+		/// <remarks>
+		/// Changing the length of this collection may result in corrupt rendering
+		/// </remarks>
+		public List<RuneCell> RuneCells {get; init;}
+	}
+
 
 	class TreeSelection<T> where T : class {
 

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -84,6 +84,7 @@ namespace UICatalog.Scenarios {
 				Width = Dim.Percent (50),
 				Height = Dim.Fill (),
 			};
+			treeViewFiles.DrawLine += TreeViewFiles_DrawLine;
 
 			_detailsFrame = new DetailsFrame (_iconProvider) {
 				X = Pos.Right (treeViewFiles),
@@ -138,6 +139,26 @@ namespace UICatalog.Scenarios {
 		private void TreeViewFiles_SelectionChanged (object sender, SelectionChangedEventArgs<IFileSystemInfo> e)
 		{
 			ShowPropertiesOf (e.NewValue);
+		}
+
+		private void TreeViewFiles_DrawLine (object sender, DrawTreeViewLineEventArgs<IFileSystemInfo> e)
+		{
+			// Render directory icons in yellow
+			if(e.Model is IDirectoryInfo d)
+			{
+				if(_iconProvider.UseNerdIcons || _iconProvider.UseUnicodeCharacters)
+				{
+					if(e.IndexOfModelText > 0 && e.IndexOfModelText < e.RuneCells.Count)
+					{
+						var cell = e.RuneCells[e.IndexOfModelText];
+						cell.ColorScheme = new ColorScheme(
+							new Terminal.Gui.Attribute(
+								Color.BrightYellow,
+								cell.ColorScheme.Normal.Background)
+						);
+					}
+				}
+			}
 		}
 
 		private void TreeViewFiles_KeyPress (object sender, KeyEventEventArgs obj)

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -107,7 +107,7 @@ namespace UICatalog.Scenarios {
 			SetupScrollBar ();
 
 			treeViewFiles.SetFocus ();
-			
+
 			UpdateIconCheckedness ();
 		}
 
@@ -144,15 +144,12 @@ namespace UICatalog.Scenarios {
 		private void TreeViewFiles_DrawLine (object sender, DrawTreeViewLineEventArgs<IFileSystemInfo> e)
 		{
 			// Render directory icons in yellow
-			if(e.Model is IDirectoryInfo d)
-			{
-				if(_iconProvider.UseNerdIcons || _iconProvider.UseUnicodeCharacters)
-				{
-					if(e.IndexOfModelText > 0 && e.IndexOfModelText < e.RuneCells.Count)
-					{
-						var cell = e.RuneCells[e.IndexOfModelText];
-						cell.ColorScheme = new ColorScheme(
-							new Terminal.Gui.Attribute(
+			if (e.Model is IDirectoryInfo d) {
+				if (_iconProvider.UseNerdIcons || _iconProvider.UseUnicodeCharacters) {
+					if (e.IndexOfModelText > 0 && e.IndexOfModelText < e.RuneCells.Count) {
+						var cell = e.RuneCells [e.IndexOfModelText];
+						cell.ColorScheme = new ColorScheme (
+							new Terminal.Gui.Attribute (
 								Color.BrightYellow,
 								cell.ColorScheme.Normal.Background)
 						);
@@ -216,7 +213,7 @@ namespace UICatalog.Scenarios {
 			private IFileSystemInfo fileInfo;
 			private FileSystemIconProvider _iconProvider;
 
-			public DetailsFrame (FileSystemIconProvider  iconProvider)
+			public DetailsFrame (FileSystemIconProvider iconProvider)
 			{
 				Title = "Details";
 				Visible = true;
@@ -230,7 +227,7 @@ namespace UICatalog.Scenarios {
 					System.Text.StringBuilder sb = null;
 
 					if (fileInfo is IFileInfo f) {
-						Title = $"{_iconProvider.GetIconWithOptionalSpace(f)}{f.Name}".Trim();
+						Title = $"{_iconProvider.GetIconWithOptionalSpace (f)}{f.Name}".Trim ();
 						sb = new System.Text.StringBuilder ();
 						sb.AppendLine ($"Path:\n {f.FullName}\n");
 						sb.AppendLine ($"Size:\n {f.Length:N0} bytes\n");
@@ -239,7 +236,7 @@ namespace UICatalog.Scenarios {
 					}
 
 					if (fileInfo is IDirectoryInfo dir) {
-						Title = $"{_iconProvider.GetIconWithOptionalSpace(dir)}{dir.Name}".Trim();
+						Title = $"{_iconProvider.GetIconWithOptionalSpace (dir)}{dir.Name}".Trim ();
 						sb = new System.Text.StringBuilder ();
 						sb.AppendLine ($"Path:\n {dir?.FullName}\n");
 						sb.AppendLine ($"Modified:\n {dir.LastWriteTime}\n");
@@ -262,7 +259,7 @@ namespace UICatalog.Scenarios {
 
 			var scrollBar = new ScrollBarView (treeViewFiles, true);
 
-			scrollBar.ChangedPosition += (s,e) => {
+			scrollBar.ChangedPosition += (s, e) => {
 				treeViewFiles.ScrollOffsetVertical = scrollBar.Position;
 				if (treeViewFiles.ScrollOffsetVertical != scrollBar.Position) {
 					scrollBar.Position = treeViewFiles.ScrollOffsetVertical;
@@ -270,7 +267,7 @@ namespace UICatalog.Scenarios {
 				treeViewFiles.SetNeedsDisplay ();
 			};
 
-			scrollBar.OtherScrollBarView.ChangedPosition += (s,e) => {
+			scrollBar.OtherScrollBarView.ChangedPosition += (s, e) => {
 				treeViewFiles.ScrollOffsetHorizontal = scrollBar.OtherScrollBarView.Position;
 				if (treeViewFiles.ScrollOffsetHorizontal != scrollBar.OtherScrollBarView.Position) {
 					scrollBar.OtherScrollBarView.Position = treeViewFiles.ScrollOffsetHorizontal;
@@ -278,7 +275,7 @@ namespace UICatalog.Scenarios {
 				treeViewFiles.SetNeedsDisplay ();
 			};
 
-			treeViewFiles.DrawContent += (s,e) => {
+			treeViewFiles.DrawContent += (s, e) => {
 				scrollBar.Size = treeViewFiles.ContentHeight;
 				scrollBar.Position = treeViewFiles.ScrollOffsetVertical;
 				scrollBar.OtherScrollBarView.Size = treeViewFiles.GetContentWidth (true);
@@ -290,20 +287,20 @@ namespace UICatalog.Scenarios {
 		private void SetupFileTree ()
 		{
 			// setup how to build tree
-			var fs =  new FileSystem();
-			var rootDirs = DriveInfo.GetDrives ().Select (d=>fs.DirectoryInfo.New(d.RootDirectory.FullName));
+			var fs = new FileSystem ();
+			var rootDirs = DriveInfo.GetDrives ().Select (d => fs.DirectoryInfo.New (d.RootDirectory.FullName));
 			treeViewFiles.TreeBuilder = new FileSystemTreeBuilder ();
 			treeViewFiles.AddObjects (rootDirs);
 
 			// Determines how to represent objects as strings on the screen
 			treeViewFiles.AspectGetter = AspectGetter;
-			
+
 			_iconProvider.IsOpenGetter = treeViewFiles.IsExpanded;
 		}
 
 		private string AspectGetter (IFileSystemInfo f)
 		{
-				return (_iconProvider.GetIconWithOptionalSpace(f) + f.Name).Trim();
+			return (_iconProvider.GetIconWithOptionalSpace (f) + f.Name).Trim ();
 		}
 
 		private void ShowLines ()

--- a/UnitTests/Views/TreeViewTests.cs
+++ b/UnitTests/Views/TreeViewTests.cs
@@ -1124,6 +1124,47 @@ oot two
 		}
 
 		[Fact, AutoInitShutdown]
+		public void TestTreeView_DrawLineEvent_Handled ()
+		{
+			var tv = new TreeView { Width = 20, Height = 10 };
+
+			tv.DrawLine += (s, e) => {
+				if(e.Model.Text.Equals("leaf 1")) {
+					e.Handled = true;
+
+					for (int i = 0; i < 10; i++) {
+
+						e.Tree.AddRune (i,e.Y,new System.Text.Rune('F'));
+					}
+				}
+			};
+
+			var n1 = new TreeNode ("root one");
+			var n1_1 = new TreeNode ("leaf 1");
+			var n1_2 = new TreeNode ("leaf 2");
+			n1.Children.Add (n1_1);
+			n1.Children.Add (n1_2);
+
+			var n2 = new TreeNode ("root two");
+			tv.AddObject (n1);
+			tv.AddObject (n2);
+			tv.Expand (n1);
+
+			tv.ColorScheme = new ColorScheme ();
+			tv.LayoutSubviews ();
+			tv.Draw ();
+
+			// Normal drawing of the tree view
+			TestHelpers.AssertDriverContentsAre (
+@"
+├-root one
+FFFFFFFFFF
+│ └─leaf 2
+└─root two
+", output);
+		}
+
+		[Fact, AutoInitShutdown]
 		public void TestTreeView_Filter ()
 		{
 			var tv = new TreeView { Width = 20, Height = 10 };


### PR DESCRIPTION
Fixes #_____ - Added DrawLine event to TreeView for advanced rendering manipulation

![shot-2023-07-23_17-13-54](https://github.com/gui-cs/Terminal.Gui/assets/31306100/c1f55761-7625-45c3-8908-53e55c08c38b)
_TreeView with files visible that uses `DrawLine` event to render files in yellow_

### Design 
I have reused the `RuneCell` class for the line but I could instead use `List<Attribute>` and `List<Rune>`.  Both feel a little janky though.  `RuneCell` works with `ColorScheme` not `Attribute` so its not ideal.  Changing to lists introduces the possibility of them going out of sync (e.g. where user changes 1 list but not the other).  Finally I could change to `Tuple<Rune,Attribute>`.  Let me know what you think


## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
