### PR TITLE
Fixes #2784. CursesDriver throws System.StackOverflowException on console resizing.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -497,8 +497,19 @@ namespace Terminal.Gui {
 			}
 		}
 
+		MouseFlags lastMouseFlags;
+
 		void ProcessMouseEvent (MouseFlags mouseFlag, Point pos)
 		{
+			if (((mouseFlag.HasFlag (MouseFlags.Button1Released) || mouseFlag.HasFlag (MouseFlags.Button2Released) || mouseFlag.HasFlag (MouseFlags.Button3Released) || mouseFlag.HasFlag (MouseFlags.Button4Released))
+				&& (!lastMouseFlags.HasFlag (MouseFlags.Button1Pressed) || !lastMouseFlags.HasFlag (MouseFlags.Button2Pressed) || !lastMouseFlags.HasFlag (MouseFlags.Button3Pressed) || !lastMouseFlags.HasFlag (MouseFlags.Button4Pressed)))
+				|| ((mouseFlag.HasFlag (MouseFlags.Button1Clicked) || mouseFlag.HasFlag (MouseFlags.Button2Clicked) || mouseFlag.HasFlag (MouseFlags.Button3Clicked) || mouseFlag.HasFlag (MouseFlags.Button4Clicked)
+				|| mouseFlag.HasFlag (MouseFlags.Button1DoubleClicked) || mouseFlag.HasFlag (MouseFlags.Button2DoubleClicked) || mouseFlag.HasFlag (MouseFlags.Button3DoubleClicked) || mouseFlag.HasFlag (MouseFlags.Button4DoubleClicked))
+				&& lastMouseFlags == 0)) {
+
+				return;
+			}
+			lastMouseFlags = mouseFlag;
 			var me = new MouseEvent () {
 				Flags = mouseFlag,
 				X = pos.X,

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -504,14 +504,39 @@ namespace Terminal.Gui {
 
 		void ProcessMouseEvent (MouseFlags mouseFlag, Point pos)
 		{
-			if (((mouseFlag.HasFlag (MouseFlags.Button1Released) || mouseFlag.HasFlag (MouseFlags.Button2Released) || mouseFlag.HasFlag (MouseFlags.Button3Released) || mouseFlag.HasFlag (MouseFlags.Button4Released))
-				&& (!lastMouseFlags.HasFlag (MouseFlags.Button1Pressed) || !lastMouseFlags.HasFlag (MouseFlags.Button2Pressed) || !lastMouseFlags.HasFlag (MouseFlags.Button3Pressed) || !lastMouseFlags.HasFlag (MouseFlags.Button4Pressed)))
-				|| ((mouseFlag.HasFlag (MouseFlags.Button1Clicked) || mouseFlag.HasFlag (MouseFlags.Button2Clicked) || mouseFlag.HasFlag (MouseFlags.Button3Clicked) || mouseFlag.HasFlag (MouseFlags.Button4Clicked)
-				|| mouseFlag.HasFlag (MouseFlags.Button1DoubleClicked) || mouseFlag.HasFlag (MouseFlags.Button2DoubleClicked) || mouseFlag.HasFlag (MouseFlags.Button3DoubleClicked) || mouseFlag.HasFlag (MouseFlags.Button4DoubleClicked))
-				&& lastMouseFlags == 0)) {
+			bool WasButtonReleased (MouseFlags flag)
+			{
+				return flag.HasFlag (MouseFlags.Button1Released) ||
+					flag.HasFlag (MouseFlags.Button2Released) ||
+					flag.HasFlag (MouseFlags.Button3Released) ||
+					flag.HasFlag (MouseFlags.Button4Released);
+			}
 
+			bool IsButtonNotPressed (MouseFlags flag)
+			{
+				return !flag.HasFlag (MouseFlags.Button1Pressed) &&
+					!flag.HasFlag (MouseFlags.Button2Pressed) &&
+					!flag.HasFlag (MouseFlags.Button3Pressed) &&
+					!flag.HasFlag (MouseFlags.Button4Pressed);
+			}
+
+			bool IsButtonClickedOrDoubleClicked (MouseFlags flag)
+			{
+				return flag.HasFlag (MouseFlags.Button1Clicked) ||
+					flag.HasFlag (MouseFlags.Button2Clicked) ||
+					flag.HasFlag (MouseFlags.Button3Clicked) ||
+					flag.HasFlag (MouseFlags.Button4Clicked) ||
+					flag.HasFlag (MouseFlags.Button1DoubleClicked) ||
+					flag.HasFlag (MouseFlags.Button2DoubleClicked) ||
+					flag.HasFlag (MouseFlags.Button3DoubleClicked) ||
+					flag.HasFlag (MouseFlags.Button4DoubleClicked);
+			}
+
+			if ((WasButtonReleased (mouseFlag) && IsButtonNotPressed (lastMouseFlags)) ||
+				(IsButtonClickedOrDoubleClicked (mouseFlag) && lastMouseFlags == 0)) {
 				return;
 			}
+
 			lastMouseFlags = mouseFlag;
 			var me = new MouseEvent () {
 				Flags = mouseFlag,

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -160,10 +160,9 @@ namespace Terminal.Gui {
 			StopReportingMouseMoves ();
 			SetCursorVisibility (CursorVisibility.Default);
 
-			var code = Curses.get_wch (out _);
-			while (code != -1) {
-				code = Curses.get_wch (out _);
-			}
+			// throws away any typeahead that has been typed by
+			// the user and has not yet been read by the program.
+			Curses.flushinp ();
 
 			Curses.endwin ();
 		}

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -341,14 +341,12 @@ namespace Terminal.Gui {
 			Key k = Key.Null;
 
 			if (code == Curses.KEY_CODE_YES) {
-				if (wch == Curses.KeyResize) {
-					while (code == Curses.KEY_CODE_YES && wch == Curses.KeyResize) {
-						ProcessWinChange ();
-						code = Curses.get_wch (out wch);
-					}
-					if (wch == 0) {
-						return;
-					}
+				while (code == Curses.KEY_CODE_YES && wch == Curses.KeyResize) {
+					ProcessWinChange ();
+					code = Curses.get_wch (out wch);
+				}
+				if (wch == 0) {
+					return;
 				}
 				if (wch == Curses.KeyMouse) {
 					int wch2 = wch;

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -142,7 +142,6 @@ namespace Terminal.Gui {
 			Curses.raw ();
 			Curses.noecho ();
 			Curses.refresh ();
-			ProcessWinChange ();
 		}
 
 		private void ProcessWinChange ()
@@ -338,7 +337,13 @@ namespace Terminal.Gui {
 
 			if (code == Curses.KEY_CODE_YES) {
 				if (wch == Curses.KeyResize) {
-					ProcessWinChange ();
+					while (code == Curses.KEY_CODE_YES && wch == Curses.KeyResize) {
+						ProcessWinChange ();
+						code = Curses.get_wch (out wch);
+					}
+					if (wch == 0) {
+						return;
+					}
 				}
 				if (wch == Curses.KeyMouse) {
 					int wch2 = wch;
@@ -529,7 +534,7 @@ namespace Terminal.Gui {
 			});
 
 			mLoop.WinChanged += () => {
-				ProcessWinChange ();
+				ProcessInput ();
 			};
 		}
 

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -160,6 +160,11 @@ namespace Terminal.Gui {
 			StopReportingMouseMoves ();
 			SetCursorVisibility (CursorVisibility.Default);
 
+			var code = Curses.get_wch (out _);
+			while (code != -1) {
+				code = Curses.get_wch (out _);
+			}
+
 			Curses.endwin ();
 		}
 

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -97,8 +97,8 @@ namespace Terminal.Gui {
 		{
 			this.mainLoop = mainLoop;
 			pipe (wakeupPipes);
-			AddWatch (wakeupPipes [0], Condition.PollIn, ml => {
-				read (wakeupPipes [0], ignore, readHandle);
+			AddWatch (wakeupPipes [1], Condition.PollIn, ml => {
+				read (wakeupPipes [1], ignore, readHandle);
 				return true;
 			});
 		}

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/binding.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/binding.cs
@@ -160,7 +160,10 @@ namespace Unix.Terminal {
 
 			console_sharp_get_dims (out l, out c);
 
-			if (l == 1 || l != lines || c != cols) {
+			if (l < 1) {
+				l = 1;
+			}
+			if (l != lines || c != cols) {
 				lines = l;
 				cols = c;
 				return true;


### PR DESCRIPTION
Fixes #2784 - The cause of the `System.StackOverflowException` was the `ProcessWinChange` being called recursively in the `Refresh` method when the terminal is while resizing. Another issue was the `WinChanged` was calling the `ProcessWinChange` method where the `Lines` and `Cols` wasn't yet updated  by the `ncurses` returning false. Afterwards it is necessary some keystroke or mouse move to later process the `Curses.KeyResize` which is what really work for resizing the terminal. One more issue was the `wakeupPipes` reading the 0 index when it must read the 1 index. The issue that was causing is when we open another scenario the main loop is continuous running even no keystroke, mouse move, timers or idle handlers to run.

The only issue that still remaining on `Windows 11` is that related here https://github.com/dotnet/runtime/issues/80695#issuecomment-1666253761.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
