### PR TITLE
Fixes #2808. v2 ColorTests unit test is failing on Windows when testing the CursesDriver instance.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -666,6 +666,9 @@ internal class CursesDriver : ConsoleDriver {
 
 		TerminalResized = terminalResized;
 
+		if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+			Clipboard = new FakeDriver.FakeClipboard ();
+		} else {
 		if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
 			Clipboard = new MacOSXClipboard ();
 		} else {
@@ -674,6 +677,7 @@ internal class CursesDriver : ConsoleDriver {
 			} else {
 				Clipboard = new CursesClipboard ();
 			}
+		}
 		}
 
 		ClearContents ();

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -669,15 +669,15 @@ internal class CursesDriver : ConsoleDriver {
 		if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
 			Clipboard = new FakeDriver.FakeClipboard ();
 		} else {
-		if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
-			Clipboard = new MacOSXClipboard ();
-		} else {
-			if (Is_WSL_Platform ()) {
-				Clipboard = new WSLClipboard ();
+			if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
+				Clipboard = new MacOSXClipboard ();
 			} else {
-				Clipboard = new CursesClipboard ();
+				if (Is_WSL_Platform ()) {
+					Clipboard = new WSLClipboard ();
+				} else {
+					Clipboard = new CursesClipboard ();
+				}
 			}
-		}
 		}
 
 		ClearContents ();


### PR DESCRIPTION
Fixes #2808 - Forces using `FakeClipboard` on the `CursesDriver` instance.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
