### PR TITLE
Fixes #2824. Add SearchText property to combobox in v2

### DIFF
--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -39,10 +39,7 @@ namespace Terminal.Gui {
 
 			private void Initialize (ComboBox container, bool hideDropdownListOnClick)
 			{
-				if (container == null)
-					throw new ArgumentNullException ("ComboBox container cannot be null.", nameof (container));
-
-				this.container = container;
+				this.container = container ?? throw new ArgumentNullException (nameof (container), "ComboBox container cannot be null.");
 				HideDropdownListOnClick = hideDropdownListOnClick;
 			}
 
@@ -236,7 +233,7 @@ namespace Terminal.Gui {
 		readonly TextField search;
 		readonly ComboListView listview;
 		bool autoHide = true;
-		int minimumHeight = 2;
+		readonly int minimumHeight = 2;
 
 		/// <summary>
 		/// Public constructor
@@ -296,7 +293,7 @@ namespace Terminal.Gui {
 			listview.Y = Pos.Bottom (search);
 			listview.OpenSelectedItem += (object sender, ListViewItemEventArgs a) => Selected ();
 
-			this.Add (search, listview);
+			Add (search, listview);
 
 			// On resize
 			LayoutComplete += (object sender, LayoutEventArgs a) => {
@@ -723,7 +720,19 @@ namespace Terminal.Gui {
 				return text;
 			}
 			set {
-				search.Text = text = value;
+				SetSearchText (value);
+			}
+		}
+
+		/// <summary>
+		/// Current search text 
+		/// </summary>
+		public string SearchText {
+			get {
+				return search.Text;
+			}
+			set {
+				SetSearchText (value);
 			}
 		}
 
@@ -779,7 +788,7 @@ namespace Terminal.Gui {
 		private void Reset (bool keepSearchText = false)
 		{
 			if (!keepSearchText) {
-				search.Text = text = "";
+				SetSearchText (string.Empty);
 			}
 
 			ResetSearchSet ();
@@ -790,6 +799,10 @@ namespace Terminal.Gui {
 			if (Subviews.Count > 0) {
 				search.SetFocus ();
 			}
+		}
+		private void SetSearchText (string value)
+		{
+			search.Text = text = value;
 		}
 
 		private void ResetSearchSet (bool noCopy = false)
@@ -847,7 +860,7 @@ namespace Terminal.Gui {
 			listview.SetSource (searchset);
 			listview.Clear (); // Ensure list shrinks in Dialog as you type
 			listview.Height = CalculatetHeight ();
-			this.SuperView?.BringSubviewToFront (this);
+			SuperView?.BringSubviewToFront (this);
 		}
 
 		/// <summary>
@@ -861,7 +874,8 @@ namespace Terminal.Gui {
 				OnOpenSelectedItem ();
 			}
 			var rect = listview.ViewToScreen (listview.Bounds);
-			Reset (SelectedItem > -1);
+			Reset (keepSearchText: true);
+			listview.Clear (rect);
 			listview.Clear (rect);
 			listview.TabStop = false;
 			SuperView?.SendSubviewToBack (this);

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -876,7 +876,6 @@ namespace Terminal.Gui {
 			var rect = listview.ViewToScreen (listview.Bounds);
 			Reset (keepSearchText: true);
 			listview.Clear (rect);
-			listview.Clear (rect);
 			listview.TabStop = false;
 			SuperView?.SendSubviewToBack (this);
 			SuperView?.SetNeedsDisplay (rect);

--- a/UnitTests/Views/ComboBoxTests.cs
+++ b/UnitTests/Views/ComboBoxTests.cs
@@ -101,7 +101,7 @@ namespace Terminal.Gui.ViewsTests {
 			cb.Text = "Tw";
 			Assert.True (cb.ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
 			Assert.True (opened);
-			Assert.Equal ("", cb.Text);
+			Assert.Equal ("Tw", cb.Text);
 			Assert.False (cb.IsShow);
 			cb.SetSource (null);
 			Assert.False (cb.ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
@@ -262,7 +262,7 @@ Three
 			Assert.False (cb.IsShow);
 			Assert.Equal (2, cb.Source.Count);
 			Assert.Equal (-1, cb.SelectedItem);
-			Assert.Equal ("", cb.Text);
+			Assert.Equal ("T", cb.Text);
 			Assert.True (cb.ProcessKey (new KeyEvent (Key.Esc, new KeyModifiers ())));
 			Assert.False (cb.IsShow);
 			Assert.Equal (-1, cb.SelectedItem); // retains last accept selected item


### PR DESCRIPTION
Fixes #2824 - Added SearchText property to ComboBox v2

As said in the discussion in #2825 , I also added changes to v2. I need to fix some test because after changing Text it rested this field.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working