### PR TITLE
Fixes #2847. CursesDriver doesn't processing response from task threading.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnixMainLoop.cs
@@ -82,7 +82,6 @@ namespace Terminal.Gui {
 		bool poll_dirty = true;
 		int [] wakeupPipes = new int [2];
 		static IntPtr ignore = Marshal.AllocHGlobal (1);
-		static IntPtr readHandle = Marshal.AllocHGlobal (1);
 		MainLoop mainLoop;
 		bool winChanged;
 
@@ -101,11 +100,11 @@ namespace Terminal.Gui {
 			if (ConsoleDriver.RunningUnitTests) {
 				return;
 			}
-			
+
 			try {
 				pipe (wakeupPipes);
-				AddWatch (wakeupPipes [1], Condition.PollIn, ml => {
-					read (wakeupPipes [1], ignore, readHandle);
+				AddWatch (wakeupPipes [0], Condition.PollIn, ml => {
+					read (wakeupPipes [0], ignore, (IntPtr)1);
 					return true;
 				});
 			} catch (DllNotFoundException e) {

--- a/UICatalog/Scenarios/Threading.cs
+++ b/UICatalog/Scenarios/Threading.cs
@@ -45,7 +45,7 @@ namespace UICatalog.Scenarios {
 			};
 
 			_btnActionCancel = new Button (1, 1, "Cancelable Load Items");
-			_btnActionCancel.Clicked += (s,e) => Application.MainLoop.Invoke (CallLoadItemsAsync);
+			_btnActionCancel.Clicked += (s, e) => Application.MainLoop.Invoke (CallLoadItemsAsync);
 
 			Win.Add (new Label ("Data Items:") {
 				X = Pos.X (_btnActionCancel),
@@ -76,19 +76,19 @@ namespace UICatalog.Scenarios {
 			var text = new TextField (1, 3, 100, "Type anything after press the button");
 
 			var _btnAction = new Button (80, 10, "Load Data Action");
-			_btnAction.Clicked += (s,e) => _action.Invoke ();
+			_btnAction.Clicked += (s, e) => _action.Invoke ();
 			var _btnLambda = new Button (80, 12, "Load Data Lambda");
-			_btnLambda.Clicked += (s,e) => _lambda.Invoke ();
+			_btnLambda.Clicked += (s, e) => _lambda.Invoke ();
 			var _btnHandler = new Button (80, 14, "Load Data Handler");
-			_btnHandler.Clicked += (s,e) => _handler.Invoke (null, new EventArgs ());
+			_btnHandler.Clicked += (s, e) => _handler.Invoke (null, new EventArgs ());
 			var _btnSync = new Button (80, 16, "Load Data Synchronous");
-			_btnSync.Clicked += (s,e) => _sync.Invoke ();
+			_btnSync.Clicked += (s, e) => _sync.Invoke ();
 			var _btnMethod = new Button (80, 18, "Load Data Method");
-			_btnMethod.Clicked += async (s,e) => await MethodAsync ();
+			_btnMethod.Clicked += async (s, e) => await MethodAsync ();
 			var _btnClearData = new Button (80, 20, "Clear Data");
-			_btnClearData.Clicked += (s,e) => { _itemsList.Source = null; LogJob ("Cleaning Data"); };
+			_btnClearData.Clicked += (s, e) => { _itemsList.Source = null; LogJob ("Cleaning Data"); };
 			var _btnQuit = new Button (80, 22, "Quit");
-			_btnQuit.Clicked += (s,e) => Application.RequestStop ();
+			_btnQuit.Clicked += (s, e) => Application.RequestStop ();
 
 			Win.Add (_itemsList, _btnActionCancel, _logJob, text, _btnAction, _btnLambda, _btnHandler, _btnSync, _btnMethod, _btnClearData, _btnQuit);
 
@@ -156,7 +156,7 @@ namespace UICatalog.Scenarios {
 					LogJob ($"Returned from task Thread:{Thread.CurrentThread.ManagedThreadId} {DateTime.Now}");
 					_itemsList.SetSource (items);
 					LogJob ($"Finished populate list view Thread:{Thread.CurrentThread.ManagedThreadId} {DateTime.Now}");
-					_btnActionCancel.Text = "Load Items";
+					_btnActionCancel.Text = "Cancelable Load Items";
 				} else {
 					LogJob ("Task was canceled!");
 				}


### PR DESCRIPTION
Fixes #2847- On the PR #2786 I ruined this one, sorry. I also fixed the button text after finished the task.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
