### PR TITLE
Fixes #2943. Default button bracket glyphs don't work on conhost.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1545,19 +1545,15 @@ internal class WindowsDriver : ConsoleDriver {
 				}
 				_outputBuffer [position].Empty = false;
 				if (Contents [row, col].Rune.IsBmp) {
-					var rune = Contents[row, col].Rune;
-					if (Force16Colors)
-					{
-                        if (rune == Glyphs.LeftBracket)
-                        {
+					var rune = Contents [row, col].Rune;
+					if (Force16Colors) {
+						if (rune == Glyphs.LeftBracket) {
 							rune = (Rune)'[';
-						}
-						else if (rune == Glyphs.RightBracket)
-						{
+						} else if (rune == Glyphs.RightBracket) {
 							rune = (Rune)']';
 						}
-                    }
-                    _outputBuffer [position].Char = (char)rune.Value;
+					}
+					_outputBuffer [position].Char = (char)rune.Value;
 				} else {
 					//_outputBuffer [position].Empty = true;
 					_outputBuffer [position].Char = (char)Rune.ReplacementChar.Value;

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1545,7 +1545,19 @@ internal class WindowsDriver : ConsoleDriver {
 				}
 				_outputBuffer [position].Empty = false;
 				if (Contents [row, col].Rune.IsBmp) {
-					_outputBuffer [position].Char = (char)Contents [row, col].Rune.Value;
+					var rune = Contents[row, col].Rune;
+					if (Force16Colors)
+					{
+                        if (rune == Glyphs.LeftBracket)
+                        {
+							rune = (Rune)'[';
+						}
+						else if (rune == Glyphs.RightBracket)
+						{
+							rune = (Rune)']';
+						}
+                    }
+                    _outputBuffer [position].Char = (char)rune.Value;
 				} else {
 					//_outputBuffer [position].Empty = true;
 					_outputBuffer [position].Char = (char)Rune.ReplacementChar.Value;


### PR DESCRIPTION
Fixes #2943 - Force to `[` and `]` on `WindowsDriver` if `Force16Colors` is true.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
