### PR TITLE
Fixes #2899 - Use Focus not HotFocus for TableView selected cells

### DIFF
--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -618,7 +618,7 @@ namespace Terminal.Gui {
 
 				Attribute cellColor;
 				if (isSelectedCell) {
-					cellColor = focused ? scheme.HotFocus : scheme.HotNormal;
+					cellColor = focused ? scheme.Focus : scheme.HotNormal;
 				} else {
 					cellColor = Enabled ? scheme.Normal : scheme.Disabled;
 				}

--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -572,7 +572,7 @@ namespace Terminal.Gui {
 			Attribute color;
 
 			if (FullRowSelect && IsSelected (0, rowToRender)) {
-				color = focused ? rowScheme.HotFocus : rowScheme.HotNormal;
+				color = focused ? rowScheme.Focus : rowScheme.HotNormal;
 			} else {
 				color = Enabled ? rowScheme.Normal : rowScheme.Disabled;
 			}
@@ -634,7 +634,7 @@ namespace Terminal.Gui {
 				if (scheme != rowScheme) {
 
 					if (isSelectedCell) {
-						color = focused ? rowScheme.HotFocus : rowScheme.HotNormal;
+						color = focused ? rowScheme.Focus : rowScheme.HotNormal;
 					} else {
 						color = Enabled ? rowScheme.Normal : rowScheme.Disabled;
 					}

--- a/UnitTests/Views/TableViewTests.cs
+++ b/UnitTests/Views/TableViewTests.cs
@@ -840,7 +840,7 @@ namespace Terminal.Gui.ViewsTests {
 				// 0
 				tv.ColorScheme.Normal,				
 				// 1
-				focused ? tv.ColorScheme.HotFocus : tv.ColorScheme.HotNormal});
+				focused ? tv.ColorScheme.Focus : tv.ColorScheme.HotNormal});
 
 			Application.Shutdown ();
 		}
@@ -880,14 +880,14 @@ namespace Terminal.Gui.ViewsTests {
 01000
 ";
 
-			var invertHotFocus = new Attribute (tv.ColorScheme.HotFocus.Background, tv.ColorScheme.HotFocus.Foreground);
+			var invertFocus = new Attribute (tv.ColorScheme.Focus.Background, tv.ColorScheme.Focus.Foreground);
 			var invertHotNormal = new Attribute (tv.ColorScheme.HotNormal.Background, tv.ColorScheme.HotNormal.Foreground);
 
 			TestHelpers.AssertDriverColorsAre (expectedColors, new Attribute [] {
 				// 0
 				tv.ColorScheme.Normal,				
 				// 1
-				focused ?  invertHotFocus : invertHotNormal});
+				focused ?  invertFocus : invertHotNormal});
 
 			Application.Shutdown ();
 		}
@@ -906,11 +906,13 @@ namespace Terminal.Gui.ViewsTests {
 			var rowHighlight = new ColorScheme () {
 				Normal = new Attribute (Color.BrightCyan, Color.DarkGray),
 				HotNormal = new Attribute (Color.Green, Color.Blue),
-				HotFocus = new Attribute (Color.BrightYellow, Color.White),
-				Focus = new Attribute (Color.Cyan, Color.Magenta),
+				Focus = new Attribute (Color.BrightYellow, Color.White),
+				
+				// Not used by TableView
+				HotFocus = new Attribute (Color.Cyan, Color.Magenta),
 			};
 
-			// when B is 2 use the custom highlight colour for the row
+			// when B is 2 use the custom highlight color for the row
 			tv.Style.RowColorGetter += (e) => Convert.ToInt32 (e.Table [e.RowIndex, 1]) == 2 ? rowHighlight : null;
 
 			// private method for forcing the view to be focused/not focused
@@ -940,7 +942,7 @@ namespace Terminal.Gui.ViewsTests {
 				// 0
 				tv.ColorScheme.Normal,				
 				// 1
-				focused ? rowHighlight.HotFocus : rowHighlight.HotNormal,
+				focused ? rowHighlight.Focus : rowHighlight.HotNormal,
 				// 2
 				rowHighlight.Normal});
 
@@ -973,7 +975,7 @@ namespace Terminal.Gui.ViewsTests {
 				// 0
 				tv.ColorScheme.Normal,
 				// 1
-				focused ? tv.ColorScheme.HotFocus : tv.ColorScheme.HotNormal });
+				focused ? tv.ColorScheme.Focus : tv.ColorScheme.HotNormal });
 
 			// Shutdown must be called to safely clean up Application if Init has been called
 			Application.Shutdown ();
@@ -993,12 +995,14 @@ namespace Terminal.Gui.ViewsTests {
 			// Create a style for column B
 			var bStyle = tv.Style.GetOrCreateColumnStyle (1);
 
-			// when B is 2 use the custom highlight colour
+			// when B is 2 use the custom highlight color
 			var cellHighlight = new ColorScheme () {
 				Normal = new Attribute (Color.BrightCyan, Color.DarkGray),
 				HotNormal = new Attribute (Color.Green, Color.Blue),
-				HotFocus = new Attribute (Color.BrightYellow, Color.White),
 				Focus = new Attribute (Color.Cyan, Color.Magenta),
+				
+				// Not used by TableView
+				HotFocus = new Attribute (Color.BrightYellow, Color.White),
 			};
 
 			bStyle.ColorGetter = (a) => Convert.ToInt32 (a.CellValue) == 2 ? cellHighlight : null;
@@ -1030,7 +1034,7 @@ namespace Terminal.Gui.ViewsTests {
 				// 0
 				tv.ColorScheme.Normal,				
 				// 1
-				focused ? tv.ColorScheme.HotFocus : tv.ColorScheme.HotNormal,
+				focused ? tv.ColorScheme.Focus : tv.ColorScheme.HotNormal,
 				// 2
 				cellHighlight.Normal});
 
@@ -1063,7 +1067,7 @@ namespace Terminal.Gui.ViewsTests {
 				// 0
 				tv.ColorScheme.Normal,				
 				// 1
-				focused ? tv.ColorScheme.HotFocus : tv.ColorScheme.HotNormal });
+				focused ? tv.ColorScheme.Focus : tv.ColorScheme.HotNormal });
 
 			// Shutdown must be called to safely clean up Application if Init has been called
 			Application.Shutdown ();
@@ -2771,7 +2775,7 @@ A B C
 			tv.Draw ();
 
 			// Focus color (1) should be used for rendering the selected line
-			// Note that because there are no vertical cell lines we use the hot focus
+			// Note that because there are no vertical cell lines we use the focus
 			// color for the whole row
 			expected =
 				@"

--- a/UnitTests/Views/TableViewTests.cs
+++ b/UnitTests/Views/TableViewTests.cs
@@ -2213,11 +2213,11 @@ namespace Terminal.Gui.ViewsTests {
 			TestHelpers.AssertDriverContentsAre (expected, output);
 
 			var normal = tv.ColorScheme.Normal;
-			var focus = tv.ColorScheme.HotFocus = new Attribute (Color.Magenta, Color.White);
+			var focus = tv.ColorScheme.Focus = new Attribute (Color.Magenta, Color.White);
 
 			tv.Draw ();
 
-			// HotFocus color (1) should be used for rendering the selected line
+			// Focus color (1) should be used for rendering the selected line
 			// But should not spill into the borders.  Normal color (0) should be
 			// used for the rest.
 			expected =
@@ -2271,11 +2271,11 @@ namespace Terminal.Gui.ViewsTests {
 			TestHelpers.AssertDriverContentsAre (expected, output);
 
 			var normal = tv.ColorScheme.Normal;
-			var focus = tv.ColorScheme.HotFocus = new Attribute (Color.Magenta, Color.White);
+			var focus = tv.ColorScheme.Focus = new Attribute (Color.Magenta, Color.White);
 
 			tv.Draw ();
 
-			// HotFocus color (1) should be used for cells only because
+			// Focus color (1) should be used for cells only because
 			// AlwaysUseNormalColorForVerticalCellLines is true
 			expected =
 				@"
@@ -2766,11 +2766,11 @@ A B C
 			TestHelpers.AssertDriverContentsAre (expected, output);
 
 			var normal = tv.ColorScheme.Normal;
-			var focus = tv.ColorScheme.HotFocus = new Attribute (Color.Magenta, Color.White);
+			var focus = tv.ColorScheme.Focus = new Attribute (Color.Magenta, Color.White);
 
 			tv.Draw ();
 
-			// HotFocus color (1) should be used for rendering the selected line
+			// Focus color (1) should be used for rendering the selected line
 			// Note that because there are no vertical cell lines we use the hot focus
 			// color for the whole row
 			expected =


### PR DESCRIPTION
Fixes #2899 - Use Focus not HotFocus for TableView selected cells.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [ x My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
