### PR TITLE
Indicate the selected column in FileDialog

### DIFF
--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -209,6 +209,7 @@ namespace Terminal.Gui {
 			};
 			this.tableView.AddKeyBinding (Key.Space, Command.ToggleChecked);
 			this.tableView.MouseClick += OnTableViewMouseClick;
+			tableView.Style.InvertSelectedCellFirstCharacter = true;
 			Style.TableStyle = tableView.Style;
 
 			var nameStyle = Style.TableStyle.GetOrCreateColumnStyle (0);


### PR DESCRIPTION
Cursor is no longer showing/blinking for TableView.  This makes it impossible to see what cell is selected when FullRowSelect is turned on.  Fortunately there is a setting for this situation `InvertSelectedCellFirstCharacter`.

This PR turns it on for `FileDialog`.  This makes things clearer when dialog is small and horizontal scrolling becomes a factor in the file details table view.

![small-file-dialog](https://github.com/gui-cs/Terminal.Gui/assets/31306100/6155ae45-91b0-44c3-aa67-b167fdfe15ab)


Fixes #_____ - Include a terse summary of the change or which issue is fixed.

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
