### PR TITLE
Fixes #2793. Windows Terminal still show vertical scroll bar using WindowsDriver.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1426,17 +1426,15 @@ namespace Terminal.Gui {
 
 			try {
 				// Needed for Windows Terminal
-				// ESC [ ? 1047 h  Activate xterm alternative buffer (no backscroll)
-				// ESC [ ? 1047 l  Restore xterm working buffer (with backscroll)
+				// ESC [ ? 1047 h  Save cursor position and activate xterm alternative buffer (no backscroll)
+				// ESC [ ? 1047 l  Restore cursor position and restore xterm working buffer (with backscroll)
 				// ESC [ ? 1048 h  Save cursor position
 				// ESC [ ? 1048 l  Restore cursor position
-				// ESC [ ? 1049 h  Save cursor position and activate xterm alternative buffer (no backscroll)
-				// ESC [ ? 1049 l  Restore cursor position and restore xterm working buffer (with backscroll)
-				// Per Issue #2264 using the alterantive screen buffer is required for Windows Terminal to not 
+				// ESC [ ? 1049 h  Activate xterm alternative buffer (no backscroll)
+				// ESC [ ? 1049 l  Restore xterm working buffer (with backscroll)
+				// Per Issue #2264 using the alternative screen buffer is required for Windows Terminal to not 
 				// wipe out the backscroll buffer when the application exits.
-				Console.Out.Write ("\x1b[?1047h");
-
-				Console.Out.Write ("\x1b[3J");
+				Console.Out.Write ("\x1b[?1049h");
 
 				var winSize = WinConsole.GetConsoleOutputWindow (out Point pos);
 				cols = winSize.Width;
@@ -1475,8 +1473,6 @@ namespace Terminal.Gui {
 				Bottom = (short)Rows,
 				Right = (short)Cols
 			};
-			Console.Out.Write ("\x1b[3J");
-
 			WinConsole.ForceRefreshCursorVisibility ();
 		}
 
@@ -1685,7 +1681,7 @@ namespace Terminal.Gui {
 			WinConsole = null;
 
 			// Disable alternative screen buffer.
-			Console.Out.Write ("\x1b[?1047l");
+			Console.Out.Write ("\x1b[?1049l");
 		}
 
 		/// <inheritdoc/>

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1420,6 +1420,7 @@ namespace Terminal.Gui {
 			return keyMod != Key.Null ? keyMod | key : key;
 		}
 
+#pragma warning disable CA1416 // Validate platform compatibility
 		private static string GetParentProcessName ()
 		{
 			var myId = Process.GetCurrentProcess ().Id;
@@ -1456,6 +1457,7 @@ namespace Terminal.Gui {
 
 			return parent.ProcessName;
 		}
+#pragma warning restore CA1416 // Validate platform compatibility
 
 		public override void Init (Action terminalResized)
 		{

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1436,6 +1436,8 @@ namespace Terminal.Gui {
 				// wipe out the backscroll buffer when the application exits.
 				Console.Out.Write ("\x1b[?1047h");
 
+				Console.Out.Write ("\x1b[3J");
+
 				var winSize = WinConsole.GetConsoleOutputWindow (out Point pos);
 				cols = winSize.Width;
 				rows = winSize.Height;
@@ -1473,6 +1475,8 @@ namespace Terminal.Gui {
 				Bottom = (short)Rows,
 				Right = (short)Cols
 			};
+			Console.Out.Write ("\x1b[3J");
+
 			WinConsole.ForceRefreshCursorVisibility ();
 		}
 

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -5,7 +5,9 @@ using NStack;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
+using System.Management;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1420,9 +1422,9 @@ namespace Terminal.Gui {
 			return keyMod != Key.Null ? keyMod | key : key;
 		}
 
-#pragma warning disable CA1416 // Validate platform compatibility
 		private static string GetParentProcessName ()
 		{
+#pragma warning disable CA1416 // Validate platform compatibility
 			var myId = Process.GetCurrentProcess ().Id;
 			var query = string.Format ($"SELECT ParentProcessId FROM Win32_Process WHERE ProcessId = {myId}");
 			var search = new ManagementObjectSearcher ("root\\CIMV2", query);
@@ -1456,8 +1458,8 @@ namespace Terminal.Gui {
 			}
 
 			return parent.ProcessName;
-		}
 #pragma warning restore CA1416 // Validate platform compatibility
+		}
 
 		public override void Init (Action terminalResized)
 		{

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -5,9 +5,7 @@ using NStack;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
-using System.Management;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1683,7 +1681,6 @@ namespace Terminal.Gui {
 
 		public override void End ()
 		{
-
 			WinConsole.Cleanup ();
 			WinConsole = null;
 

--- a/Terminal.Gui/Core/Border.cs
+++ b/Terminal.Gui/Core/Border.cs
@@ -445,10 +445,12 @@ namespace Terminal.Gui {
 
 		private void Parent_Removed (View obj)
 		{
-			if (borderBrush != null) {
+			if (borderBrush != null)
+			{
 				BorderBrush = default;
 			}
-			if (background != null) {
+			if (background != null)
+			{
 				Background = default;
 			}
 			child.Removed -= Parent_Removed;
@@ -798,7 +800,7 @@ namespace Terminal.Gui {
 			SetBorderBrush (driver);
 
 			// Draw the upper BorderThickness
-			for (int r = Math.Max (frame.Y, 0);
+			for (int r = frame.Y;
 				r < Math.Min (frame.Y + borderThickness.Top, frame.Bottom); r++) {
 				for (int c = frame.X;
 					c < Math.Min (frame.Right, driver.Cols); c++) {
@@ -808,7 +810,7 @@ namespace Terminal.Gui {
 			}
 
 			// Draw the left BorderThickness
-			for (int r = Math.Max (Math.Min (frame.Y + borderThickness.Top, frame.Bottom), 0);
+			for (int r = Math.Min (frame.Y + borderThickness.Top, frame.Bottom);
 				r < Math.Min (frame.Bottom - borderThickness.Bottom, driver.Rows); r++) {
 				for (int c = frame.X;
 					c < Math.Min (frame.X + borderThickness.Left, frame.Right); c++) {
@@ -818,7 +820,7 @@ namespace Terminal.Gui {
 			}
 
 			// Draw the right BorderThickness
-			for (int r = Math.Max (Math.Min (frame.Y + borderThickness.Top, frame.Bottom), 0);
+			for (int r = Math.Min (frame.Y + borderThickness.Top, frame.Bottom);
 				r < Math.Min (frame.Bottom - borderThickness.Bottom, driver.Rows); r++) {
 				for (int c = Math.Max (frame.Right - borderThickness.Right, frame.X);
 					c < Math.Min (frame.Right, driver.Cols); c++) {
@@ -840,7 +842,7 @@ namespace Terminal.Gui {
 			SetBackground (driver);
 
 			// Draw the upper Padding
-			for (int r = Math.Max (frame.Y + borderThickness.Top, 0);
+			for (int r = frame.Y + borderThickness.Top;
 				r < Math.Min (frame.Y + sumThickness.Top, frame.Bottom - borderThickness.Bottom); r++) {
 				for (int c = frame.X + borderThickness.Left;
 					c < Math.Min (frame.Right - borderThickness.Right, driver.Cols); c++) {
@@ -850,7 +852,7 @@ namespace Terminal.Gui {
 			}
 
 			// Draw the left Padding
-			for (int r = Math.Max (frame.Y + sumThickness.Top, 0);
+			for (int r = frame.Y + sumThickness.Top;
 				r < Math.Min (frame.Bottom - sumThickness.Bottom, driver.Rows); r++) {
 				for (int c = frame.X + borderThickness.Left;
 					c < Math.Min (frame.X + sumThickness.Left, frame.Right - borderThickness.Right); c++) {
@@ -860,7 +862,7 @@ namespace Terminal.Gui {
 			}
 
 			// Draw the right Padding
-			for (int r = Math.Max (frame.Y + sumThickness.Top, 0);
+			for (int r = frame.Y + sumThickness.Top;
 				r < Math.Min (frame.Bottom - sumThickness.Bottom, driver.Rows); r++) {
 				for (int c = Math.Max (frame.Right - sumThickness.Right, frame.X + sumThickness.Left);
 					c < Math.Max (frame.Right - borderThickness.Right, frame.X + sumThickness.Left); c++) {

--- a/Terminal.Gui/Core/Border.cs
+++ b/Terminal.Gui/Core/Border.cs
@@ -445,12 +445,10 @@ namespace Terminal.Gui {
 
 		private void Parent_Removed (View obj)
 		{
-			if (borderBrush != null)
-			{
+			if (borderBrush != null) {
 				BorderBrush = default;
 			}
-			if (background != null)
-			{
+			if (background != null) {
 				Background = default;
 			}
 			child.Removed -= Parent_Removed;
@@ -800,7 +798,7 @@ namespace Terminal.Gui {
 			SetBorderBrush (driver);
 
 			// Draw the upper BorderThickness
-			for (int r = frame.Y;
+			for (int r = Math.Max (frame.Y, 0);
 				r < Math.Min (frame.Y + borderThickness.Top, frame.Bottom); r++) {
 				for (int c = frame.X;
 					c < Math.Min (frame.Right, driver.Cols); c++) {
@@ -810,7 +808,7 @@ namespace Terminal.Gui {
 			}
 
 			// Draw the left BorderThickness
-			for (int r = Math.Min (frame.Y + borderThickness.Top, frame.Bottom);
+			for (int r = Math.Max (Math.Min (frame.Y + borderThickness.Top, frame.Bottom), 0);
 				r < Math.Min (frame.Bottom - borderThickness.Bottom, driver.Rows); r++) {
 				for (int c = frame.X;
 					c < Math.Min (frame.X + borderThickness.Left, frame.Right); c++) {
@@ -820,7 +818,7 @@ namespace Terminal.Gui {
 			}
 
 			// Draw the right BorderThickness
-			for (int r = Math.Min (frame.Y + borderThickness.Top, frame.Bottom);
+			for (int r = Math.Max (Math.Min (frame.Y + borderThickness.Top, frame.Bottom), 0);
 				r < Math.Min (frame.Bottom - borderThickness.Bottom, driver.Rows); r++) {
 				for (int c = Math.Max (frame.Right - borderThickness.Right, frame.X);
 					c < Math.Min (frame.Right, driver.Cols); c++) {
@@ -842,7 +840,7 @@ namespace Terminal.Gui {
 			SetBackground (driver);
 
 			// Draw the upper Padding
-			for (int r = frame.Y + borderThickness.Top;
+			for (int r = Math.Max (frame.Y + borderThickness.Top, 0);
 				r < Math.Min (frame.Y + sumThickness.Top, frame.Bottom - borderThickness.Bottom); r++) {
 				for (int c = frame.X + borderThickness.Left;
 					c < Math.Min (frame.Right - borderThickness.Right, driver.Cols); c++) {
@@ -852,7 +850,7 @@ namespace Terminal.Gui {
 			}
 
 			// Draw the left Padding
-			for (int r = frame.Y + sumThickness.Top;
+			for (int r = Math.Max (frame.Y + sumThickness.Top, 0);
 				r < Math.Min (frame.Bottom - sumThickness.Bottom, driver.Rows); r++) {
 				for (int c = frame.X + borderThickness.Left;
 					c < Math.Min (frame.X + sumThickness.Left, frame.Right - borderThickness.Right); c++) {
@@ -862,7 +860,7 @@ namespace Terminal.Gui {
 			}
 
 			// Draw the right Padding
-			for (int r = frame.Y + sumThickness.Top;
+			for (int r = Math.Max (frame.Y + sumThickness.Top, 0);
 				r < Math.Min (frame.Bottom - sumThickness.Bottom, driver.Rows); r++) {
 				for (int c = Math.Max (frame.Right - sumThickness.Right, frame.X + sumThickness.Left);
 					c < Math.Max (frame.Right - borderThickness.Right, frame.X + sumThickness.Left); c++) {

--- a/UICatalog/Properties/launchSettings.json
+++ b/UICatalog/Properties/launchSettings.json
@@ -52,7 +52,12 @@
       "commandLineArgs": "\"Windows & FrameViews\""
     },
     "Docker": {
-      "commandName": "Docker"      
+      "commandName": "Docker"
+    },
+    "UICatalog WT": {
+      "commandName": "Executable",
+      "executablePath": "wt",
+      "commandLineArgs": "UICatalog.exe"
     }
   }
 }


### PR DESCRIPTION
Fixes #2793 - Since WT doesn't allows resizing the buffer using Win32 API, we need to use the `"\x1b[3J"` escape sequence. This issue only happens running `WindowsDriver` on `Windows Terminal`. @tig please reconsider this because we mustn't allow WT breaking the back buffer because the scroll bar is enabled after resizing. With all others drivers this issue doesn't happens on WT.

**Edit:**
There is no need to use `"\x1b[3J"` but only `"\x1b[?1049h"` to activate alternate buffer on enter and `"\x1b[?1049l"` to disable alternate buffer on exit. Only valid for the `Windows Terminal`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
