### PR TITLE
Fixes #2847. CursesDriver doesn't processing response from task threading.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -142,6 +142,7 @@ namespace Terminal.Gui {
 			Curses.raw ();
 			Curses.noecho ();
 			Curses.refresh ();
+			ProcessWinChange ();
 		}
 
 		private void ProcessWinChange ()

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -82,7 +82,6 @@ namespace Terminal.Gui {
 		bool poll_dirty = true;
 		int [] wakeupPipes = new int [2];
 		static IntPtr ignore = Marshal.AllocHGlobal (1);
-		static IntPtr readHandle = Marshal.AllocHGlobal (1);
 		MainLoop mainLoop;
 		bool winChanged;
 
@@ -97,8 +96,8 @@ namespace Terminal.Gui {
 		{
 			this.mainLoop = mainLoop;
 			pipe (wakeupPipes);
-			AddWatch (wakeupPipes [1], Condition.PollIn, ml => {
-				read (wakeupPipes [1], ignore, readHandle);
+			AddWatch (wakeupPipes [0], Condition.PollIn, ml => {
+				read (wakeupPipes [0], ignore, (IntPtr)1);
 				return true;
 			});
 		}

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -175,10 +175,18 @@ namespace Terminal.Gui {
 			if (mainLoop.timeouts.Count > 0) {
 				pollTimeout = (int)((mainLoop.timeouts.Keys [0] - now) / TimeSpan.TicksPerMillisecond);
 				if (pollTimeout < 0) {
-					// This avoids poll waiting infinitely if pollTimeout=-1 until some action is detected
-					if (pollTimeout == -1) {
-						pollTimeout = 0;
-					}
+					// This avoids 'poll' waiting infinitely if 'pollTimeout < 0' until some action is detected
+					// This can occur after IMainLoopDriver.Wakeup is executed where the pollTimeout is less than 0
+					// and no event occurred in elapsed time when the 'poll' is start running again.
+					/*
+					The 'poll' function in the C standard library uses a signed integer as the timeout argument, where:
+
+					    - A positive value specifies a timeout in milliseconds.
+					    - A value of 0 means the poll function will return immediately, checking for events and not waiting.
+					    - A value of -1 means the poll function will wait indefinitely until an event occurs or an error occurs.
+					    - A negative value other than -1 typically indicates an error.
+					 */
+					pollTimeout = 0;
 					return true;
 				}
 			} else

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -175,6 +175,10 @@ namespace Terminal.Gui {
 			if (mainLoop.timeouts.Count > 0) {
 				pollTimeout = (int)((mainLoop.timeouts.Keys [0] - now) / TimeSpan.TicksPerMillisecond);
 				if (pollTimeout < 0) {
+					// This avoids poll waiting infinitely if pollTimeout=-1 until some action is detected
+					if (pollTimeout == -1) {
+						pollTimeout = 0;
+					}
 					return true;
 				}
 			} else

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -97,7 +97,7 @@ namespace Terminal.Gui {
 			this.mainLoop = mainLoop;
 			pipe (wakeupPipes);
 			AddWatch (wakeupPipes [0], Condition.PollIn, ml => {
-				read (wakeupPipes [0], ignore, (IntPtr)1);
+				read (wakeupPipes [1], ignore, (IntPtr)1);
 				return true;
 			});
 		}

--- a/UICatalog/Scenarios/Threading.cs
+++ b/UICatalog/Scenarios/Threading.cs
@@ -157,7 +157,7 @@ namespace UICatalog.Scenarios {
 					LogJob ($"Returned from task Thread:{Thread.CurrentThread.ManagedThreadId} {DateTime.Now}");
 					_itemsList.SetSource (items);
 					LogJob ($"Finished populate list view Thread:{Thread.CurrentThread.ManagedThreadId} {DateTime.Now}");
-					_btnActionCancel.Text = "Load Items";
+					_btnActionCancel.Text = "Cancelable Load Items";
 				} else {
 					LogJob ("Task was canceled!");
 				}


### PR DESCRIPTION
Fixes #2847- On the PR #2786 I ruined this one, sorry. I also fixed the button text after finished the task.
Also fixes #2860 - When the `pollTimeout == -1` the `poll` method seem to instruct it must wait until some action is detected. Setting the `pollTimeout = 0`, seem to fix the issue.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
