### PR TITLE
Fixes #2944. TreeView ColorGetter not disposing sometimes causes unit test error.

### DIFF
--- a/Terminal.Gui/Views/TreeView/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView/TreeView.cs
@@ -1433,6 +1433,13 @@ namespace Terminal.Gui {
 			DrawLine?.Invoke (this, e);
 		}
 
+		/// <inheritdoc/>
+		protected override void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+
+			ColorGetter = null;
+		}
 	}
 	class TreeSelection<T> where T : class {
 


### PR DESCRIPTION
Fixes #2944 - `ColorGetter` wasn't disposing and thus sometimes causing an older handler to be processed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
