### PR TITLE
Fixes #2930. Console.CursorLeft-- throw an exception with NetDriver on Linux (v2).

### DIFF
--- a/Terminal.Gui/Application.cs
+++ b/Terminal.Gui/Application.cs
@@ -668,9 +668,6 @@ namespace Terminal.Gui {
 				} else if (Current.SuperView == null && Current?.Modal == true) {
 					Refresh ();
 				}
-				if (Driver.EnsureCursorVisibility ()) {
-					state.Toplevel.SetNeedsDisplay ();
-				}
 			}
 
 			firstIteration = false;

--- a/Terminal.Gui/Application.cs
+++ b/Terminal.Gui/Application.cs
@@ -480,7 +480,7 @@ namespace Terminal.Gui {
 #endif
 				resume = false;
 				var runState = Begin (view);
-				// If ExitRunLoopAfterFirstIteration is true then the user must dispose of the runToken
+				// If EndAfterFirstIteration is true then the user must dispose of the runToken
 				// by using NotifyStopRunState event.
 				RunLoop (runState);
 				if (!EndAfterFirstIteration) {

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -173,7 +173,7 @@ public static class EscSeqUtils {
 	/// <param name="x"></param>
 	/// <param name="y"></param>
 	/// <returns></returns>
-	public static string CSI_SetCursorPosition (int x, int y) => $"{CSI}{y};{x}H";
+	public static string CSI_SetCursorPosition (int y, int x) => $"{CSI}{y};{x}H";
 
 
 	//ESC [ <y> ; <x> f - HVP     Horizontal Vertical Position* Cursor moves to<x>; <y> coordinate within the viewport, where <x> is the column of the<y> line

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -812,7 +812,7 @@ internal class NetDriver : ConsoleDriver {
 					output.Append (rune.ToString ());
 					if (rune.IsSurrogatePair () && rune.GetColumns () < 2) {
 						WriteToConsole (output, ref lastCol, row, ref outputWidth);
-						Console.CursorLeft--;
+						SetCursorPosition (row, col - 1);
 					}
 					Contents [row, col].IsDirty = false;
 				}
@@ -888,20 +888,20 @@ internal class NetDriver : ConsoleDriver {
 	#region Cursor Handling
 	bool SetCursorPosition (int col, int row)
 	{
-		//if (IsWinPlatform) {
-		// Could happens that the windows is still resizing and the col is bigger than Console.WindowWidth.
-		try {
-			Console.SetCursorPosition (col, row);
+		if (IsWinPlatform) {
+			// Could happens that the windows is still resizing and the col is bigger than Console.WindowWidth.
+			try {
+				Console.SetCursorPosition (col, row);
+				return true;
+			} catch (Exception) {
+				return false;
+			}
+		} else {
+			// + 1 is needed because non-Windows is based on 1 instead of 0 and
+			// Console.CursorTop/CursorLeft isn't reliable.
+			Console.Out.Write (EscSeqUtils.CSI_SetCursorPosition (row + 1, col + 1));
 			return true;
-		} catch (Exception) {
-			return false;
 		}
-		// BUGBUG: This breaks -usc on WSL; not sure why. But commenting out fixes.
-		//} else {
-		//	// TODO: Explain why + 1 is needed (and why we do this for non-Windows).
-		//	Console.Out.Write (EscSeqUtils.CSI_SetCursorPosition (row + 1, col + 1));
-		//	return true;
-		//}
 	}
 
 	CursorVisibility? _cachedCursorVisibility;

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -759,8 +759,8 @@ internal class NetDriver : ConsoleDriver {
 		Attribute redrawAttr = new Attribute ();
 		var lastCol = -1;
 
-		//GetCursorVisibility (out CursorVisibility savedVisibitity);
-		//SetCursorVisibility (CursorVisibility.Invisible); 
+		GetCursorVisibility (out CursorVisibility savedVisibitity);
+		SetCursorVisibility (CursorVisibility.Invisible);
 
 		for (var row = top; row < rows; row++) {
 			if (Console.WindowHeight < 1) {
@@ -824,7 +824,7 @@ internal class NetDriver : ConsoleDriver {
 		}
 		SetCursorPosition (0, 0);
 
-		//SetCursorVisibility (savedVisibitity);
+		SetCursorVisibility (savedVisibitity);
 
 		void WriteToConsole (StringBuilder output, ref int lastCol, int row, ref int outputWidth)
 		{
@@ -926,7 +926,7 @@ internal class NetDriver : ConsoleDriver {
 	{
 		_cachedCursorVisibility = visibility;
 		var isVisible = RunningUnitTests ? visibility == CursorVisibility.Default : Console.CursorVisible = visibility == CursorVisibility.Default;
-		//Console.Out.Write (isVisible ? EscSeqUtils.CSI_ShowCursor : EscSeqUtils.CSI_HideCursor);
+		Console.Out.Write (isVisible ? EscSeqUtils.CSI_ShowCursor : EscSeqUtils.CSI_HideCursor);
 		return isVisible;
 	}
 

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -812,7 +812,7 @@ internal class NetDriver : ConsoleDriver {
 					output.Append (rune.ToString ());
 					if (rune.IsSurrogatePair () && rune.GetColumns () < 2) {
 						WriteToConsole (output, ref lastCol, row, ref outputWidth);
-						SetCursorPosition (row, col - 1);
+						SetCursorPosition (col - 1, row);
 					}
 					Contents [row, col].IsDirty = false;
 				}

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -759,7 +759,7 @@ internal class NetDriver : ConsoleDriver {
 		Attribute redrawAttr = new Attribute ();
 		var lastCol = -1;
 
-		GetCursorVisibility (out CursorVisibility savedVisibitity);
+		var savedVisibitity = _cachedCursorVisibility;
 		SetCursorVisibility (CursorVisibility.Invisible);
 
 		for (var row = top; row < rows; row++) {
@@ -824,7 +824,7 @@ internal class NetDriver : ConsoleDriver {
 		}
 		SetCursorPosition (0, 0);
 
-		SetCursorVisibility (savedVisibitity);
+		_cachedCursorVisibility = savedVisibitity;
 
 		void WriteToConsole (StringBuilder output, ref int lastCol, int row, ref int outputWidth)
 		{


### PR DESCRIPTION
Fixes #2930 - Linux doesn't support `Console.CursorTop` and `Console.CursorLeft` and that why the Ansi escape sequences is used for. The problem with the `CSI_SetCursorPosition` was that the parameters are inverted and thus was disabled.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
