### PR TITLE
Fixes #2870 - Memory leaks in Toplevel, Responder, and LineCanvas

### DIFF
--- a/Terminal.Gui/Configuration/ConfigurationManager.cs
+++ b/Terminal.Gui/Configuration/ConfigurationManager.cs
@@ -15,6 +15,31 @@ using System.Text.Json.Serialization;
 #nullable enable
 
 namespace Terminal.Gui;
+
+/// <summary>
+/// <para>
+/// Classes should implement this interface on any class that should be notified when the configuration changes.
+/// This is an alternative to using the <see cref="ConfigurationManager.Updated"/> and
+/// <see cref="ConfigurationManager.Applied"/> events.
+/// <para>
+/// When the configuration has changed, the <see cref="ConfigurationManager"/> will call the <see cref="OnUpdated"/>
+/// method. When the configuration is being applied, the <see cref="OnApplied"/> method will be called.
+/// 
+/// </para>
+/// </summary>
+public interface ISupportConfigChanges {
+
+	/// <summary>
+	/// Called when the configuration has been updated.
+	/// </summary>
+	public void OnUpdated ();
+
+	/// <summary>
+	/// Called when the configuration is being applied.
+	/// </summary>
+	public void OnApplied ();
+}
+
 /// <summary>
 /// Provides settings and configuration management for Terminal.Gui applications. 
 /// <para>
@@ -326,6 +351,10 @@ public static partial class ConfigurationManager {
 	{
 		Debug.WriteLine ($"ConfigurationManager.OnApplied()");
 		Applied?.Invoke (null, new ConfigurationManagerEventArgs ());
+
+		// TODO: Refactor ConfigurationManager to not use an event handler for this.
+		// Instead, have it call a method on any class appropriately attributed
+		// to update the cached values. See Issue #2871
 	}
 
 	/// <summary>

--- a/Terminal.Gui/Drawing/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas.cs
@@ -65,12 +65,15 @@ namespace Terminal.Gui {
 	/// Facilitates box drawing and line intersection detection
 	/// and rendering.  Does not support diagonal lines.
 	/// </summary>
-	public class LineCanvas {
+	public class LineCanvas : IDisposable {
 		/// <summary>
 		/// Creates a new instance.
 		/// </summary>
 		public LineCanvas()
 		{
+			// TODO: Refactor ConfigurationManager to not use an event handler for this.
+			// Instead, have it call a method on any class appropriately attributed
+			// to update the cached values. See Issue #2871
 			ConfigurationManager.Applied += ConfigurationManager_Applied;
 		}
 
@@ -731,6 +734,12 @@ namespace Terminal.Gui {
 			foreach (var line in lineCanvas._lines) {
 				AddLine (line);
 			}
+		}
+		
+		/// <inheritdoc />
+		public void Dispose ()
+		{
+			ConfigurationManager.Applied -= ConfigurationManager_Applied;
 		}
 	}
 	internal class IntersectionDefinition {

--- a/Terminal.Gui/Input/Responder.cs
+++ b/Terminal.Gui/Input/Responder.cs
@@ -276,12 +276,13 @@ namespace Terminal.Gui {
 					// TODO: dispose managed state (managed objects)
 				}
 
-				// TODO: free unmanaged resources (unmanaged objects) and override finalizer
-				// TODO: set large fields to null
+#if DEBUG_IDISPOSABLE
+				Instances.Remove (this);
+#endif                               
 				disposedValue = true;
 			}
 		}
-
+		
 		/// <summary>
 		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resource.
 		/// </summary>

--- a/Terminal.Gui/View/Frame.cs
+++ b/Terminal.Gui/View/Frame.cs
@@ -56,19 +56,6 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Frames only render to their Parent or Parent's SuperView's LineCanvas,
-		/// so this always throws an <see cref="InvalidOperationException"/>.
-		/// </summary>
-		public override LineCanvas LineCanvas {
-			get {
-				throw new NotImplementedException ();
-			}
-			set {
-				throw new NotImplementedException ();
-			}
-		}
-
-		/// <summary>
 		/// Does nothing for Frame
 		/// </summary>
 		/// <returns></returns>

--- a/Terminal.Gui/View/View.cs
+++ b/Terminal.Gui/View/View.cs
@@ -494,6 +494,8 @@ namespace Terminal.Gui {
 		/// <inheritdoc/>
 		protected override void Dispose (bool disposing)
 		{
+			LineCanvas.Dispose ();
+			
 			Margin?.Dispose ();
 			Margin = null;
 			Border?.Dispose ();
@@ -506,6 +508,7 @@ namespace Terminal.Gui {
 				Remove (subview);
 				subview.Dispose ();
 			}
+			
 			base.Dispose (disposing);
 		}
 	}

--- a/Terminal.Gui/View/ViewDrawing.cs
+++ b/Terminal.Gui/View/ViewDrawing.cs
@@ -288,7 +288,7 @@ namespace Terminal.Gui {
 		/// The canvas that any line drawing that is to be shared by subviews of this view should add lines to.
 		/// </summary>
 		/// <remarks><see cref="Border"/> adds border lines to this LineCanvas.</remarks>
-		public virtual LineCanvas LineCanvas { get; set; } = new LineCanvas ();
+		public virtual LineCanvas LineCanvas { get; internal set; } = new LineCanvas ();
 
 		/// <summary>
 		/// Gets or sets whether this View will use it's SuperView's <see cref="LineCanvas"/> for

--- a/Terminal.Gui/Views/Toplevel.cs
+++ b/Terminal.Gui/Views/Toplevel.cs
@@ -966,6 +966,9 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		protected override void Dispose (bool disposing)
 		{
+			Application.GrabbingMouse -= Application_GrabbingMouse;
+			Application.UnGrabbingMouse -= Application_UnGrabbingMouse;
+
 			_dragPosition = null;
 			base.Dispose (disposing);
 		}

--- a/UICatalog/Scenarios/Dialogs.cs
+++ b/UICatalog/Scenarios/Dialogs.cs
@@ -156,105 +156,112 @@ namespace UICatalog.Scenarios {
 				IsDefault = true,
 			};
 			showDialogButton.Clicked += (s, e) => {
-				try {
-					Dialog dialog = null;
-
-					int width = 0;
-					int.TryParse (widthEdit.Text, out width);
-					int height = 0;
-					int.TryParse (heightEdit.Text, out height);
-					int numButtons = 3;
-					int.TryParse (numButtonsEdit.Text, out numButtons);
-
-					var buttons = new List<Button> ();
-					var clicked = -1;
-					for (int i = 0; i < numButtons; i++) {
-						int buttonId = i;
-						Button button = null;
-						if (glyphsNotWords.Checked == true) {
-							buttonId = i;
-							button = new Button (NumberToWords.Convert (buttonId) + " " + Char.ConvertFromUtf32 (buttonId + CODE_POINT),
-								is_default: buttonId == 0);
-						} else {
-							button = new Button (NumberToWords.Convert (buttonId),
-							       is_default: buttonId == 0);
-						}
-						button.Clicked += (s, e) => {
-							clicked = buttonId;
-							Application.RequestStop ();
-						};
-						buttons.Add (button);
-					}
-					//if (buttons.Count > 1) {
-					//	buttons [1].Text = "Accept";
-					//	buttons [1].IsDefault = true;
-					//	buttons [0].Visible = false;
-					//	buttons [0].Text = "_Back";
-					//	buttons [0].IsDefault = false;
-					//}
-
-					// This tests dynamically adding buttons; ensuring the dialog resizes if needed and 
-					// the buttons are laid out correctly
-					dialog = new Dialog (buttons.ToArray ()) {
-						Title = titleEdit.Text,
-						ButtonAlignment = (Dialog.ButtonAlignments)styleRadioGroup.SelectedItem
-					};
-					if (height != 0 || width != 0) {
-						dialog.Height = height;
-						dialog.Width = width;
-					}
-
-					var add = new Button ("Add a button") {
-						X = Pos.Center (),
-						Y = Pos.Center ()
-					};
-					add.Clicked += (s, e) => {
-						var buttonId = buttons.Count;
-						Button button;
-						if (glyphsNotWords.Checked == true) {
-							button = new Button (NumberToWords.Convert (buttonId) + " " + Char.ConvertFromUtf32 (buttonId + CODE_POINT),
-								is_default: buttonId == 0);
-						} else {
-							button = new Button (NumberToWords.Convert (buttonId),
-								is_default: buttonId == 0);
-						}
-						button.Clicked += (s, e) => {
-							clicked = buttonId;
-							Application.RequestStop ();
-
-						};
-						buttons.Add (button);
-						dialog.AddButton (button);
-						if (buttons.Count > 1) {
-							button.TabIndex = buttons [buttons.Count - 2].TabIndex + 1;
-						}
-					};
-					dialog.Add (add);
-
-					var addChar = new Button ($"Add a {Char.ConvertFromUtf32 (CODE_POINT)} to each button") {
-						X = Pos.Center (),
-						Y = Pos.Center () + 1
-					};
-					addChar.Clicked += (s, e) => {
-						foreach (var button in buttons) {
-							button.Text += Char.ConvertFromUtf32 (CODE_POINT);
-						}
-						dialog.LayoutSubviews ();
-					};
-					dialog.Closed += (s, e) => {
-						buttonPressedLabel.Text = $"{clicked}";
-					};
-					dialog.Add (addChar);
-
-					Application.Run (dialog);
-
-				} catch (FormatException) {
-					buttonPressedLabel.Text = "Invalid Options";
-				}
+				var dlg = CreateDemoDialog (widthEdit, heightEdit, titleEdit, numButtonsEdit, glyphsNotWords, styleRadioGroup, buttonPressedLabel);
+				Application.Run (dlg);
 			};
+
 			Win.Add (showDialogButton);
 
 			Win.Add (buttonPressedLabel);
 		}
+
+		Dialog CreateDemoDialog (TextField widthEdit, TextField heightEdit, TextField titleEdit, TextField numButtonsEdit, CheckBox glyphsNotWords, RadioGroup styleRadioGroup,  Label buttonPressedLabel)
+		{
+			Dialog dialog = null;
+			try {
+
+				int width = 0;
+				int.TryParse (widthEdit.Text, out width);
+				int height = 0;
+				int.TryParse (heightEdit.Text, out height);
+				int numButtons = 3;
+				int.TryParse (numButtonsEdit.Text, out numButtons);
+
+				var buttons = new List<Button> ();
+				var clicked = -1;
+				for (int i = 0; i < numButtons; i++) {
+					int buttonId = i;
+					Button button = null;
+					if (glyphsNotWords.Checked == true) {
+						buttonId = i;
+						button = new Button (NumberToWords.Convert (buttonId) + " " + Char.ConvertFromUtf32 (buttonId + CODE_POINT),
+							is_default: buttonId == 0);
+					} else {
+						button = new Button (NumberToWords.Convert (buttonId),
+						       is_default: buttonId == 0);
+					}
+					button.Clicked += (s, e) => {
+						clicked = buttonId;
+						Application.RequestStop ();
+					};
+					buttons.Add (button);
+				}
+				//if (buttons.Count > 1) {
+				//	buttons [1].Text = "Accept";
+				//	buttons [1].IsDefault = true;
+				//	buttons [0].Visible = false;
+				//	buttons [0].Text = "_Back";
+				//	buttons [0].IsDefault = false;
+				//}
+
+				// This tests dynamically adding buttons; ensuring the dialog resizes if needed and 
+				// the buttons are laid out correctly
+				dialog = new Dialog (buttons.ToArray ()) {
+					Title = titleEdit.Text,
+					ButtonAlignment = (Dialog.ButtonAlignments)styleRadioGroup.SelectedItem
+				};
+				if (height != 0 || width != 0) {
+					dialog.Height = height;
+					dialog.Width = width;
+				}
+
+				var add = new Button ("Add a button") {
+					X = Pos.Center (),
+					Y = Pos.Center ()
+				};
+				add.Clicked += (s, e) => {
+					var buttonId = buttons.Count;
+					Button button;
+					if (glyphsNotWords.Checked == true) {
+						button = new Button (NumberToWords.Convert (buttonId) + " " + Char.ConvertFromUtf32 (buttonId + CODE_POINT),
+							is_default: buttonId == 0);
+					} else {
+						button = new Button (NumberToWords.Convert (buttonId),
+							is_default: buttonId == 0);
+					}
+					button.Clicked += (s, e) => {
+						clicked = buttonId;
+						Application.RequestStop ();
+
+					};
+					buttons.Add (button);
+					dialog.AddButton (button);
+					if (buttons.Count > 1) {
+						button.TabIndex = buttons [buttons.Count - 2].TabIndex + 1;
+					}
+				};
+				dialog.Add (add);
+
+				var addChar = new Button ($"Add a {Char.ConvertFromUtf32 (CODE_POINT)} to each button") {
+					X = Pos.Center (),
+					Y = Pos.Center () + 1
+				};
+				addChar.Clicked += (s, e) => {
+					foreach (var button in buttons) {
+						button.Text += Char.ConvertFromUtf32 (CODE_POINT);
+					}
+					dialog.LayoutSubviews ();
+				};
+				dialog.Closed += (s, e) => {
+					buttonPressedLabel.Text = $"{clicked}";
+				};
+				dialog.Add (addChar);
+
+			} catch (FormatException) {
+				buttonPressedLabel.Text = "Invalid Options";
+			}
+			return dialog;
+		}
 	}
 }
+

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -84,20 +84,6 @@ namespace Terminal.Gui.ApplicationTests {
 		}
 
 		[Fact]
-		public void Init_Shutdown_Toplevel_Not_Disposed ()
-		{
-			Application.Init (new FakeDriver ());
-
-			Application.Shutdown ();
-
-#if DEBUG_IDISPOSABLE
-			// 4 for Application.Top and it's 3 Frames
-			Assert.Equal (4, Responder.Instances.Count);
-			Assert.True (Responder.Instances [0].WasDisposed);
-#endif
-		}
-
-		[Fact]
 		public void Init_Unbalanced_Throws ()
 		{
 			Application.Init (new FakeDriver ());

--- a/UnitTests/ConsoleDrivers/AddRuneTests.cs
+++ b/UnitTests/ConsoleDrivers/AddRuneTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.Utilities;
+﻿//////using Microsoft.VisualStudio.TestPlatform.Utilities;
 using System.Buffers;
 using System.Text;
 using Xunit;

--- a/UnitTests/Input/ResponderTests.cs
+++ b/UnitTests/Input/ResponderTests.cs
@@ -5,7 +5,7 @@ using Console = Terminal.Gui.FakeConsole;
 
 namespace Terminal.Gui.InputTests {
 	public class ResponderTests {
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void New_Initializes ()
 		{
 			var r = new Responder ();
@@ -15,9 +15,10 @@ namespace Terminal.Gui.InputTests {
 			Assert.False (r.HasFocus);
 			Assert.True (r.Enabled);
 			Assert.True (r.Visible);
+			r.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void New_Methods_Return_False ()
 		{
 			var r = new Responder ();
@@ -30,14 +31,29 @@ namespace Terminal.Gui.InputTests {
 			Assert.False (r.MouseEvent (new MouseEvent () { Flags = MouseFlags.AllEvents }));
 			Assert.False (r.OnMouseEnter (new MouseEvent () { Flags = MouseFlags.AllEvents }));
 			Assert.False (r.OnMouseLeave (new MouseEvent () { Flags = MouseFlags.AllEvents }));
-			Assert.False (r.OnEnter (new View ()));
-			Assert.False (r.OnLeave (new View ()));
+			
+			var v = new View ();
+			Assert.False (r.OnEnter (v));
+			v.Dispose ();
+			
+			v = new View ();
+			Assert.False (r.OnLeave (v));
+			v.Dispose ();
+
+			r.Dispose ();
 		}
 
 		// Generic lifetime (IDisposable) tests
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void Dispose_Works ()
 		{
+		
+			var r = new Responder ();
+#if DEBUG_IDISPOSABLE
+			Assert.Equal (1, Responder.Instances.Count);
+#endif
+
+			r.Dispose ();
 
 		}
 
@@ -52,7 +68,7 @@ namespace Terminal.Gui.InputTests {
 			}
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void IsOverridden_False_IfNotOverridden ()
 		{
 			// MouseEvent IS defined on Responder but NOT overridden
@@ -67,9 +83,15 @@ namespace Terminal.Gui.InputTests {
 
 			// OnKeyDown is defined on View and NOT overrident on Button
 			Assert.False (Responder.IsOverridden (new Button () { Text = "Button does not override OnKeyDown" }, "OnKeyDown"));
+
+#if DEBUG_IDISPOSABLE
+			// HACK: Force clean up of Responders to avoid having to Dispose all the Views created above.
+			Responder.Instances.Clear ();
+			Assert.Empty (Responder.Instances);
+#endif
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void IsOverridden_True_IfOverridden ()
 		{
 			// MouseEvent is defined on Responder IS overriden on ScrollBarView (but not View)
@@ -86,6 +108,11 @@ namespace Terminal.Gui.InputTests {
 			Assert.True (Responder.IsOverridden (new ScrollBarView () { Text = "ScrollBarView overrides OnDrawContent" }, "OnDrawContent"));
 
 			Assert.True (Responder.IsOverridden (new Button () { Text = "Button overrides MouseEvent" }, "MouseEvent"));
+#if DEBUG_IDISPOSABLE
+			// HACK: Force clean up of Responders to avoid having to Dispose all the Views created above.
+			Responder.Instances.Clear ();
+			Assert.Empty (Responder.Instances);
+#endif
 		}
 	}
 }

--- a/UnitTests/View/BorderTests.cs
+++ b/UnitTests/View/BorderTests.cs
@@ -16,6 +16,7 @@ namespace Terminal.Gui.ViewTests {
 			var view = new View ();
 			Assert.Equal (LineStyle.None, view.BorderStyle);
 			Assert.Equal (Thickness.Empty, view.Border.Thickness);
+			view.Dispose ();
 		}
 
 		[Fact]
@@ -33,6 +34,7 @@ namespace Terminal.Gui.ViewTests {
 			view.BorderStyle = LineStyle.None;
 			Assert.Equal (LineStyle.None, view.BorderStyle);
 			Assert.Equal (Thickness.Empty, view.Border.Thickness);
+			view.Dispose ();
 		}
 
 		//[Fact]

--- a/UnitTests/View/FrameTests.cs
+++ b/UnitTests/View/FrameTests.cs
@@ -41,6 +41,7 @@ namespace Terminal.Gui.ViewTests {
 
 			view.Margin.Thickness = new Thickness (1, 2, 3, 4);
 			Assert.Equal (new Thickness (3, 5, 7, 9), view.GetFramesThickness ());
+			view.Dispose ();
 		}
 
 		[Theory, AutoInitShutdown]
@@ -91,7 +92,7 @@ namespace Terminal.Gui.ViewTests {
 				break;
 			}
 			_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
-
+			Application.End (rs);
 		}
 
 		[Theory, AutoInitShutdown]
@@ -242,6 +243,7 @@ namespace Terminal.Gui.ViewTests {
 ╚═══╝";
 
 			_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -268,6 +270,7 @@ namespace Terminal.Gui.ViewTests {
 ╚════════╝";
 
 			_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+			Application.End (rs);
 		}
 
 		[Theory, AutoInitShutdown]
@@ -379,6 +382,7 @@ namespace Terminal.Gui.ViewTests {
 				break;
 			}
 			_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+			Application.End (rs);
 		}
 
 		[Theory, AutoInitShutdown]
@@ -490,6 +494,7 @@ namespace Terminal.Gui.ViewTests {
 				break;
 			}
 			_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+			Application.End (rs);
 		}
 
 		[Theory, AutoInitShutdown]
@@ -601,6 +606,7 @@ namespace Terminal.Gui.ViewTests {
 				break;
 			}
 			_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+			Application.End (rs);
 		}
 	}
 }

--- a/UnitTests/View/Layout/AbsoluteLayoutTests.cs
+++ b/UnitTests/View/Layout/AbsoluteLayoutTests.cs
@@ -18,7 +18,7 @@ namespace Terminal.Gui.ViewTests {
 			this.output = output;
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Constructor ()
 		{
 			var frame = new Rect (1, 2, 3, 4);
@@ -30,6 +30,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (v.Y);
 			Assert.Null (v.Height);
 			Assert.Null (v.Width);
+			v.Dispose ();
 
 			v = new View (frame, "v");
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
@@ -39,6 +40,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (v.Y);
 			Assert.Null (v.Height);
 			Assert.Null (v.Width);
+			v.Dispose ();
 
 			v = new View (frame.X, frame.Y, "v");
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
@@ -49,9 +51,11 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (v.Y);
 			Assert.Null (v.Height);
 			Assert.Null (v.Width);
+			v.Dispose ();
+			
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_Frame ()
 		{
 			var frame = new Rect (1, 2, 3, 4);
@@ -66,6 +70,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (v.Y);
 			Assert.Null (v.Height);
 			Assert.Null (v.Width);
+			v.Dispose ();
 
 			v = new View (frame.X, frame.Y, "v");
 			v.Frame = newFrame;
@@ -75,6 +80,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (v.Y);
 			Assert.Null (v.Height);
 			Assert.Null (v.Width);
+			v.Dispose ();
 
 			newFrame = new Rect (10, 20, 30, 40);
 			v = new View (frame);
@@ -85,6 +91,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (v.Y);
 			Assert.Null (v.Height);
 			Assert.Null (v.Width);
+			v.Dispose ();
 
 			v = new View (frame.X, frame.Y, "v");
 			v.Frame = newFrame;
@@ -94,10 +101,10 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (v.Y);
 			Assert.Null (v.Height);
 			Assert.Null (v.Width);
-
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_Height_or_Width_Absolute ()
 		{
 			var frame = new Rect (1, 2, 3, 4);
@@ -113,27 +120,30 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (v.Y);
 			Assert.Equal ($"Absolute({newFrame.Height})", v.Height.ToString());
 			Assert.Equal ($"Absolute({newFrame.Width})", v.Width.ToString ());
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_Height_or_Width_NotAbsolute ()
 		{
 			var v = new View (Rect.Empty);
 			v.Height = Dim.Fill ();
 			v.Width = Dim.Fill ();
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);  // BUGBUG: v2 - Changing the Height or Width should change the LayoutStyle
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_Height_or_Width_Null ()
 		{
 			var v = new View (Rect.Empty);
 			v.Height = null;
 			v.Width = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_X_or_Y_Absolute ()
 		{
 			var frame = new Rect (1, 2, 3, 4);
@@ -149,23 +159,26 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal ($"Absolute({newFrame.Y})", v.Y.ToString ());
 			Assert.Null (v.Height);
 			Assert.Null (v.Width);
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_X_or_Y_NotAbsolute ()
 		{
 			var v = new View (Rect.Empty);
 			v.X = Pos.Center ();
 			v.Y = Pos.Center ();
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute); // BUGBUG: v2 - Changing the Height or Width should change the LayoutStyle
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_X_or_Y_Null ()
 		{
 			var v = new View (Rect.Empty);
 			v.X = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
+			v.Dispose ();
 
 			v = new View (Rect.Empty);
 			v.X = Pos.Center ();
@@ -173,10 +186,12 @@ namespace Terminal.Gui.ViewTests {
 
 			v.X = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
+			v.Dispose ();
 
 			v = new View (Rect.Empty);
 			v.Y = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
+			v.Dispose ();
 
 			v = new View (Rect.Empty);
 			v.Y = Pos.Center ();
@@ -184,9 +199,10 @@ namespace Terminal.Gui.ViewTests {
 
 			v.Y = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_X_Y_Height_Width_Absolute ()
 		{
 			var v = new View (Rect.Empty);
@@ -195,6 +211,7 @@ namespace Terminal.Gui.ViewTests {
 			v.Height = 3;
 			v.Width = 4;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
+			v.Dispose ();
 
 			v = new View (Rect.Empty);
 			v.X = Pos.Center ();
@@ -209,6 +226,7 @@ namespace Terminal.Gui.ViewTests {
 			v.Height = null;
 			v.Width = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute); // We never automatically change to Absolute from Computed??
+			v.Dispose ();
 
 			v = new View (Rect.Empty);
 			v.X = Pos.Center ();
@@ -223,6 +241,7 @@ namespace Terminal.Gui.ViewTests {
 			v.Height = null;
 			v.Width = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute); // We never automatically change to Absolute from Computed??
+			v.Dispose ();
 
 			v = new View (Rect.Empty);
 			v.X = Pos.Center ();
@@ -237,6 +256,7 @@ namespace Terminal.Gui.ViewTests {
 			v.Height = null;
 			v.Width = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute); // We never automatically change to Absolute from Computed??
+			v.Dispose ();
 
 			v = new View (Rect.Empty);
 			v.X = Pos.Center ();
@@ -251,6 +271,7 @@ namespace Terminal.Gui.ViewTests {
 			v.Height = 3;
 			v.Width = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute); // We never automatically change to Absolute from Computed??
+			v.Dispose ();
 
 			v = new View (Rect.Empty);
 			v.X = Pos.Center ();
@@ -265,9 +286,10 @@ namespace Terminal.Gui.ViewTests {
 			v.Height = null;
 			v.Width = 4;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute); // We never automatically change to Absolute from Computed??
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Change_X_Y_Height_Width_Null ()
 		{
 			var v = new View (Rect.Empty);
@@ -277,6 +299,7 @@ namespace Terminal.Gui.ViewTests {
 			v.Width = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute);
 
+			v.Dispose ();
 			v = new View (Rect.Empty);
 			v.X = Pos.Center ();
 			v.Y = Pos.Center ();
@@ -290,9 +313,10 @@ namespace Terminal.Gui.ViewTests {
 			v.Height = null;
 			v.Width = null;
 			Assert.True (v.LayoutStyle == LayoutStyle.Absolute); // We never automatically change to Absolute from Computed??
+			v.Dispose ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void AbsoluteLayout_Layout ()
 		{
 			var superRect = new Rect (0, 0, 100, 100);
@@ -320,6 +344,7 @@ namespace Terminal.Gui.ViewTests {
 			super.LayoutSubviews ();
 			Assert.Equal (new Rect (0, 0, 10, 10), v1.Frame);
 			Assert.Equal (new Rect (10, 10, 10, 10), v2.Frame);
+			super.Dispose ();
 		}
 	}
 }

--- a/UnitTests/View/Layout/LayoutTests.cs
+++ b/UnitTests/View/Layout/LayoutTests.cs
@@ -29,6 +29,9 @@ namespace Terminal.Gui.ViewTests {
 			sub2.Width = Dim.Width (sub1);
 
 			Assert.Throws<InvalidOperationException> (() => root.LayoutSubviews ());
+			root.Dispose ();
+			sub1.Dispose ();
+			sub2.Dispose ();
 		}
 
 		[Fact]
@@ -43,6 +46,9 @@ namespace Terminal.Gui.ViewTests {
 
 			var exception = Record.Exception (root.LayoutSubviews);
 			Assert.Null (exception);
+			root.Dispose ();
+			sub1.Dispose ();
+			sub2.Dispose ();
 		}
 
 		[Fact]
@@ -60,6 +66,9 @@ namespace Terminal.Gui.ViewTests {
 			root.LayoutSubviews ();
 
 			Assert.Equal (6, second.Frame.X);
+			root.Dispose ();
+			first.Dispose ();
+			second.Dispose ();
 		}
 
 		[Fact]
@@ -74,12 +83,16 @@ namespace Terminal.Gui.ViewTests {
 
 			var second = new View () { Id = "second" };
 			root.Add (second);
-
+			
 			second.X = Pos.Right (first) + 1;
 
 			root.LayoutSubviews ();
 
 			Assert.Equal (6, second.Frame.X);
+			root.Dispose ();
+			top.Dispose ();
+			first.Dispose ();
+			second.Dispose ();
 		}
 
 		[Fact]
@@ -92,6 +105,8 @@ namespace Terminal.Gui.ViewTests {
 			super.Add (sub);
 			super.Width = Dim.Width (sub);
 			Assert.Throws<InvalidOperationException> (() => root.LayoutSubviews ());
+			root.Dispose ();
+			super.Dispose ();
 		}
 
 		[Fact, AutoInitShutdown]
@@ -173,7 +188,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal (5, rHeight);
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void GetCurrentWidth_TrySetWidth ()
 		{
 			var top = new View () {
@@ -204,6 +219,7 @@ namespace Terminal.Gui.ViewTests {
 			top.LayoutSubviews ();
 
 			Assert.True (v.TrySetWidth (0, out _));
+			top.Dispose ();
 		}
 
 		[Fact]
@@ -237,6 +253,7 @@ namespace Terminal.Gui.ViewTests {
 			top.LayoutSubviews ();
 
 			Assert.True (v.TrySetHeight (0, out _));
+			top.Dispose ();
 		}
 
 		[Fact]
@@ -249,6 +266,9 @@ namespace Terminal.Gui.ViewTests {
 			Assert.False (view1.AutoSize);
 			Assert.False (view2.AutoSize);
 			Assert.False (view3.AutoSize);
+			view1.Dispose ();
+			view2.Dispose ();
+			view3.Dispose ();
 		}
 
 		[Fact]
@@ -262,6 +282,9 @@ namespace Terminal.Gui.ViewTests {
 			Assert.False (view1.AutoSize);
 			Assert.False (view2.AutoSize);
 			Assert.False (view3.AutoSize);
+			view1.Dispose ();
+			view2.Dispose ();
+			view3.Dispose ();
 		}
 
 		[Fact]
@@ -274,6 +297,9 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (label1.AutoSize);
 			Assert.True (label2.AutoSize);
 			Assert.True (label3.AutoSize);
+			label1.Dispose ();
+			label2.Dispose ();
+			label3.Dispose ();
 		}
 
 		[Fact]
@@ -287,6 +313,9 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (label1.AutoSize);
 			Assert.True (label2.AutoSize);
 			Assert.True (label3.AutoSize);
+			label1.Dispose ();
+			label2.Dispose ();
+			label3.Dispose ();
 		}
 
 		[Fact]
@@ -301,6 +330,7 @@ namespace Terminal.Gui.ViewTests {
 
 			Assert.False (label.AutoSize);
 			Assert.Equal ("(0,0,0,1)", label.Bounds.ToString ());
+			super.Dispose ();
 		}
 
 		[Fact]
@@ -316,6 +346,7 @@ namespace Terminal.Gui.ViewTests {
 
 			Assert.True (label.AutoSize);
 			Assert.Equal ("(0,0,8,1)", label.Bounds.ToString ());
+			super.Dispose ();
 		}
 
 		[Fact, AutoInitShutdown]
@@ -337,10 +368,11 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal ("(0,0,28,78)", label.Bounds.ToString ());
 			Assert.False (label.IsInitialized);
 
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 			Assert.True (label.IsInitialized);
 			Assert.False (label.AutoSize);
 			Assert.Equal ("(0,0,28,78)", label.Bounds.ToString ());
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -366,7 +398,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal ("(0,0,28,2)", label.Bounds.ToString ());
 			Assert.False (label.IsInitialized);
 
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 
 			Assert.True (label.AutoSize);
 			Assert.Equal ("(0,0,28,2)", label.Bounds.ToString ());
@@ -377,6 +409,7 @@ namespace Terminal.Gui.ViewTests {
 
 			Assert.False (label.AutoSize);
 			Assert.Equal ("(0,0,28,1)", label.Bounds.ToString ());
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -391,7 +424,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (label.AutoSize);
 			Assert.Equal ("(0,0,0,0)", label.Bounds.ToString ());
 
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 
 			Assert.True (label.AutoSize);
 			// Here the AutoSize ensuring the right size with width 28 (Dim.Fill)
@@ -430,6 +463,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (label.AutoSize);
 			// BUGBUG: v2 - AutoSize is broken - temporarily disabling test See #2432
 			//Assert.Equal ("(0,0,28,3)", label.Bounds.ToString ());
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -440,7 +474,7 @@ namespace Terminal.Gui.ViewTests {
 			var viewY = new View ("Y") { Y = Pos.Bottom (label) };
 
 			Application.Top.Add (label, viewX, viewY);
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 
 			Assert.True (label.AutoSize);
 			Assert.Equal (new Rect (0, 0, 10, 2), label.Frame);
@@ -468,6 +502,7 @@ Y
 
 			pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 			Assert.Equal (new Rect (0, 0, 11, 3), pos);
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -478,7 +513,7 @@ Y
 			var viewY = new View ("Y") { Y = Pos.Bottom (label) };
 
 			Application.Top.Add (label, viewX, viewY);
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 
 			Assert.True (label.AutoSize);
 			Assert.Equal (new Rect (0, 0, 2, 10), label.Frame);
@@ -522,6 +557,7 @@ Y
 
 			pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 			Assert.Equal (new Rect (0, 0, 3, 11), pos);
+			Application.End (rs);
 		}
 
 		[Fact]
@@ -530,7 +566,7 @@ Y
 		{
 			var lbl = new Label ("123");
 			Application.Top.Add (lbl);
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 
 			Assert.True (lbl.AutoSize);
 			Assert.Equal ("123 ", GetContents ());
@@ -554,6 +590,7 @@ Y
 				}
 				return text;
 			}
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -579,7 +616,7 @@ Y
 			};
 			win.Add (horizontalView, verticalView);
 			Application.Top.Add (win);
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 			((FakeDriver)Application.Driver).SetBufferSize (32, 32);
 
 			Assert.False (horizontalView.AutoSize);
@@ -664,6 +701,7 @@ Y
 
 			pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 			Assert.Equal (new Rect (0, 0, 32, 32), pos);
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -674,7 +712,7 @@ Y
 			win.Add (view);
 			Application.Top.Add (win);
 
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 			((FakeDriver)Application.Driver).SetBufferSize (22, 22);
 
 			Assert.Equal (new Rect (0, 0, 22, 22), win.Frame);
@@ -976,6 +1014,7 @@ Y
 
 			pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 			Assert.Equal (new Rect (0, 0, 22, 22), pos);
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -1004,7 +1043,7 @@ Y
 			};
 			win.Add (horizontalView, verticalView);
 			Application.Top.Add (win);
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 			((FakeDriver)Application.Driver).SetBufferSize (22, 22);
 
 			Assert.True (horizontalView.AutoSize);
@@ -1088,6 +1127,7 @@ Y
 
 			pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 			Assert.Equal (new Rect (0, 0, 22, 22), pos);
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -1109,7 +1149,7 @@ Y
 
 			Assert.True (label.AutoSize);
 
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 			((FakeDriver)Application.Driver).SetBufferSize (30, 5);
 			var expected = @$"
 ┌┤Test Demo 你├──────────────┐
@@ -1134,6 +1174,7 @@ Y
 ";
 
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -1195,7 +1236,7 @@ Y
 			Assert.Equal ("Absolute(10)", view6.Width.ToString ());
 			Assert.Equal ("Absolute(5)", view6.Height.ToString ());
 
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 
 			Assert.True (view1.IsInitialized);
 			Assert.True (view2.IsInitialized);
@@ -1226,6 +1267,7 @@ Y
 			Assert.Equal (new Rect (0, 0, 10, 5), view6.Frame);
 			Assert.Equal ("Absolute(10)", view6.Width.ToString ());
 			Assert.Equal ("Absolute(5)", view6.Height.ToString ());
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -1288,7 +1330,7 @@ Y
 			//Assert.Equal ("Absolute(10)", view6.Width.ToString ());
 			//Assert.Equal ("Absolute(5)", view6.Height.ToString ());
 
-			Application.Begin (Application.Top);
+			var rs = Application.Begin (Application.Top);
 
 			Assert.True (view1.IsInitialized);
 			Assert.True (view2.IsInitialized);
@@ -1320,6 +1362,7 @@ Y
 			//Assert.Equal (new Rect (0, 0, 10, 17), view6.Frame);
 			//Assert.Equal ("Absolute(10)", view6.Width.ToString ());
 			//Assert.Equal ("Absolute(5)", view6.Height.ToString ());
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -1374,6 +1417,7 @@ Y
 			// BUGBUG: v2 - Autosize is broken when setting Width/Height AutoSize. Disabling test for now.
 			//Assert.Equal ("Absolute(2)", view2.Width.ToString ());
 			//Assert.Equal ("Absolute(17)", view2.Height.ToString ());
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -1410,9 +1454,10 @@ Y
 			Assert.Equal ("Center", view2.Y.ToString ());
 			Assert.Equal ("Fill(0)", view2.Width.ToString ());
 			Assert.Equal ("Fill(0)", view2.Height.ToString ());
+		
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void SetRelativeLayout_PosCombine_Center_Plus_Absolute ()
 		{
 			var superView = new View () {
@@ -1516,6 +1561,9 @@ Y
 			testView.SetRelativeLayout (superView.Frame);
 			Assert.Equal (6, testView.Frame.X);
 			Assert.Equal (6, testView.Frame.Y);
+
+			superView.Dispose ();
+
 		}
 
 		[Theory, AutoInitShutdown]
@@ -1653,6 +1701,7 @@ Y
 				break;
 			}
 			_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+			Application.End (rs);
 		}
 
 		[Theory, AutoInitShutdown]
@@ -1803,6 +1852,7 @@ Y
 				break;
 			}
 			_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+			Application.End (rs);
 		}
 
 		[Fact, AutoInitShutdown]
@@ -1856,7 +1906,7 @@ Y
 			Application.End (rs);
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void Draw_Vertical_Throws_IndexOutOfRangeException_With_Negative_Bounds ()
 		{
 			Application.Init (new FakeDriver ());
@@ -1887,7 +1937,7 @@ Y
 			Application.Shutdown ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void Draw_Throws_IndexOutOfRangeException_With_Negative_Bounds ()
 		{
 			Application.Init (new FakeDriver ());

--- a/UnitTests/View/Layout/PosTests.cs
+++ b/UnitTests/View/Layout/PosTests.cs
@@ -378,7 +378,7 @@ namespace Terminal.Gui.ViewTests {
 		/// <summary>
 		/// Tests Pos.Left, Pos.X, Pos.Top, Pos.Y, Pos.Right, and Pos.Bottom set operations
 		/// </summary>
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void PosSide_SetsValue ()
 		{
 			string side; // used in format string
@@ -533,7 +533,7 @@ namespace Terminal.Gui.ViewTests {
 		}
 
 		// See: https://github.com/gui-cs/Terminal.Gui/issues/504
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void LeftTopBottomRight_Win_ShouldNotThrow ()
 		{
 			// Setup Fake driver
@@ -611,9 +611,6 @@ namespace Terminal.Gui.ViewTests {
 			// If Application.RunState is used then we must use Application.RunLoop with the rs parameter
 			Application.RunLoop (rs);
 			cleanup (rs);
-#if DEBUG_IDISPOSABLE
-			Assert.Empty (Responder.Instances);
-#endif
 		}
 
 		[Fact]
@@ -818,7 +815,7 @@ namespace Terminal.Gui.ViewTests {
 		//	Application.Shutdown ();
 		//}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void PosCombine_Will_Throws ()
 		{
 			Application.Init (new FakeDriver ());
@@ -850,12 +847,9 @@ namespace Terminal.Gui.ViewTests {
 			Application.Shutdown ();
 
 			v2.Dispose ();
-#if DEBUG_IDISPOSABLE
-			Assert.Empty (Responder.Instances);
-#endif
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void Pos_Add_Operator ()
 		{
 			Application.Init (new FakeDriver ());
@@ -899,12 +893,9 @@ namespace Terminal.Gui.ViewTests {
 
 			// Shutdown must be called to safely clean up Application if Init has been called
 			Application.Shutdown ();
-#if DEBUG_IDISPOSABLE
-			Assert.Empty (Responder.Instances);
-#endif
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void Pos_Subtract_Operator ()
 		{
 			Application.Init (new FakeDriver ());
@@ -960,12 +951,10 @@ namespace Terminal.Gui.ViewTests {
 
 			// Shutdown must be called to safely clean up Application if Init has been called
 			Application.Shutdown ();
-#if DEBUG_IDISPOSABLE
-			Assert.Empty (Responder.Instances);
-#endif
+
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void Internal_Tests ()
 		{
 			var posFactor = new Pos.PosFactor (0.10F);

--- a/UnitTests/View/NavigationTests.cs
+++ b/UnitTests/View/NavigationTests.cs
@@ -45,6 +45,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal ("FrameSubview", top.MostFocused.Text);
 			top.ProcessKey (new KeyEvent (Key.BackTab | Key.ShiftMask, new KeyModifiers ()));
 			Assert.Equal ($"WindowSubview", top.MostFocused.Text);
+			top.Dispose ();
 		}
 
 
@@ -69,6 +70,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal (r.Subviews.IndexOf (v1), r.TabIndexes.IndexOf (v1));
 			Assert.Equal (r.Subviews.IndexOf (v2), r.TabIndexes.IndexOf (v2));
 			Assert.Equal (r.Subviews.IndexOf (v3), r.TabIndexes.IndexOf (v3));
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -89,6 +91,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (r.TabIndexes.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v2) == 1);
 			Assert.True (r.TabIndexes.IndexOf (v3) == 2);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -109,6 +112,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (r.TabIndexes.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v2) == 1);
 			Assert.True (r.TabIndexes.IndexOf (v3) == 2);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -129,8 +133,9 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (r.TabIndexes.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v2) == 1);
 			Assert.True (r.TabIndexes.IndexOf (v3) == 2);
-		}
-
+			r.Dispose ();
+		} 
+		
 		[Fact]
 		public void SendSubviewBackwards_Subviews_vs_TabIndexes ()
 		{
@@ -149,6 +154,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (r.TabIndexes.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v2) == 1);
 			Assert.True (r.TabIndexes.IndexOf (v3) == 2);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -168,6 +174,7 @@ namespace Terminal.Gui.ViewTests {
 			v1.TabIndex = 2;
 			Assert.True (r.Subviews.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v1) == 2);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -183,6 +190,7 @@ namespace Terminal.Gui.ViewTests {
 			v1.TabIndex = 3;
 			Assert.True (r.Subviews.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v1) == 2);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -198,6 +206,7 @@ namespace Terminal.Gui.ViewTests {
 			v1.TabIndex = -1;
 			Assert.True (r.Subviews.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v1) == 0);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -215,6 +224,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.True (r.Subviews.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v1) == 0);
 			Assert.Equal (-1, v1.TabIndex);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -231,6 +241,7 @@ namespace Terminal.Gui.ViewTests {
 			v1.TabIndex = 1;
 			Assert.True (r.Subviews.IndexOf (v1) == 0);
 			Assert.True (r.TabIndexes.IndexOf (v1) == 1);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -255,6 +266,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.False (v1.HasFocus);
 			Assert.False (v2.HasFocus);
 			Assert.True (v3.HasFocus);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -279,6 +291,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.False (v1.HasFocus);
 			Assert.False (v2.HasFocus);
 			Assert.False (v3.HasFocus);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -303,6 +316,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.False (v1.HasFocus);
 			Assert.False (v2.HasFocus);
 			Assert.False (v3.HasFocus);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -327,6 +341,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.False (v1.HasFocus);
 			Assert.False (v2.HasFocus);
 			Assert.False (v3.HasFocus);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -359,6 +374,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.False (v1.HasFocus);
 			Assert.False (v2.HasFocus);
 			Assert.True (v3.HasFocus);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -391,6 +407,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.False (v1.HasFocus);
 			Assert.False (v2.HasFocus);
 			Assert.True (v3.HasFocus);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -433,6 +450,7 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal (r.TabIndexes.IndexOf (v3), v3.TabIndex);
 			Assert.Equal (2, v3.TabIndex);
 			Assert.True (v3.TabStop);
+			r.Dispose ();
 		}
 
 		[Fact]
@@ -463,6 +481,7 @@ namespace Terminal.Gui.ViewTests {
 			v.CanFocus = true;
 			Assert.False (f.CanFocus);
 			Assert.True (v.CanFocus);
+			t.Dispose ();
 		}
 
 		[Fact]
@@ -986,7 +1005,8 @@ namespace Terminal.Gui.ViewTests {
 			window.Add (view);
 
 			// Act
-			Application.Begin (top);
+			var rs = Application.Begin (top);
+			Application.End (rs);
 			Application.Shutdown ();
 
 			// Assert does Not throw NullReferenceException
@@ -1018,12 +1038,14 @@ namespace Terminal.Gui.ViewTests {
 			subView1.Add (subView1subView1);
 			var view2 = new View { CanFocus = true };
 			top.Add (view1, view2);
-			Application.Begin (top);
+			var rs = Application.Begin (top);
 
 			view2.SetFocus ();
 			Assert.True (view1Leave);
 			Assert.True (subView1Leave);
 			Assert.False (subView1subView1Leave);
+			Application.End (rs);
+			subView1subView1.Dispose ();
 		}
 
 		[Fact, AutoInitShutdown]

--- a/UnitTests/View/TitleTests.cs
+++ b/UnitTests/View/TitleTests.cs
@@ -68,6 +68,7 @@ namespace Terminal.Gui.ViewTests {
 			expectedOld = r.Title;
 			r.Title = expected;
 			Assert.Equal (expected, r.Title);
+			r.Dispose ();
 		}
 
 	}

--- a/UnitTests/Views/OverlappedTests.cs
+++ b/UnitTests/Views/OverlappedTests.cs
@@ -19,25 +19,22 @@ namespace Terminal.Gui.ViewsTests {
 #endif
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void Dispose_Toplevel_IsOverlappedContainer_False_With_Begin_End ()
 		{
 			Application.Init (new FakeDriver ());
 
 			var top = new Toplevel ();
 			var rs = Application.Begin (top);
-			Application.End (rs);
-
-			Application.Shutdown ();
-
 #if DEBUG_IDISPOSABLE
-			Assert.Equal (8, Responder.Instances.Count);
-			Assert.True (Responder.Instances [0].WasDisposed);
-			Assert.True (Responder.Instances [1].WasDisposed);
+			Assert.Equal (4, Responder.Instances.Count);
 #endif
+
+			Application.End (rs);
+			Application.Shutdown ();
 		}
 
-		[Fact]
+		[Fact, TestRespondersDisposed]
 		public void Dispose_Toplevel_IsOverlappedContainer_True_With_Begin ()
 		{
 			Application.Init (new FakeDriver ());
@@ -47,11 +44,6 @@ namespace Terminal.Gui.ViewsTests {
 			Application.End (rs);
 
 			Application.Shutdown ();
-#if DEBUG_IDISPOSABLE
-			Assert.Equal (8, Responder.Instances.Count);
-			Assert.True (Responder.Instances [0].WasDisposed);
-			Assert.True (Responder.Instances [1].WasDisposed);
-#endif
 		}
 
 		[Fact, AutoInitShutdown]

--- a/UnitTests/Views/ToplevelTests.cs
+++ b/UnitTests/Views/ToplevelTests.cs
@@ -1602,5 +1602,101 @@ namespace Terminal.Gui.ViewsTests {
 			var exception = Record.Exception (() => topChild.ProcessHotKey (new KeyEvent (Key.AltMask, new KeyModifiers { Alt = true })));
 			Assert.Null (exception);
 		}
+
+
+		[Fact, TestRespondersDisposed]
+		public void Multi_Thread_Toplevels ()
+		{
+			Application.Init (new FakeDriver ());
+
+			var t = Application.Top;
+			var w = new Window ();
+			t.Add (w);
+
+			int count = 0, count1 = 0, count2 = 0;
+			bool log = false, log1 = false, log2 = false;
+			bool fromTopStillKnowFirstIsRunning = false;
+			bool fromTopStillKnowSecondIsRunning = false;
+			bool fromFirstStillKnowSecondIsRunning = false;
+
+			Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+				count++;
+				if (count1 == 5) {
+					log1 = true;
+				}
+				if (count1 == 14 && count2 == 10 && count == 15) { // count2 is already stopped
+					fromTopStillKnowFirstIsRunning = true;
+				}
+				if (count1 == 7 && count2 == 7 && count == 8) {
+					fromTopStillKnowSecondIsRunning = true;
+				}
+				if (count == 30) {
+					Assert.Equal (30, count);
+					Assert.Equal (20, count1);
+					Assert.Equal (10, count2);
+
+					Assert.True (log);
+					Assert.True (log1);
+					Assert.True (log2);
+
+					Assert.True (fromTopStillKnowFirstIsRunning);
+					Assert.True (fromTopStillKnowSecondIsRunning);
+					Assert.True (fromFirstStillKnowSecondIsRunning);
+
+					Application.RequestStop ();
+					return false;
+				}
+				return true;
+			});
+
+			t.Ready += FirstDialogToplevel;
+
+			void FirstDialogToplevel (object sender, EventArgs args)
+			{
+				var od = new OpenDialog ();
+				od.Ready += SecondDialogToplevel;
+
+				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+					count1++;
+					if (count2 == 5) {
+						log2 = true;
+					}
+					if (count2 == 4 && count1 == 5 && count == 5) {
+						fromFirstStillKnowSecondIsRunning = true;
+					}
+					if (count1 == 20) {
+						Assert.Equal (20, count1);
+						Application.RequestStop ();
+						return false;
+					}
+					return true;
+				});
+
+				Application.Run (od);
+			}
+
+			void SecondDialogToplevel (object sender, EventArgs args)
+			{
+				var d = new Dialog ();
+
+				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+					count2++;
+					if (count < 30) {
+						log = true;
+					}
+					if (count2 == 10) {
+						Assert.Equal (10, count2);
+						Application.RequestStop ();
+						return false;
+					}
+					return true;
+				});
+
+				Application.Run (d);
+			}
+
+			Application.Run ();
+			Application.Shutdown ();
+		}
 	}
 }

--- a/UnitTests/xunit.runner.json
+++ b/UnitTests/xunit.runner.json
@@ -2,5 +2,5 @@
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "parallelizeTestCollections": false,
   "parallelizeAssembly": false,
-  "stopOnFail": true
+  "stopOnFail": false
 }

--- a/UnitTests/xunit.runner.json
+++ b/UnitTests/xunit.runner.json
@@ -2,5 +2,5 @@
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "parallelizeTestCollections": false,
   "parallelizeAssembly": false,
-  "stopOnFail": false
+  "stopOnFail": true
 }


### PR DESCRIPTION
Fixes #2870 - Memory leaks in Toplevel, Responder, and LineCanvas

- Also updates unit tests with a new attribute `TestRespondersDisposed` that a) clears `Responder.Instances` Before and b) verifies `Responder.Instances` is empty a End.

Needs to be backported to v1 as well. See #2878.

Related issue #2872

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
