### PR TITLE
Fixes #2474. PushMockKeyPress/ReadKey requires extra keypress to work (sometimes).

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -353,7 +353,7 @@ public class FakeDriver : ConsoleDriver {
 		_keyUpHandler = keyUpHandler;
 
 		// Note: Net doesn't support keydown/up events and thus any passed keyDown/UpHandlers will never be called
-		(mainLoop.MainLoopDriver as FakeMainLoop).KeyPressed += (consoleKey) => ProcessInput (consoleKey);
+		(mainLoop.MainLoopDriver as FakeMainLoop).KeyPressed = (consoleKey) => ProcessInput (consoleKey);
 	}
 
 	void ProcessInput (ConsoleKeyInfo consoleKey)

--- a/UnitTests/UICatalog/ScenarioTests.cs
+++ b/UnitTests/UICatalog/ScenarioTests.cs
@@ -74,16 +74,17 @@ namespace UICatalog.Tests {
 					// BUGBUG: (#2474) For some reason ReadKey is not returning the QuitKey for some Scenarios
 					// by adding this Space it seems to work.
 					// See #2474 for why this is commented out
-					//Assert.Equal (Application.QuitKey, args.KeyEvent.Key);
-					args.Handled = false;
+					Assert.Equal (Application.QuitKey, args.KeyEvent.Key);
 				};
 
 				uint abortTime = 500;
 				// If the scenario doesn't close within 500ms, this will force it to quit
 				Func<MainLoop, bool> forceCloseCallback = (MainLoop loop) => {
-					Application.RequestStop ();
-					// See #2474 for why this is commented out
-					//Assert.Fail ($"'{scenario.GetName ()}' failed to Quit with {Application.QuitKey} after {abortTime}ms. Force quit.");
+					if (Application.Top.Running && FakeConsole.MockKeyPresses.Count == 0) {
+						Application.RequestStop ();
+						// See #2474 for why this is commented out
+						Assert.Fail ($"'{scenario.GetName ()}' failed to Quit with {Application.QuitKey} after {abortTime}ms. Force quit.");
+					}
 					return false;
 				};
 				//output.WriteLine ($"  Add timeout to force quit after {abortTime}ms");
@@ -91,9 +92,9 @@ namespace UICatalog.Tests {
 
 				Application.Iteration += () => {
 					//output.WriteLine ($"  iteration {++iterations}");
-					if (FakeConsole.MockKeyPresses.Count == 0) {
+					if (Application.Top.Running && FakeConsole.MockKeyPresses.Count == 0) {
 						Application.RequestStop ();
-						//Assert.Fail ($"'{scenario.GetName ()}' failed to Quit with {Application.QuitKey}. Force quit.");
+						Assert.Fail ($"'{scenario.GetName ()}' failed to Quit with {Application.QuitKey}. Force quit.");
 					}
 				};
 


### PR DESCRIPTION
Fixes #2474 - It's need to check if `Application.Top.Running` is `true` and `FakeConsole.MockKeyPresses.Count == 0` before throw a fail test. Also avoid to use incremental subscription to an `Action`, unless is absolutely necessary on instances.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
