### PR TITLE
Fixes 2780. Moving a Window that is Application.Top shouldn't be allowed.

### DIFF
--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -620,10 +620,10 @@ namespace Terminal.Gui {
 			//System.Diagnostics.Debug.WriteLine ($"nx:{nx}, rWidth:{rWidth}");
 			bool m = false, s = false;
 			mb = null; sb = null;
-			if (!(top is Window) && (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top)) {
+			if (!(top is Window && top == Application.Top) && (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top)) {
 				m = Application.Top.MenuBar?.Visible == true;
 				mb = Application.Top.MenuBar;
-			} else if (!(top is Window)) {
+			} else if (!(top is Window && top == Application.Top)) {
 				var t = top.SuperView;
 				while (!(t is Toplevel)) {
 					t = t.SuperView;
@@ -637,10 +637,10 @@ namespace Terminal.Gui {
 				l = 0;
 			}
 			ny = Math.Max (y, l);
-			if (!(top is Window) && (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top)) {
+			if (!(top is Window && top == Application.Top) && (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top)) {
 				s = Application.Top.StatusBar?.Visible == true;
 				sb = Application.Top.StatusBar;
-			} else if (!(top is Window)) {
+			} else if (!(top is Window && top == Application.Top)) {
 				var t = top.SuperView;
 				while (!(t is Toplevel)) {
 					t = t.SuperView;

--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -603,7 +603,7 @@ namespace Terminal.Gui {
 			out int nx, out int ny, out View mb, out View sb)
 		{
 			int l;
-			View superView;
+			View superView = null;
 			if (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top) {
 				l = Driver.Cols;
 				superView = Application.Top;
@@ -618,11 +618,12 @@ namespace Terminal.Gui {
 				nx = Math.Max (top.Frame.Right - mfLength, 0);
 			}
 			//System.Diagnostics.Debug.WriteLine ($"nx:{nx}, rWidth:{rWidth}");
-			bool m, s;
-			if (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top) {
+			bool m = false, s = false;
+			mb = null; sb = null;
+			if (!(top is Window) && (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top)) {
 				m = Application.Top.MenuBar?.Visible == true;
 				mb = Application.Top.MenuBar;
-			} else {
+			} else if (!(top is Window)) {
 				var t = top.SuperView;
 				while (!(t is Toplevel)) {
 					t = t.SuperView;
@@ -636,10 +637,10 @@ namespace Terminal.Gui {
 				l = 0;
 			}
 			ny = Math.Max (y, l);
-			if (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top) {
+			if (!(top is Window) && (top?.SuperView == null || top == Application.Top || top?.SuperView == Application.Top)) {
 				s = Application.Top.StatusBar?.Visible == true;
 				sb = Application.Top.StatusBar;
-			} else {
+			} else if (!(top is Window)) {
 				var t = top.SuperView;
 				while (!(t is Toplevel)) {
 					t = t.SuperView;


### PR DESCRIPTION
Fixes #2780 - Include a terse summary of the change or which issue is fixed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
