### PR TITLE
Add localization scenario. Update localizations.

### DIFF
--- a/Terminal.Gui/FileServices/DefaultFileOperations.cs
+++ b/Terminal.Gui/FileServices/DefaultFileOperations.cs
@@ -24,7 +24,7 @@ namespace Terminal.Gui {
 			int result = MessageBox.Query (
 				string.Format (Strings.fdDeleteTitle, adjective),
 				string.Format (Strings.fdDeleteBody, adjective),
-				Strings.fdYes, Strings.fdNo);
+				Strings.btnYes, Strings.btnNo);
 
 			try {
 				if (result == 0) {
@@ -37,7 +37,7 @@ namespace Terminal.Gui {
 					return true;
 				}
 			} catch (Exception ex) {
-				MessageBox.ErrorQuery (Strings.fdDeleteFailedTitle, ex.Message, "Ok");
+				MessageBox.ErrorQuery (Strings.fdDeleteFailedTitle, ex.Message, Strings.btnOk);
 			}
 
 			return false;
@@ -47,14 +47,14 @@ namespace Terminal.Gui {
 		{
 
 			bool confirm = false;
-			var btnOk = new Button ("Ok") {
+			var btnOk = new Button (Strings.btnOk) {
 				IsDefault = true,
 			};
 			btnOk.Clicked += (s, e) => {
 				confirm = true;
 				Application.RequestStop ();
 			};
-			var btnCancel = new Button ("Cancel");
+			var btnCancel = new Button (Strings.btnCancel);
 			btnCancel.Clicked += (s, e) => {
 				confirm = false;
 				Application.RequestStop ();

--- a/Terminal.Gui/Resources/Strings.Designer.cs
+++ b/Terminal.Gui/Resources/Strings.Designer.cs
@@ -61,6 +61,69 @@ namespace Terminal.Gui.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        internal static string btnCancel {
+            get {
+                return ResourceManager.GetString("btnCancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No.
+        /// </summary>
+        internal static string btnNo {
+            get {
+                return ResourceManager.GetString("btnNo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string btnOk {
+            get {
+                return ResourceManager.GetString("btnOk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open.
+        /// </summary>
+        internal static string btnOpen {
+            get {
+                return ResourceManager.GetString("btnOpen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save.
+        /// </summary>
+        internal static string btnSave {
+            get {
+                return ResourceManager.GetString("btnSave", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save as.
+        /// </summary>
+        internal static string btnSaveAs {
+            get {
+                return ResourceManager.GetString("btnSaveAs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Yes.
+        /// </summary>
+        internal static string btnYes {
+            get {
+                return ResourceManager.GetString("btnYes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Copy.
         /// </summary>
         internal static string ctxCopy {
@@ -268,15 +331,6 @@ namespace Terminal.Gui.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No.
-        /// </summary>
-        internal static string fdNo {
-            get {
-                return ResourceManager.GetString("fdNo", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Open.
         /// </summary>
         internal static string fdOpen {
@@ -390,15 +444,6 @@ namespace Terminal.Gui.Resources {
         internal static string fdWrongFileTypeFeedback {
             get {
                 return ResourceManager.GetString("fdWrongFileTypeFeedback", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Yes.
-        /// </summary>
-        internal static string fdYes {
-            get {
-                return ResourceManager.GetString("fdYes", resourceCulture);
             }
         }
         

--- a/Terminal.Gui/Resources/Strings.fr-FR.resx
+++ b/Terminal.Gui/Resources/Strings.fr-FR.resx
@@ -145,7 +145,7 @@
     <value>Ficher</value>
   </data>
   <data name="fdSave" xml:space="preserve">
-    <value>_Enregistrer</value>
+    <value>Enregistrer</value>
   </data>
   <data name="fdSaveAs" xml:space="preserve">
     <value>E_nregistrer sous</value>

--- a/Terminal.Gui/Resources/Strings.fr-FR.resx
+++ b/Terminal.Gui/Resources/Strings.fr-FR.resx
@@ -148,7 +148,7 @@
     <value>Enregistrer</value>
   </data>
   <data name="fdSaveAs" xml:space="preserve">
-    <value>E_nregistrer sous</value>
+    <value>Enregistrer sous</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
     <value>Ouvrir</value>
@@ -167,5 +167,14 @@
   </data>
   <data name="wzNext" xml:space="preserve">
     <value>Prochai_n...</value>
+  </data>
+  <data name="btnSave" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="btnSaveAs" xml:space="preserve">
+    <value>E_nregistrer sous</value>
+  </data>
+  <data name="btnOpen" xml:space="preserve">
+    <value>Ouvrir</value>
   </data>
 </root>

--- a/Terminal.Gui/Resources/Strings.fr-FR.resx
+++ b/Terminal.Gui/Resources/Strings.fr-FR.resx
@@ -142,7 +142,7 @@
     <value>_Dossier</value>
   </data>
   <data name="fdFile" xml:space="preserve">
-    <value>_Ficher</value>
+    <value>Ficher</value>
   </data>
   <data name="fdSave" xml:space="preserve">
     <value>_Enregistrer</value>
@@ -151,7 +151,7 @@
     <value>E_nregistrer sous</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
-    <value>_Ouvrir</value>
+    <value>Ouvrir</value>
   </data>
   <data name="fdSelectFolder" xml:space="preserve">
     <value>Sélection de _dossier</value>

--- a/Terminal.Gui/Resources/Strings.ja-JP.resx
+++ b/Terminal.Gui/Resources/Strings.ja-JP.resx
@@ -145,10 +145,10 @@
     <value>ファイル</value>
   </data>
   <data name="fdSave" xml:space="preserve">
-    <value>保存 (_S)</value>
+    <value>保存</value>
   </data>
   <data name="fdSaveAs" xml:space="preserve">
-    <value>名前を付けて保存 (_S)</value>
+    <value>名前を付けて保存</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
     <value>開く</value>
@@ -189,10 +189,10 @@
   <data name="fdNewTitle" xml:space="preserve">
     <value>新規ディレクトリ</value>
   </data>
-  <data name="fdNo" xml:space="preserve">
+  <data name="btnNo" xml:space="preserve">
     <value>いいえ (_N)</value>
   </data>
-  <data name="fdYes" xml:space="preserve">
+  <data name="btnYes" xml:space="preserve">
     <value>はい (_Y)</value>
   </data>
   <data name="fdModified" xml:space="preserve">
@@ -239,5 +239,20 @@
   </data>
   <data name="fdAnyFiles" xml:space="preserve">
     <value>任意ファイル</value>
+  </data>
+  <data name="btnCancel" xml:space="preserve">
+    <value>キャンセル (_C)</value>
+  </data>
+  <data name="btnOk" xml:space="preserve">
+    <value>OK (_O)</value>
+  </data>
+  <data name="btnOpen" xml:space="preserve">
+    <value>開く (_O)</value>
+  </data>
+  <data name="btnSave" xml:space="preserve">
+    <value>保存 (_S)</value>
+  </data>
+  <data name="btnSaveAs" xml:space="preserve">
+    <value>名前を付けて保存 (_S)</value>
   </data>
 </root>

--- a/Terminal.Gui/Resources/Strings.ja-JP.resx
+++ b/Terminal.Gui/Resources/Strings.ja-JP.resx
@@ -145,19 +145,19 @@
     <value>ファイル</value>
   </data>
   <data name="fdSave" xml:space="preserve">
-    <value>保存</value>
+    <value>保存 (_S)</value>
   </data>
   <data name="fdSaveAs" xml:space="preserve">
-    <value>名前を付けて保存</value>
+    <value>名前を付けて保存 (_S)</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
-    <value>開く</value>
+    <value>開く (_O)</value>
   </data>
   <data name="fdSelectFolder" xml:space="preserve">
-    <value>フォルダーを選択</value>
+    <value>フォルダーを選択 (_S)</value>
   </data>
   <data name="fdSelectMixed" xml:space="preserve">
-    <value>混在選択</value>
+    <value>混在選択 (_S)</value>
   </data>
   <data name="wzBack" xml:space="preserve">
     <value>戻る (_B)</value>
@@ -190,10 +190,10 @@
     <value>新規ディレクトリ</value>
   </data>
   <data name="fdNo" xml:space="preserve">
-    <value>いいえ</value>
+    <value>いいえ (_N)</value>
   </data>
   <data name="fdYes" xml:space="preserve">
-    <value>はい</value>
+    <value>はい (_Y)</value>
   </data>
   <data name="fdModified" xml:space="preserve">
     <value>変更日時</value>

--- a/Terminal.Gui/Resources/Strings.ja-JP.resx
+++ b/Terminal.Gui/Resources/Strings.ja-JP.resx
@@ -151,7 +151,7 @@
     <value>名前を付けて保存 (_S)</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
-    <value>開く (_O)</value>
+    <value>開く</value>
   </data>
   <data name="fdSelectFolder" xml:space="preserve">
     <value>フォルダーを選択 (_S)</value>

--- a/Terminal.Gui/Resources/Strings.ja-JP.resx
+++ b/Terminal.Gui/Resources/Strings.ja-JP.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ctxCopy" xml:space="preserve">
-    <value>コピー (C)</value>
+    <value>コピー (_C)</value>
   </data>
   <data name="ctxCut" xml:space="preserve">
-    <value>切り取り (T)</value>
+    <value>切り取り (_T)</value>
   </data>
   <data name="ctxDeleteAll" xml:space="preserve">
-    <value>全て削除 (D)</value>
+    <value>全て削除 (_D)</value>
   </data>
   <data name="ctxPaste" xml:space="preserve">
-    <value>貼り付け (P)</value>
+    <value>貼り付け (_P)</value>
   </data>
   <data name="ctxRedo" xml:space="preserve">
-    <value>やり直し (R)</value>
+    <value>やり直し (_R)</value>
   </data>
   <data name="ctxSelectAll" xml:space="preserve">
-    <value>全て選択 (S)</value>
+    <value>全て選択 (_S)</value>
   </data>
   <data name="ctxUndo" xml:space="preserve">
-    <value>元に戻す (U)</value>
+    <value>元に戻す (_U)</value>
   </data>
   <data name="fdDirectory" xml:space="preserve">
     <value>ディレクトリ</value>
@@ -160,12 +160,84 @@
     <value>混在選択</value>
   </data>
   <data name="wzBack" xml:space="preserve">
-    <value>戻る</value>
+    <value>戻る (_B)</value>
   </data>
   <data name="wzFinish" xml:space="preserve">
-    <value>終える</value>
+    <value>終わる (_N)</value>
   </data>
   <data name="wzNext" xml:space="preserve">
-    <value>次に</value>
+    <value>次に (_N)...</value>
+  </data>
+  <data name="fdDirectoryAlreadyExistsFeedback" xml:space="preserve">
+    <value>同じ名前のディレクトリはすでに存在しました</value>
+  </data>
+  <data name="fdDeleteBody" xml:space="preserve">
+    <value>“{0}”を削除もよろしいですか？この操作は元に戻りません。</value>
+  </data>
+  <data name="fdType" xml:space="preserve">
+    <value>タイプ</value>
+  </data>
+  <data name="fdSize" xml:space="preserve">
+    <value>サイズ</value>
+  </data>
+  <data name="fdPathCaption" xml:space="preserve">
+    <value>パスを入力</value>
+  </data>
+  <data name="fdFilename" xml:space="preserve">
+    <value>ファイル名</value>
+  </data>
+  <data name="fdNewTitle" xml:space="preserve">
+    <value>新規ディレクトリ</value>
+  </data>
+  <data name="fdNo" xml:space="preserve">
+    <value>いいえ</value>
+  </data>
+  <data name="fdYes" xml:space="preserve">
+    <value>はい</value>
+  </data>
+  <data name="fdModified" xml:space="preserve">
+    <value>変更日時</value>
+  </data>
+  <data name="fdFileOrDirectoryMustExistFeedback" xml:space="preserve">
+    <value>すでに存在したファイルまたはディレクトリを選択してください</value>
+  </data>
+  <data name="fdDirectoryMustExistFeedback" xml:space="preserve">
+    <value>すでに存在したディレクトリを選択してください</value>
+  </data>
+  <data name="fdFileMustExistFeedback" xml:space="preserve">
+    <value>すでに存在したファイルを選択してください</value>
+  </data>
+  <data name="fdRenamePrompt" xml:space="preserve">
+    <value>名前：</value>
+  </data>
+  <data name="fdDeleteTitle" xml:space="preserve">
+    <value>{0} を削除</value>
+  </data>
+  <data name="fdNewFailed" xml:space="preserve">
+    <value>新規失敗</value>
+  </data>
+  <data name="fdExisting" xml:space="preserve">
+    <value>既存</value>
+  </data>
+  <data name="fdRenameTitle" xml:space="preserve">
+    <value>名前を変更</value>
+  </data>
+  <data name="fdRenameFailedTitle" xml:space="preserve">
+    <value>変更失敗</value>
+  </data>
+  <data name="fdDeleteFailedTitle" xml:space="preserve">
+    <value>削除失敗</value>
+  </data>
+  <data name="fdFileAlreadyExistsFeedback" xml:space="preserve">
+    <value>同じ名前のファイルはすでに存在しました</value>
+  </data>
+  <data name="fdSearchCaption" xml:space="preserve">
+    <value>検索を入力</value>
+  </data>
+  <data name="fdWrongFileTypeFeedback" xml:space="preserve">
+    <value>ファイルタイプが間違っでいます</value>
+  </data>
+  <data name="fdAnyFiles" xml:space="preserve">
+    <value>任意ファイル</value>
   </data>
 </root>

--- a/Terminal.Gui/Resources/Strings.ja-JP.resx
+++ b/Terminal.Gui/Resources/Strings.ja-JP.resx
@@ -172,7 +172,7 @@
     <value>同じ名前のディレクトリはすでに存在しました</value>
   </data>
   <data name="fdDeleteBody" xml:space="preserve">
-    <value>“{0}”を削除もよろしいですか？この操作は元に戻りません。</value>
+    <value>“{0}”を削除もよろしいですか？この操作は元に戻りません</value>
   </data>
   <data name="fdType" xml:space="preserve">
     <value>タイプ</value>

--- a/Terminal.Gui/Resources/Strings.pt-PT.resx
+++ b/Terminal.Gui/Resources/Strings.pt-PT.resx
@@ -168,4 +168,13 @@
   <data name="wzNext" xml:space="preserve">
     <value>S_eguir</value>
   </data>
+  <data name="btnSaveAs" xml:space="preserve">
+    <value>Guardar como</value>
+  </data>
+  <data name="btnSave" xml:space="preserve">
+    <value>Guardar</value>
+  </data>
+  <data name="btnOpen" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
 </root>

--- a/Terminal.Gui/Resources/Strings.resx
+++ b/Terminal.Gui/Resources/Strings.resx
@@ -212,7 +212,7 @@
     <comment>Describes an AllowedType that matches anything</comment>
   </data>
   <data name="fdDeleteBody" xml:space="preserve">
-    <value>Are you sure you want to delete '{0}'? This operation is permanent.</value>
+    <value>Are you sure you want to delete '{0}'? This operation is permanent</value>
   </data>
   <data name="fdDeleteFailedTitle" xml:space="preserve">
     <value>Delete Failed</value>

--- a/Terminal.Gui/Resources/Strings.resx
+++ b/Terminal.Gui/Resources/Strings.resx
@@ -226,7 +226,7 @@
   <data name="fdNewTitle" xml:space="preserve">
     <value>New Folder</value>
   </data>
-  <data name="fdNo" xml:space="preserve">
+  <data name="btnNo" xml:space="preserve">
     <value>No</value>
   </data>
   <data name="fdRenameFailedTitle" xml:space="preserve">
@@ -238,10 +238,25 @@
   <data name="fdRenameTitle" xml:space="preserve">
     <value>Rename</value>
   </data>
-  <data name="fdYes" xml:space="preserve">
+  <data name="btnYes" xml:space="preserve">
     <value>Yes</value>
   </data>
   <data name="fdExisting" xml:space="preserve">
     <value>Existing</value>
+  </data>
+  <data name="btnOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="btnSave" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="btnSaveAs" xml:space="preserve">
+    <value>Save as</value>
+  </data>
+  <data name="btnOk" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="btnCancel" xml:space="preserve">
+    <value>Cancel</value>
   </data>
 </root>

--- a/Terminal.Gui/Resources/Strings.zh-Hans.resx
+++ b/Terminal.Gui/Resources/Strings.zh-Hans.resx
@@ -151,7 +151,7 @@
     <value>另存为 (_S)</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
-    <value>打开 (_O)</value>
+    <value>打开</value>
   </data>
   <data name="wzNext" xml:space="preserve">
     <value>下一步 (_N)...</value>

--- a/Terminal.Gui/Resources/Strings.zh-Hans.resx
+++ b/Terminal.Gui/Resources/Strings.zh-Hans.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,130 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ctxSelectAll" xml:space="preserve">
-    <value>_Select All</value>
+    <value>全选 (_S)</value>
   </data>
   <data name="ctxDeleteAll" xml:space="preserve">
-    <value>_Delete All</value>
+    <value>清空 (_D)</value>
   </data>
   <data name="ctxCopy" xml:space="preserve">
-    <value>_Copy</value>
+    <value>复制 (_C)</value>
   </data>
   <data name="ctxCut" xml:space="preserve">
-    <value>Cu_t</value>
+    <value>剪切 (_T)</value>
   </data>
   <data name="ctxPaste" xml:space="preserve">
-    <value>_Paste</value>
+    <value>粘贴 (_P)</value>
   </data>
   <data name="ctxUndo" xml:space="preserve">
-    <value>_Undo</value>
+    <value>撤销 (_U)</value>
   </data>
   <data name="ctxRedo" xml:space="preserve">
-    <value>_Redo</value>
+    <value>重做 (_R)</value>
   </data>
   <data name="fdDirectory" xml:space="preserve">
-    <value>Directory</value>
+    <value>目录</value>
   </data>
   <data name="fdFile" xml:space="preserve">
-    <value>File</value>
+    <value>文件</value>
   </data>
   <data name="fdSave" xml:space="preserve">
-    <value>Save</value>
+    <value>保存</value>
   </data>
   <data name="fdSaveAs" xml:space="preserve">
-    <value>Save as</value>
+    <value>另存为</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
-    <value>Open</value>
-  </data>
-  <data name="fdSelectFolder" xml:space="preserve">
-    <value>Select folder</value>
-  </data>
-  <data name="fdSelectMixed" xml:space="preserve">
-    <value>Select Mixed</value>
-  </data>
-  <data name="wzBack" xml:space="preserve">
-    <value>_Back</value>
-  </data>
-  <data name="wzFinish" xml:space="preserve">
-    <value>Fi_nish</value>
+    <value>打开</value>
   </data>
   <data name="wzNext" xml:space="preserve">
-    <value>_Next...</value>
+    <value>下一步 (_N)...</value>
+  </data>
+  <data name="fdSelectFolder" xml:space="preserve">
+    <value>选择文件夹</value>
+  </data>
+  <data name="fdSelectMixed" xml:space="preserve">
+    <value>混合选择</value>
+  </data>
+  <data name="wzBack" xml:space="preserve">
+    <value>返回 (_B)</value>
+  </data>
+  <data name="wzFinish" xml:space="preserve">
+    <value>结束 (_N)</value>
   </data>
   <data name="fdDirectoryAlreadyExistsFeedback" xml:space="preserve">
-    <value>Directory already exists with that name</value>
-    <comment>When trying to save a file with a name already taken by a directory</comment>
+    <value>已存在相同名称的目录</value>
   </data>
   <data name="fdDirectoryMustExistFeedback" xml:space="preserve">
-    <value>Must select an existing directory</value>
+    <value>必须选择已有的目录</value>
   </data>
   <data name="fdFileAlreadyExistsFeedback" xml:space="preserve">
-    <value>File already exists with that name</value>
+    <value>已存在相同名称的文件</value>
   </data>
   <data name="fdFileMustExistFeedback" xml:space="preserve">
-    <value>Must select an existing file</value>
-    <comment>When trying to save a directory with a name already used by a file</comment>
+    <value>必须选择已有的文件</value>
   </data>
   <data name="fdFilename" xml:space="preserve">
-    <value>Filename</value>
+    <value>文件名</value>
   </data>
   <data name="fdFileOrDirectoryMustExistFeedback" xml:space="preserve">
-    <value>Must select an existing file or directory</value>
+    <value>必须选择已有的文件或目录</value>
   </data>
   <data name="fdModified" xml:space="preserve">
-    <value>Modified</value>
+    <value>修改时间</value>
   </data>
   <data name="fdPathCaption" xml:space="preserve">
-    <value>Enter Path</value>
+    <value>请输入路径</value>
   </data>
   <data name="fdSearchCaption" xml:space="preserve">
-    <value>Enter Search</value>
+    <value>输入以搜索</value>
   </data>
   <data name="fdSize" xml:space="preserve">
-    <value>Size</value>
+    <value>大小</value>
   </data>
   <data name="fdType" xml:space="preserve">
-    <value>Type</value>
+    <value>类型</value>
   </data>
   <data name="fdWrongFileTypeFeedback" xml:space="preserve">
-    <value>Wrong file type</value>
-    <comment>When trying to open/save a file that does not match the provided filter (e.g. csv)</comment>
+    <value>文件类型有误</value>
   </data>
   <data name="fdAnyFiles" xml:space="preserve">
-    <value>Any Files</value>
-    <comment>Describes an AllowedType that matches anything</comment>
+    <value>任意文件</value>
   </data>
   <data name="fdDeleteBody" xml:space="preserve">
-    <value>Are you sure you want to delete '{0}'? This operation is permanent.</value>
+    <value>您是否要删除“{0}”？此操作不可撤销。</value>
   </data>
   <data name="fdDeleteFailedTitle" xml:space="preserve">
-    <value>Delete Failed</value>
+    <value>删除失败</value>
   </data>
   <data name="fdDeleteTitle" xml:space="preserve">
-    <value>Delete {0}</value>
+    <value>删除 {0}</value>
   </data>
   <data name="fdNewFailed" xml:space="preserve">
-    <value>New Failed</value>
+    <value>新建失败</value>
   </data>
   <data name="fdNewTitle" xml:space="preserve">
-    <value>New Folder</value>
+    <value>新建文件夹</value>
   </data>
   <data name="fdNo" xml:space="preserve">
-    <value>No</value>
+    <value>否</value>
   </data>
   <data name="fdRenameFailedTitle" xml:space="preserve">
-    <value>Rename Failed</value>
+    <value>重命名失败</value>
   </data>
   <data name="fdRenamePrompt" xml:space="preserve">
-    <value>Name:</value>
+    <value>名称：</value>
   </data>
   <data name="fdRenameTitle" xml:space="preserve">
-    <value>Rename</value>
+    <value>重命名</value>
   </data>
   <data name="fdYes" xml:space="preserve">
-    <value>Yes</value>
+    <value>是</value>
   </data>
   <data name="fdExisting" xml:space="preserve">
-    <value>Existing</value>
+    <value>已有</value>
   </data>
 </root>

--- a/Terminal.Gui/Resources/Strings.zh-Hans.resx
+++ b/Terminal.Gui/Resources/Strings.zh-Hans.resx
@@ -145,10 +145,10 @@
     <value>文件</value>
   </data>
   <data name="fdSave" xml:space="preserve">
-    <value>保存 (_S)</value>
+    <value>保存</value>
   </data>
   <data name="fdSaveAs" xml:space="preserve">
-    <value>另存为 (_S)</value>
+    <value>另存为</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
     <value>打开</value>
@@ -222,7 +222,7 @@
   <data name="fdNewTitle" xml:space="preserve">
     <value>新建文件夹</value>
   </data>
-  <data name="fdNo" xml:space="preserve">
+  <data name="btnNo" xml:space="preserve">
     <value>否 (_N)</value>
   </data>
   <data name="fdRenameFailedTitle" xml:space="preserve">
@@ -234,10 +234,25 @@
   <data name="fdRenameTitle" xml:space="preserve">
     <value>重命名</value>
   </data>
-  <data name="fdYes" xml:space="preserve">
+  <data name="btnYes" xml:space="preserve">
     <value>是 (_Y)</value>
   </data>
   <data name="fdExisting" xml:space="preserve">
     <value>已有</value>
+  </data>
+  <data name="btnOk" xml:space="preserve">
+    <value>确定 (_O)</value>
+  </data>
+  <data name="btnOpen" xml:space="preserve">
+    <value>打开 (_O)</value>
+  </data>
+  <data name="btnSave" xml:space="preserve">
+    <value>保存 (_S)</value>
+  </data>
+  <data name="btnSaveAs" xml:space="preserve">
+    <value>另存为 (_S)</value>
+  </data>
+  <data name="btnCancel" xml:space="preserve">
+    <value>取消 (_C)</value>
   </data>
 </root>

--- a/Terminal.Gui/Resources/Strings.zh-Hans.resx
+++ b/Terminal.Gui/Resources/Strings.zh-Hans.resx
@@ -145,22 +145,22 @@
     <value>文件</value>
   </data>
   <data name="fdSave" xml:space="preserve">
-    <value>保存</value>
+    <value>保存 (_S)</value>
   </data>
   <data name="fdSaveAs" xml:space="preserve">
-    <value>另存为</value>
+    <value>另存为 (_S)</value>
   </data>
   <data name="fdOpen" xml:space="preserve">
-    <value>打开</value>
+    <value>打开 (_O)</value>
   </data>
   <data name="wzNext" xml:space="preserve">
     <value>下一步 (_N)...</value>
   </data>
   <data name="fdSelectFolder" xml:space="preserve">
-    <value>选择文件夹</value>
+    <value>选择文件夹 (_S)</value>
   </data>
   <data name="fdSelectMixed" xml:space="preserve">
-    <value>混合选择</value>
+    <value>混合选择 (_S)</value>
   </data>
   <data name="wzBack" xml:space="preserve">
     <value>返回 (_B)</value>
@@ -223,7 +223,7 @@
     <value>新建文件夹</value>
   </data>
   <data name="fdNo" xml:space="preserve">
-    <value>否</value>
+    <value>否 (_N)</value>
   </data>
   <data name="fdRenameFailedTitle" xml:space="preserve">
     <value>重命名失败</value>
@@ -235,7 +235,7 @@
     <value>重命名</value>
   </data>
   <data name="fdYes" xml:space="preserve">
-    <value>是</value>
+    <value>是 (_Y)</value>
   </data>
   <data name="fdExisting" xml:space="preserve">
     <value>已有</value>

--- a/Terminal.Gui/Resources/Strings.zh-Hans.resx
+++ b/Terminal.Gui/Resources/Strings.zh-Hans.resx
@@ -208,7 +208,7 @@
     <value>任意文件</value>
   </data>
   <data name="fdDeleteBody" xml:space="preserve">
-    <value>您是否要删除“{0}”？此操作不可撤销。</value>
+    <value>您是否要删除“{0}”？此操作不可撤销</value>
   </data>
   <data name="fdDeleteFailedTitle" xml:space="preserve">
     <value>删除失败</value>

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -154,7 +154,7 @@ namespace Terminal.Gui {
 				this.NavigateIf (k, Key.CursorUp, this.tableView);
 			};
 
-			this.btnCancel = new Button ("Cancel") {
+			this.btnCancel = new Button (Strings.btnCancel) {
 				Y = Pos.AnchorEnd (1),
 				X = Pos.Function (() =>
 					this.Bounds.Width
@@ -710,19 +710,31 @@ namespace Terminal.Gui {
 			this.tbPath.SelectAll ();
 
 			if (string.IsNullOrEmpty (Title)) {
-				switch (OpenMode) {
-				case OpenMode.File:
-					this.Title = $"{Strings.fdOpen} {(MustExist ? Strings.fdExisting + " " : "")}{Strings.fdFile}";
-					break;
-				case OpenMode.Directory:
-					this.Title = $"{Strings.fdOpen} {(MustExist ? Strings.fdExisting + " " : "")}{Strings.fdDirectory}";
-					break;
-				case OpenMode.Mixed:
-					this.Title = $"{Strings.fdOpen} {(MustExist ? Strings.fdExisting : "")}";
-					break;
-				}
+				this.Title = GetDefaultTitle ();
 			}
 			this.LayoutSubviews ();
+		}
+		/// <summary>
+		/// Gets a default dialog title, when <see cref="Title"/> is not set or empty, 
+		/// result of the function will be shown.
+		/// </summary>
+		protected virtual string GetDefaultTitle ()
+		{
+			List<string> titleParts = new () {
+				Strings.fdOpen
+			};
+			if (MustExist) {
+				titleParts.Add (Strings.fdExisting);
+			}
+			switch (OpenMode) {
+			case OpenMode.File:
+				titleParts.Add (Strings.fdFile);
+				break;
+			case OpenMode.Directory:
+				titleParts.Add (Strings.fdDirectory);
+				break;
+			}
+			return string.Join (' ', titleParts);
 		}
 
 		private void AllowedTypeMenuClicked (int idx)

--- a/Terminal.Gui/Views/OpenDialog.cs
+++ b/Terminal.Gui/Views/OpenDialog.cs
@@ -55,8 +55,7 @@ namespace Terminal.Gui {
 	/// To select more than one file, users can use the spacebar, or control-t.
 	/// </para>
 	/// </remarks>
-	public class OpenDialog : FileDialog {		
-
+	public class OpenDialog : FileDialog {
 		/// <summary>
 		/// Initializes a new <see cref="OpenDialog"/>.
 		/// </summary>
@@ -70,9 +69,9 @@ namespace Terminal.Gui {
 		/// <param name="openMode">The open mode.</param>
 		public OpenDialog (string title, List<IAllowedType> allowedTypes = null, OpenMode openMode = OpenMode.File)
 		{
-			this.OpenMode = openMode;
+			OpenMode = openMode;
 			Title = title;
-			Style.OkButtonText = openMode == OpenMode.File ? Strings.fdOpen : openMode == OpenMode.Directory ? Strings.fdSelectFolder : Strings.fdSelectMixed;
+			Style.OkButtonText = openMode == OpenMode.File ? Strings.btnOpen : openMode == OpenMode.Directory ? Strings.fdSelectFolder : Strings.fdSelectMixed;
 			
 			if (allowedTypes != null) {
 				AllowedTypes = allowedTypes;

--- a/Terminal.Gui/Views/SaveDialog.cs
+++ b/Terminal.Gui/Views/SaveDialog.cs
@@ -42,7 +42,7 @@ namespace Terminal.Gui {
 		{
 			//: base (title, prompt: Strings.fdSave, nameFieldLabel: $"{Strings.fdSaveAs}:", message: message, allowedTypes) { }
 			Title = title;
-			Style.OkButtonText = Strings.fdSave;
+			Style.OkButtonText = Strings.btnSave;
 
 			if(allowedTypes != null) {
 				AllowedTypes = allowedTypes;
@@ -61,6 +61,25 @@ namespace Terminal.Gui {
 
 				return Path;
 			}
+		}
+
+		protected override string GetDefaultTitle ()
+		{
+			List<string> titleParts = new () {
+				Strings.fdSave
+			};
+			if (MustExist) {
+				titleParts.Add (Strings.fdExisting);
+			}
+			switch (OpenMode) {
+			case OpenMode.File:
+				titleParts.Add (Strings.fdFile);
+				break;
+			case OpenMode.Directory:
+				titleParts.Add (Strings.fdDirectory);
+				break;
+			}
+			return string.Join (' ', titleParts);
 		}
 	}
 }

--- a/UICatalog/Scenarios/Localization.cs
+++ b/UICatalog/Scenarios/Localization.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Terminal.Gui;
+
+namespace UICatalog.Scenarios {
+	[ScenarioMetadata (Name: "Localization", Description: "Test for localization resources.")]
+	[ScenarioCategory ("Text and Formatting")]
+	[ScenarioCategory ("Tests")]
+	public class Localization : Scenario {
+		public CultureInfo CurrentCulture { get; private set; } = Thread.CurrentThread.CurrentUICulture;
+
+		private CultureInfo [] _cultureInfoSource;
+		private string [] _cultureInfoNameSource;
+		private ComboBox _languageComboBox;
+		private CheckBox _allowAnyCheckBox;
+		private OpenMode _currentOpenMode = OpenMode.File;
+
+		public override void Setup ()
+		{
+			base.Setup ();
+			_cultureInfoSource = Application.SupportedCultures.Append (CultureInfo.InvariantCulture).ToArray ();
+			_cultureInfoNameSource = Application.SupportedCultures.Select (c => $"{c.NativeName} ({c.Name})").Append ("Invariant").ToArray ();
+			var languageMenus = Application.SupportedCultures
+				.Select (c => new MenuItem ($"{c.NativeName} ({c.Name})", "", () => SetCulture (c))
+				).Concat (
+					new MenuItem [] {
+						null,
+						new MenuItem ("Invariant", "", () => SetCulture (CultureInfo.InvariantCulture))
+					}
+				)
+				.ToArray ();
+			var menu = new MenuBar (new MenuBarItem [] {
+				new MenuBarItem ("_File", new MenuItem [] {
+					new MenuBarItem("_Language", languageMenus),
+					null,
+					new MenuItem ("_Quit", "", Quit),
+				}),
+			});
+			Application.Top.Add (menu);
+
+			var selectLanguageLabel = new Label ("Please select a language.") {
+				X = 2,
+				Y = 1,
+				Width = Dim.Fill (2),
+				AutoSize = true
+			};
+			Win.Add (selectLanguageLabel);
+
+			_languageComboBox = new ComboBox (_cultureInfoNameSource) {
+				X = 2,
+				Y = Pos.Bottom (selectLanguageLabel) + 1,
+				Width = _cultureInfoNameSource.Select (cn => cn.Length + 3).Max (),
+				Height = _cultureInfoNameSource.Length + 1,
+				HideDropdownListOnClick = true,
+				AutoSize = true,
+				SelectedItem = _cultureInfoNameSource.Length - 1
+			};
+			_languageComboBox.SelectedItemChanged += LanguageComboBox_SelectChanged;
+			Win.Add (_languageComboBox);
+
+			var textAndFileDialogLabel = new Label ("Right click on the text field to open a context menu, click the button to open a file dialog.\r\nOpen mode will loop through 'File', 'Directory' and 'Mixed' as 'Open' or 'Save' button clicked.") {
+				X = 2,
+				Y = Pos.Top (_languageComboBox) + 3,
+				Width = Dim.Fill (2),
+				AutoSize = true
+			};
+			Win.Add (textAndFileDialogLabel);
+
+			var textField = new TextView {
+				X = 2,
+				Y = Pos.Bottom (textAndFileDialogLabel) + 1,
+				Width = Dim.Fill (32),
+				Height = 1
+			};
+			Win.Add (textField);
+
+			_allowAnyCheckBox = new CheckBox {
+				X = Pos.Right (textField) + 1,
+				Y = Pos.Bottom (textAndFileDialogLabel) + 1,
+				Checked = false,
+				Text = "Allow any"
+			};
+			Win.Add (_allowAnyCheckBox);
+
+			var openDialogButton = new Button ("Open") {
+				X = Pos.Right (_allowAnyCheckBox) + 1,
+				Y = Pos.Bottom (textAndFileDialogLabel) + 1
+			};
+			openDialogButton.Clicked += (sender, e) => ShowFileDialog (false);
+			Win.Add (openDialogButton);
+
+			var saveDialogButton = new Button ("Save") {
+				X = Pos.Right (openDialogButton) + 1,
+				Y = Pos.Bottom (textAndFileDialogLabel) + 1
+			};
+			saveDialogButton.Clicked += (sender, e) => ShowFileDialog (true);
+			Win.Add (saveDialogButton);
+
+			var wizardLabel = new Label ("Click the button to open a wizard.") {
+				X = 2,
+				Y = Pos.Bottom (textField) + 1,
+				Width = Dim.Fill (2),
+				AutoSize = true
+			};
+			Win.Add (wizardLabel);
+
+			var wizardButton = new Button ("Open _wizard") {
+				X = 2,
+				Y = Pos.Bottom (wizardLabel) + 1
+			};
+			wizardButton.Clicked += (sender, e) => ShowWizard ();
+			Win.Add (wizardButton);
+
+			Win.Unloaded += (sender, e) => Quit ();
+		}
+
+		public void SetCulture (CultureInfo culture)
+		{
+			if (_cultureInfoSource [_languageComboBox.SelectedItem] != culture) {
+				_languageComboBox.SelectedItem = Array.IndexOf (_cultureInfoSource, culture);
+			}
+			if (this.CurrentCulture == culture) return;
+			this.CurrentCulture = culture;
+			Thread.CurrentThread.CurrentUICulture = culture;
+			Application.Refresh ();
+		}
+		private void LanguageComboBox_SelectChanged (object sender, ListViewItemEventArgs e)
+		{
+			if (e.Value is string cultureName) {
+				var item = Array.IndexOf (_cultureInfoNameSource, cultureName);
+				if (item >= 0) {
+					SetCulture (_cultureInfoSource [Array.IndexOf (_cultureInfoNameSource, cultureName)]);
+				}
+			}
+		}
+		public void ShowFileDialog (bool isSaveFile)
+		{
+			FileDialog dialog = isSaveFile ? new SaveDialog () : new OpenDialog ("", null, _currentOpenMode);
+			dialog.AllowedTypes = new List<IAllowedType> () {
+				(_allowAnyCheckBox.Checked ?? false) ? new AllowedTypeAny() : new AllowedType("Dynamic link library", ".dll"),
+				new AllowedType("Json", ".json"),
+				new AllowedType("Text", ".txt"),
+				new AllowedType("Yaml", ".yml", ".yaml")
+			};
+			dialog.MustExist = !isSaveFile;
+			dialog.AllowsMultipleSelection = !isSaveFile;
+			_currentOpenMode++;
+			if (_currentOpenMode > OpenMode.Mixed) _currentOpenMode = OpenMode.File;
+			Application.Run (dialog);
+		}
+		public void ShowWizard ()
+		{
+			Wizard wizard = new Wizard {
+				Height = 8,
+				Width = 36,
+				Title = "The wizard"
+			};
+			wizard.AddStep (new WizardStep () {
+				HelpText = "Wizard first step",
+			});
+			wizard.AddStep (new WizardStep () {
+				HelpText = "Wizard step 2",
+				NextButtonText = ">>> (_N)"
+			});
+			wizard.AddStep (new WizardStep () {
+				HelpText = "Wizard last step"
+			});
+			Application.Run (wizard);
+		}
+		public void Quit ()
+		{
+			SetCulture (CultureInfo.InvariantCulture);
+			Application.RequestStop ();
+		}
+	}
+}

--- a/UICatalog/Scenarios/Localization.cs
+++ b/UICatalog/Scenarios/Localization.cs
@@ -24,8 +24,8 @@ namespace UICatalog.Scenarios {
 			_cultureInfoSource = Application.SupportedCultures.Append (CultureInfo.InvariantCulture).ToArray ();
 			_cultureInfoNameSource = Application.SupportedCultures.Select (c => $"{c.NativeName} ({c.Name})").Append ("Invariant").ToArray ();
 			var languageMenus = Application.SupportedCultures
-				.Select (c => new MenuItem ($"{c.NativeName} ({c.Name})", "", () => SetCulture (c))
-				).Concat (
+				.Select (c => new MenuItem ($"{c.NativeName} ({c.Name})", "", () => SetCulture (c)))
+				.Concat (
 					new MenuItem [] {
 						null,
 						new MenuItem ("Invariant", "", () => SetCulture (CultureInfo.InvariantCulture))
@@ -130,9 +130,9 @@ namespace UICatalog.Scenarios {
 		private void LanguageComboBox_SelectChanged (object sender, ListViewItemEventArgs e)
 		{
 			if (e.Value is string cultureName) {
-				var item = Array.IndexOf (_cultureInfoNameSource, cultureName);
-				if (item >= 0) {
-					SetCulture (_cultureInfoSource [Array.IndexOf (_cultureInfoNameSource, cultureName)]);
+				var index = Array.IndexOf (_cultureInfoNameSource, cultureName);
+				if (index >= 0) {
+					SetCulture (_cultureInfoSource [index]);
 				}
 			}
 		}
@@ -148,7 +148,9 @@ namespace UICatalog.Scenarios {
 			dialog.MustExist = !isSaveFile;
 			dialog.AllowsMultipleSelection = !isSaveFile;
 			_currentOpenMode++;
-			if (_currentOpenMode > OpenMode.Mixed) _currentOpenMode = OpenMode.File;
+			if (_currentOpenMode > OpenMode.Mixed) {
+				_currentOpenMode = OpenMode.File;
+			}
 			Application.Run (dialog);
 		}
 		public void ShowWizard ()

--- a/UnitTests/Views/DateFieldTests.cs
+++ b/UnitTests/Views/DateFieldTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -59,6 +60,8 @@ namespace Terminal.Gui.ViewsTests {
 		[Fact]
 		public void KeyBindings_Command ()
 		{
+			CultureInfo cultureBackup = CultureInfo.CurrentCulture;
+			CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 			DateField df = new DateField (DateTime.Parse ("12/12/1971"));
 			df.ReadOnly = true;
 			Assert.True (df.ProcessKey (new KeyEvent (Key.DeleteChar, new KeyModifiers ())));
@@ -93,6 +96,7 @@ namespace Terminal.Gui.ViewsTests {
 			df.ReadOnly = false;
 			Assert.True (df.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers ())));
 			Assert.Equal (" 12/02/1971", df.Text);
+			CultureInfo.CurrentCulture = cultureBackup;
 		}
 	}
 }


### PR DESCRIPTION
- Add a scenario to test localizations for TextView context menu, FileDialog and Wizard.
- Add localization of zh-Hans.
- Add new translations for ja-JP.
- Fix minor localization issues for fr-FR and ja-JP.
- Fix an issue about date time formatting under non en-US culture in DateFieldTest.

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
