### PR TITLE
Fixes #2834. v1 Border BorderBrush and Background wrongly sets to an invalid Color enum.

### DIFF
--- a/Terminal.Gui/Core/Border.cs
+++ b/Terminal.Gui/Core/Border.cs
@@ -375,8 +375,10 @@ namespace Terminal.Gui {
 		public Color BorderBrush {
 			get => borderBrush != null ? (Color)borderBrush : (Color)(-1);
 			set {
-				borderBrush = value;
-				OnBorderChanged ();
+				if (Enum.IsDefined (typeof (Color), value)) {
+					borderBrush = value;
+					OnBorderChanged ();
+				}
 			}
 		}
 
@@ -386,8 +388,10 @@ namespace Terminal.Gui {
 		public Color Background {
 			get => background != null ? (Color)background : (Color)(-1);
 			set {
-				background = value;
-				OnBorderChanged ();
+				if (Enum.IsDefined (typeof (Color), value)) {
+					background = value;
+					OnBorderChanged ();
+				}
 			}
 		}
 
@@ -445,12 +449,10 @@ namespace Terminal.Gui {
 
 		private void Parent_Removed (View obj)
 		{
-			if (borderBrush != null)
-			{
+			if (borderBrush != null) {
 				BorderBrush = default;
 			}
-			if (background != null)
-			{
+			if (background != null) {
 				Background = default;
 			}
 			child.Removed -= Parent_Removed;

--- a/UnitTests/Core/BorderTests.cs
+++ b/UnitTests/Core/BorderTests.cs
@@ -619,5 +619,29 @@ At 0,0
 ████████████████████
 At 0,4              ", output);
 		}
+
+		[Fact]
+		public void BorderBrush_Background_Only_Is_Set_To_Valid_Color_Enum ()
+		{
+			var border = new Border ();
+			Assert.Equal ((Color)(-1), border.BorderBrush);
+			Assert.Equal ((Color)(-1), border.Background);
+			Assert.Null (border.GetFieldValue<string> ("borderBrush"));
+			Assert.Null (border.GetFieldValue<string> ("background"));
+
+			border.BorderBrush = (Color)(-1);
+			border.Background = (Color)(-1);
+			Assert.Equal ((Color)(-1), border.BorderBrush);
+			Assert.Equal ((Color)(-1), border.Background);
+			Assert.Null (border.GetFieldValue<Color?> ("borderBrush"));
+			Assert.Null (border.GetFieldValue<Color?> ("background"));
+
+			border.BorderBrush = Color.Blue;
+			border.Background = Color.White;
+			Assert.Equal (Color.Blue, border.BorderBrush);
+			Assert.Equal (Color.White, border.Background);
+			Assert.Equal (Color.Blue, border.GetFieldValue<Color> ("borderBrush"));
+			Assert.Equal (Color.White, border.GetFieldValue<Color?> ("background"));
+		}
 	}
 }

--- a/UnitTests/ReflectionTools.cs
+++ b/UnitTests/ReflectionTools.cs
@@ -32,4 +32,12 @@ public static class ReflectionTools {
 		}
 		return null;
 	}
+
+	public static T GetFieldValue<T> (this object obj, string name)
+	{
+		// Set the flags so that private and public fields from instances will be found
+		var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+		var field = obj.GetType ().GetField (name, bindingFlags);
+		return (T)field?.GetValue (obj);
+	}
 }


### PR DESCRIPTION
Fixes #2834 - The `borderBrush` and `background` private fields are a nullable `Color` type to specify if they are defined but to avoid breaking changes the `BorderBrush` and `Background` couldn't been also set to a nullable `Color` type, because it would force the users to do `Color` casting. So, the solution is to avoid them be set to a non defined `Color`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
