### PR TITLE
Fixes #2904. v2 InvokeKeybindings called twice when running in Dialog.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -627,7 +627,7 @@ internal class CursesDriver : ConsoleDriver {
 			return true;
 		});
 
-		_mainLoop.WinChanged += ProcessInput;
+		_mainLoop.WinChanged = ProcessInput;
 	}
 
 	public override void Init (Action terminalResized)

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -861,9 +861,9 @@ internal class WindowsDriver : ConsoleDriver {
 		_mouseHandler = mouseHandler;
 
 		_mainLoop = mainLoop.MainLoopDriver as WindowsMainLoop;
-		_mainLoop.ProcessInput += ProcessInput;
+		_mainLoop.ProcessInput = ProcessInput;
 #if HACK_CHECK_WINCHANGED
-		_mainLoop.WinChanged += ChangeWin;
+		_mainLoop.WinChanged = ChangeWin;
 #endif
 	}
 


### PR DESCRIPTION
Fixes #2904 - Avoid use incremental subscription on `Action` declarations.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
