### PR TITLE
Fixes 2859 - Add more file dialog customization options

### DIFF
--- a/Terminal.Gui/FileServices/FileDialogStyle.cs
+++ b/Terminal.Gui/FileServices/FileDialogStyle.cs
@@ -21,7 +21,7 @@ namespace Terminal.Gui {
 		/// Gets or sets the default value to use for <see cref="UseColors"/>.
 		/// This can be populated from .tui config files via <see cref="ConfigurationManager"/>
 		/// </summary>
-		[SerializableConfigurationProperty(Scope = typeof (SettingsScope))]
+		[SerializableConfigurationProperty (Scope = typeof (SettingsScope))]
 		public static bool DefaultUseColors { get; set; }
 
 		/// <summary>
@@ -42,20 +42,20 @@ namespace Terminal.Gui {
 		/// Gets or sets the class responsible for determining which symbol
 		/// to use to represent files and directories.
 		/// </summary>
-		public FileSystemIconProvider IconProvider { get; set;} = new FileSystemIconProvider();
+		public FileSystemIconProvider IconProvider { get; set; } = new FileSystemIconProvider ();
 
 		/// <summary>
 		///	Gets or sets the class thatis responsible for determining which color
 		/// to use to represent files and directories when <see cref="UseColors"/> is
 		/// <see langword="true"/>.
 		/// </summary>
-		public FileSystemColorProvider ColorProvider { get;set;} = new FileSystemColorProvider();
+		public FileSystemColorProvider ColorProvider { get; set; } = new FileSystemColorProvider ();
 
 		/// <summary>
 		/// Gets or sets the culture to use (e.g. for number formatting).
 		/// Defaults to <see cref="CultureInfo.CurrentUICulture"/>.
 		/// </summary>
-		public CultureInfo Culture {get;set;} = CultureInfo.CurrentUICulture;
+		public CultureInfo Culture { get; set; } = CultureInfo.CurrentUICulture;
 
 		/// <summary>
 		/// Gets or sets the header text displayed in the Filename column of the files table.
@@ -184,7 +184,7 @@ namespace Terminal.Gui {
 		}
 
 
-		private Dictionary<IDirectoryInfo,string> DefaultTreeRootGetter ()
+		private Dictionary<IDirectoryInfo, string> DefaultTreeRootGetter ()
 		{
 			var roots = new Dictionary<IDirectoryInfo, string> ();
 			try {
@@ -192,7 +192,7 @@ namespace Terminal.Gui {
 
 					var dir = _fileSystem.DirectoryInfo.New (d);
 
-					if (!roots.ContainsKey(dir)) {
+					if (!roots.ContainsKey (dir)) {
 						roots.Add (dir, d);
 					}
 				}
@@ -206,14 +206,14 @@ namespace Terminal.Gui {
 					try {
 						var path = Environment.GetFolderPath (special);
 
-						if(string.IsNullOrWhiteSpace (path)) {
+						if (string.IsNullOrWhiteSpace (path)) {
 							continue;
 						}
 
 						var dir = _fileSystem.DirectoryInfo.New (path);
 
 						if (!roots.ContainsKey (dir) && dir.Exists) {
-							roots.Add (dir, special.ToString());
+							roots.Add (dir, special.ToString ());
 						}
 					} catch (Exception) {
 						// Special file exists but contents are unreadable (permissions?)

--- a/Terminal.Gui/FileServices/FileDialogStyle.cs
+++ b/Terminal.Gui/FileServices/FileDialogStyle.cs
@@ -99,6 +99,13 @@ namespace Terminal.Gui {
 		public string CancelButtonText { get; set; } = "Cancel";
 
 		/// <summary>
+		/// Gets or sets whether to flip the order of the Ok and Cancel buttons. Defaults
+		/// to false (Ok button then Cancel button). Set to true to show Cancel button on
+		/// left then Ok button instead.
+		/// </summary>
+		public bool FlipOkCancelButtonLayoutOrder { get; set; }
+
+		/// <summary>
 		/// Gets or sets error message when user attempts to select a file type that is not one of <see cref="FileDialog.AllowedTypes"/>
 		/// </summary>
 		public string WrongFileTypeFeedback { get; set; } = Strings.fdWrongFileTypeFeedback;

--- a/Terminal.Gui/FileServices/FileDialogStyle.cs
+++ b/Terminal.Gui/FileServices/FileDialogStyle.cs
@@ -80,12 +80,12 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Gets or sets the text displayed in the 'Search' text box when user has not supplied any input yet.
 		/// </summary>
-		public string SearchCaption { get; internal set; } = Strings.fdSearchCaption;
+		public string SearchCaption { get; set; } = Strings.fdSearchCaption;
 
 		/// <summary>
 		/// Gets or sets the text displayed in the 'Path' text box when user has not supplied any input yet.
 		/// </summary>
-		public string PathCaption { get; internal set; } = Strings.fdPathCaption;
+		public string PathCaption { get; set; } = Strings.fdPathCaption;
 
 		/// <summary>
 		/// Gets or sets the text on the 'Ok' button.  Typically you may want to change this to
@@ -94,39 +94,44 @@ namespace Terminal.Gui {
 		public string OkButtonText { get; set; } = "Ok";
 
 		/// <summary>
+		/// Gets or sets the text on the 'Cancel' button.
+		/// </summary>
+		public string CancelButtonText { get; set; } = "Cancel";
+
+		/// <summary>
 		/// Gets or sets error message when user attempts to select a file type that is not one of <see cref="FileDialog.AllowedTypes"/>
 		/// </summary>
-		public string WrongFileTypeFeedback { get; internal set; } = Strings.fdWrongFileTypeFeedback;
+		public string WrongFileTypeFeedback { get; set; } = Strings.fdWrongFileTypeFeedback;
 
 		/// <summary>
 		/// Gets or sets error message when user selects a directory that does not exist and
 		/// <see cref="OpenMode"/> is <see cref="OpenMode.Directory"/> and <see cref="FileDialog.MustExist"/> is <see langword="true"/>.
 		/// </summary>
-		public string DirectoryMustExistFeedback { get; internal set; } = Strings.fdDirectoryMustExistFeedback;
+		public string DirectoryMustExistFeedback { get; set; } = Strings.fdDirectoryMustExistFeedback;
 
 		/// <summary>
 		/// Gets or sets error message when user <see cref="OpenMode"/> is <see cref="OpenMode.Directory"/>
 		/// and user enters the name of an existing file (File system cannot have a folder with the same name as a file).
 		/// </summary>
-		public string FileAlreadyExistsFeedback { get; internal set; } = Strings.fdFileAlreadyExistsFeedback;
+		public string FileAlreadyExistsFeedback { get; set; } = Strings.fdFileAlreadyExistsFeedback;
 
 		/// <summary>
 		/// Gets or sets error message when user selects a file that does not exist and
 		/// <see cref="OpenMode"/> is <see cref="OpenMode.File"/> and <see cref="FileDialog.MustExist"/> is <see langword="true"/>.
 		/// </summary>
-		public string FileMustExistFeedback { get; internal set; } = Strings.fdFileMustExistFeedback;
+		public string FileMustExistFeedback { get; set; } = Strings.fdFileMustExistFeedback;
 
 		/// <summary>
 		/// Gets or sets error message when user <see cref="OpenMode"/> is <see cref="OpenMode.File"/>
 		/// and user enters the name of an existing directory (File system cannot have a folder with the same name as a file).
 		/// </summary>
-		public string DirectoryAlreadyExistsFeedback { get; internal set; } = Strings.fdDirectoryAlreadyExistsFeedback;
+		public string DirectoryAlreadyExistsFeedback { get; set; } = Strings.fdDirectoryAlreadyExistsFeedback;
 
 		/// <summary>
 		/// Gets or sets error message when user selects a file/dir that does not exist and
 		/// <see cref="OpenMode"/> is <see cref="OpenMode.Mixed"/> and <see cref="FileDialog.MustExist"/> is <see langword="true"/>.
 		/// </summary>
-		public string FileOrDirectoryMustExistFeedback { get; internal set; } = Strings.fdFileOrDirectoryMustExistFeedback;
+		public string FileOrDirectoryMustExistFeedback { get; set; } = Strings.fdFileOrDirectoryMustExistFeedback;
 
 		/// <summary>
 		/// Gets the style settings for the table of files (in currently selected directory).

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -188,7 +188,6 @@ namespace Terminal.Gui {
 
 			this.tbPath = new TextField {
 				Width = Dim.Fill (0),
-				Caption = Style.PathCaption,
 				CaptionColor = Color.Black
 			};
 			this.tbPath.KeyPress += (s, k) => {
@@ -644,10 +643,14 @@ namespace Terminal.Gui {
 
 			// May have been updated after instance was constructed
 			this.btnOk.Text = Style.OkButtonText;
+			this.btnCancel.Text = Style.CancelButtonText;
 			this.btnUp.Text = this.GetUpButtonText ();
 			this.btnBack.Text = this.GetBackButtonText ();
 			this.btnForward.Text = this.GetForwardButtonText ();
 			this.btnToggleSplitterCollapse.Text = this.GetToggleSplitterText (false);
+
+			tbPath.Caption = Style.PathCaption;
+			tbFind.Caption = Style.SearchCaption;
 
 			tbPath.Autocomplete.ColorScheme.Normal = Attribute.Make (Color.Black, tbPath.ColorScheme.Normal.Background);
 

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -142,11 +142,7 @@ namespace Terminal.Gui {
 
 			this.btnOk = new Button (Style.OkButtonText) {
 				Y = Pos.AnchorEnd (1),
-				X = Pos.Function (() =>
-					this.Bounds.Width
-					- btnOk.Bounds.Width
-					// TODO: Fiddle factor, seems the Bounds are wrong for someone
-					- 2)
+				X = Pos.Function (CalculateOkButtonPosX)
 			};
 			this.btnOk.Clicked += (s, e) => this.Accept (true);
 			this.btnOk.KeyPress += (s, k) => {
@@ -156,14 +152,7 @@ namespace Terminal.Gui {
 
 			this.btnCancel = new Button ("Cancel") {
 				Y = Pos.AnchorEnd (1),
-				X = Pos.Function (() =>
-					this.Bounds.Width
-					- btnOk.Bounds.Width
-					- btnCancel.Bounds.Width
-					- 1
-					// TODO: Fiddle factor, seems the Bounds are wrong for someone
-					- 2
-					)
+				X = Pos.Right (btnOk) + 1
 			};
 			this.btnCancel.KeyPress += (s, k) => {
 				this.NavigateIf (k, Key.CursorLeft, this.btnToggleSplitterCollapse);
@@ -284,7 +273,6 @@ namespace Terminal.Gui {
 
 			tbFind = new TextField {
 				X = Pos.Right (this.btnToggleSplitterCollapse) + 1,
-				Caption = Style.SearchCaption,
 				CaptionColor = Color.Black,
 				Width = 30,
 				Y = Pos.AnchorEnd (1),
@@ -370,6 +358,16 @@ namespace Terminal.Gui {
 			this.Add (this.btnForward);
 			this.Add (this.tbPath);
 			this.Add (this.splitContainer);
+		}
+
+		private int CalculateOkButtonPosX ()
+		{
+			return this.Bounds.Width
+				- btnOk.Bounds.Width
+				- btnCancel.Bounds.Width
+				- 1
+				// TODO: Fiddle factor, seems the Bounds are wrong for someone
+				- 2;
 		}
 
 		private string AspectGetter (object o)
@@ -648,6 +646,14 @@ namespace Terminal.Gui {
 			this.btnBack.Text = this.GetBackButtonText ();
 			this.btnForward.Text = this.GetForwardButtonText ();
 			this.btnToggleSplitterCollapse.Text = this.GetToggleSplitterText (false);
+
+			if(Style.FlipOkCancelButtonLayoutOrder) {
+				var p1 = btnOk.X;
+				var p2 = btnCancel.X;
+
+				btnOk.X = p2;
+				btnCancel.X = p1;
+			}
 
 			tbPath.Caption = Style.PathCaption;
 			tbFind.Caption = Style.SearchCaption;

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -714,7 +714,7 @@ namespace Terminal.Gui {
 
 			// if no path has been provided
 			if (this.tbPath.Text.Length <= 0) {
-				this.tbPath.Text = Environment.CurrentDirectory;
+				this.Path = Environment.CurrentDirectory;
 			}
 
 			// to streamline user experience and allow direct typing of paths
@@ -805,7 +805,7 @@ namespace Terminal.Gui {
 				.Select (s => s.FileSystemInfo.FullName)
 				.ToList ().AsReadOnly ();
 
-			this.tbPath.Text = this.MultiSelected.Count == 1 ? this.MultiSelected [0] : string.Empty;
+			this.Path = this.MultiSelected.Count == 1 ? this.MultiSelected [0] : string.Empty;
 
 			FinishAccept ();
 		}
@@ -818,7 +818,7 @@ namespace Terminal.Gui {
 				return;
 			}
 
-			this.tbPath.Text = f.FullName;
+			this.Path = f.FullName;
 
 			if (AllowsMultipleSelection) {
 				this.MultiSelected = new List<string> { f.FullName }.AsReadOnly ();
@@ -897,7 +897,7 @@ namespace Terminal.Gui {
 				return;
 			}
 
-			this.tbPath.Text = e.NewValue.FullName;
+			this.Path = e.NewValue.FullName;
 		}
 
 		private void UpdateNavigationVisibility ()
@@ -933,7 +933,7 @@ namespace Terminal.Gui {
 			try {
 				this.pushingState = true;
 
-				this.tbPath.Text = dest.FullName;
+				this.Path = dest.FullName;
 				this.State.Selected = stats;
 				this.tbPath.Autocomplete.ClearSuggestions ();
 
@@ -1136,12 +1136,10 @@ namespace Terminal.Gui {
 				this.tbPath.Autocomplete.ClearSuggestions ();
 
 				if (pathText != null) {
-					this.tbPath.Text = pathText;
-					this.tbPath.MoveEnd ();
+					this.Path = pathText;
 				} else
 				if (setPathText) {
-					this.tbPath.Text = newState.Directory.FullName;
-					this.tbPath.MoveEnd ();
+					this.Path = newState.Directory.FullName;
 				}
 
 				this.State = newState;

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -105,7 +105,7 @@ namespace Terminal.Gui {
 		private int currentSortColumn;
 
 		private bool currentSortIsAsc = true;
-		private Dictionary<IDirectoryInfo,string> _treeRoots = new Dictionary<IDirectoryInfo, string>();
+		private Dictionary<IDirectoryInfo, string> _treeRoots = new Dictionary<IDirectoryInfo, string> ();
 
 		/// <summary>
 		/// Event fired when user attempts to confirm a selection (or multi selection).
@@ -374,13 +374,13 @@ namespace Terminal.Gui {
 		{
 			var fsi = (IFileSystemInfo)o;
 
-			if(o is IDirectoryInfo dir && _treeRoots.ContainsKey(dir)) {
+			if (o is IDirectoryInfo dir && _treeRoots.ContainsKey (dir)) {
 
 				// Directory has a special name e.g. 'Pictures'
 				return _treeRoots [dir];
 			}
 
-			return (Style.IconProvider.GetIconWithOptionalSpace(fsi) + fsi.Name).Trim();
+			return (Style.IconProvider.GetIconWithOptionalSpace (fsi) + fsi.Name).Trim ();
 		}
 
 		private void OnTableViewMouseClick (object sender, MouseEventEventArgs e)
@@ -647,8 +647,8 @@ namespace Terminal.Gui {
 			this.btnForward.Text = this.GetForwardButtonText ();
 			this.btnToggleSplitterCollapse.Text = this.GetToggleSplitterText (false);
 
-			if(Style.FlipOkCancelButtonLayoutOrder) {
-				btnCancel.X = Pos.Function(this.CalculateOkButtonPosX);
+			if (Style.FlipOkCancelButtonLayoutOrder) {
+				btnCancel.X = Pos.Function (this.CalculateOkButtonPosX);
 				btnOk.X = Pos.Right (btnCancel) + 1;
 
 
@@ -1187,13 +1187,13 @@ namespace Terminal.Gui {
 			}
 
 
-			var color = Style.ColorProvider.GetTrueColor(stats.FileSystemInfo)
-			??	TrueColor.FromConsoleColor(Color.White);
-			var black = TrueColor.FromConsoleColor(Color.Black);
+			var color = Style.ColorProvider.GetTrueColor (stats.FileSystemInfo)
+			?? TrueColor.FromConsoleColor (Color.White);
+			var black = TrueColor.FromConsoleColor (Color.Black);
 
 			// TODO: Add some kind of cache for this
-			return new ColorScheme{
-				Normal = new Attribute (color,black),
+			return new ColorScheme {
+				Normal = new Attribute (color, black),
 				HotNormal = new Attribute (color, black),
 				Focus = new Attribute (black, color),
 				HotFocus = new Attribute (black, color),

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -648,11 +648,16 @@ namespace Terminal.Gui {
 			this.btnToggleSplitterCollapse.Text = this.GetToggleSplitterText (false);
 
 			if(Style.FlipOkCancelButtonLayoutOrder) {
-				var p1 = btnOk.X;
-				var p2 = btnCancel.X;
+				btnCancel.X = Pos.Function(this.CalculateOkButtonPosX);
+				btnOk.X = Pos.Right (btnCancel) + 1;
 
-				btnOk.X = p2;
-				btnCancel.X = p1;
+
+				// Flip tab order too for consistency
+				var p1 = this.btnOk.TabIndex;
+				var p2 = this.btnCancel.TabIndex;
+
+				this.btnOk.TabIndex = p2;
+				this.btnCancel.TabIndex = p1;
 			}
 
 			tbPath.Caption = Style.PathCaption;

--- a/UICatalog/Scenarios/FileDialogExamples.cs
+++ b/UICatalog/Scenarios/FileDialogExamples.cs
@@ -25,6 +25,9 @@ namespace UICatalog.Scenarios {
 		private RadioGroup rgIcons;
 		private RadioGroup rgAllowedTypes;
 
+		private TextField tbOkButton;
+		private TextField tbCancelButton;
+		private CheckBox cbFlipButtonOrder;
 		public override void Setup ()
 		{
 			var y = 0;
@@ -110,6 +113,25 @@ namespace UICatalog.Scenarios {
 			rgAllowedTypes.RadioLabels = new string [] { "Any", "Csv (Recommended)", "Csv (Strict)" };
 			Win.Add (rgAllowedTypes);
 
+			y = 5;
+			x = 45;
+
+			Win.Add (new LineView (Orientation.Vertical) {
+				X = x++,
+				Y = y + 1,
+				Height = 4
+			});
+			Win.Add (new Label ("Buttons") { X = x++, Y = y++ });
+
+			Win.Add(new Label("Ok Text:") { X = x, Y = y++ });
+			tbOkButton = new TextField () { X = x, Y = y++, Width = 12 };
+			Win.Add (tbOkButton);
+			Win.Add (new Label ("Cancel Text:") { X = x, Y = y++ });
+			tbCancelButton = new TextField () { X = x, Y = y++, Width = 12 };
+			Win.Add (tbCancelButton);
+			cbFlipButtonOrder = new CheckBox ("Flip Order") { X = x, Y = y++};
+			Win.Add (cbFlipButtonOrder);
+
 			var btn = new Button ($"Run Dialog") {
 				X = 1,
 				Y = 9
@@ -176,6 +198,16 @@ namespace UICatalog.Scenarios {
 					fd.AllowedTypes.Insert (1, new AllowedTypeAny ());
 				}
 
+			}
+
+			if (!string.IsNullOrWhiteSpace (tbOkButton.Text)) {
+				fd.Style.OkButtonText = tbOkButton.Text;
+			}
+			if (!string.IsNullOrWhiteSpace (tbCancelButton.Text)) {
+				fd.Style.CancelButtonText= tbCancelButton.Text;
+			}
+			if(cbFlipButtonOrder.Checked ?? false) {
+				fd.Style.FlipOkCancelButtonLayoutOrder = true;
 			}
 
 			Application.Run (fd);

--- a/UICatalog/Scenarios/FileDialogExamples.cs
+++ b/UICatalog/Scenarios/FileDialogExamples.cs
@@ -123,13 +123,13 @@ namespace UICatalog.Scenarios {
 			});
 			Win.Add (new Label ("Buttons") { X = x++, Y = y++ });
 
-			Win.Add(new Label("Ok Text:") { X = x, Y = y++ });
+			Win.Add (new Label ("Ok Text:") { X = x, Y = y++ });
 			tbOkButton = new TextField () { X = x, Y = y++, Width = 12 };
 			Win.Add (tbOkButton);
 			Win.Add (new Label ("Cancel Text:") { X = x, Y = y++ });
 			tbCancelButton = new TextField () { X = x, Y = y++, Width = 12 };
 			Win.Add (tbCancelButton);
-			cbFlipButtonOrder = new CheckBox ("Flip Order") { X = x, Y = y++};
+			cbFlipButtonOrder = new CheckBox ("Flip Order") { X = x, Y = y++ };
 			Win.Add (cbFlipButtonOrder);
 
 			var btn = new Button ($"Run Dialog") {
@@ -187,7 +187,7 @@ namespace UICatalog.Scenarios {
 
 			if (cbDrivesOnlyInTree.Checked ?? false) {
 				fd.Style.TreeRootGetter = () => {
-					return System.Environment.GetLogicalDrives ().ToDictionary(dirInfoFactory.New,k=>k);
+					return System.Environment.GetLogicalDrives ().ToDictionary (dirInfoFactory.New, k => k);
 				};
 			}
 
@@ -204,9 +204,9 @@ namespace UICatalog.Scenarios {
 				fd.Style.OkButtonText = tbOkButton.Text;
 			}
 			if (!string.IsNullOrWhiteSpace (tbCancelButton.Text)) {
-				fd.Style.CancelButtonText= tbCancelButton.Text;
+				fd.Style.CancelButtonText = tbCancelButton.Text;
 			}
-			if(cbFlipButtonOrder.Checked ?? false) {
+			if (cbFlipButtonOrder.Checked ?? false) {
 				fd.Style.FlipOkCancelButtonLayoutOrder = true;
 			}
 

--- a/UnitTests/FileServices/FileDialogTests.cs
+++ b/UnitTests/FileServices/FileDialogTests.cs
@@ -398,7 +398,7 @@ namespace Terminal.Gui.FileServicesTests {
  │                                                                  │
  │                                                                  │
  │                                                                  │
-│{CM.Glyphs.LeftBracket} ►► {CM.Glyphs.RightBracket} Enter Search                            {CM.Glyphs.LeftBracket} Cancel {CM.Glyphs.RightBracket} {CM.Glyphs.LeftBracket} Ok {CM.Glyphs.RightBracket}  │
+│{CM.Glyphs.LeftBracket} ►► {CM.Glyphs.RightBracket} Enter Search                            {CM.Glyphs.LeftBracket} Ok {CM.Glyphs.RightBracket} {CM.Glyphs.LeftBracket} Cancel {CM.Glyphs.RightBracket}  │
  └──────────────────────────────────────────────────────────────────┘
 ";
 			TestHelpers.AssertDriverContentsAre (expected, output, true);
@@ -434,7 +434,7 @@ namespace Terminal.Gui.FileServicesTests {
 ││mybinary.exe│7.00 bytes│2001-01-01T11:44:42           │.exe     ││
 │                                                                  │
 │                                                                  │
-│{CM.Glyphs.LeftBracket} ►► {CM.Glyphs.RightBracket} Enter Search                            {CM.Glyphs.LeftBracket} Cancel {CM.Glyphs.RightBracket} {CM.Glyphs.LeftBracket} Ok {CM.Glyphs.RightBracket}  │
+│{CM.Glyphs.LeftBracket} ►► {CM.Glyphs.RightBracket} Enter Search                            {CM.Glyphs.LeftBracket} Ok {CM.Glyphs.RightBracket} {CM.Glyphs.LeftBracket} Cancel {CM.Glyphs.RightBracket}  │
 └──────────────────────────────────────────────────────────────────┘
 ";
 			TestHelpers.AssertDriverContentsAre (expected, output, true);


### PR DESCRIPTION
Fixes #2859  - Add additional style customization options for FileDialog

I have also flipped the default order of the Ok/Cancel to match windows (Ok on left, Cancel on right).  There is a style option to empower user to choose.

![custom-button-text](https://github.com/gui-cs/Terminal.Gui/assets/31306100/37fa0c41-db34-4fe0-b02a-8ff5bcde4c9e)


## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
