### PR TITLE
fix issue #2913

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -2934,6 +2934,10 @@ namespace Terminal.Gui {
 		/// <inheritdoc/>
 		protected override void Dispose (bool disposing)
 		{
+			height = null;
+			width = null;
+			x = null;
+			y = null;
 			for (var i = InternalSubviews.Count - 1; i >= 0; i--) {
 				var subview = InternalSubviews [i];
 				Remove (subview);


### PR DESCRIPTION
Fixes #2913 - View.Dispose now sets x, y, height and width variables to Null before Disposing subviews

## Pull Request checklist:

- [ x ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ x ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ x ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ x ] I ran `dotnet test` before commit
- [ not needed (I changed one existing func) ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ x ] My changes generate no new warnings
- [ x ] I have checked my code and corrected any poor grammar or misspellings
- [ x ] I conducted basic QA to assure all features are working

Please also see [this other pull request](https://github.com/gui-cs/Terminal.Gui/pull/2914), wich I made to help testing this resolution.