### PR TITLE
Fixes #2892 for v1 - Null reference pressing menu shortcuts when menus have separators

### DIFF
--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -1677,6 +1677,11 @@ namespace Terminal.Gui {
 			var c = ((uint)kb.Key & (uint)Key.CharMask);
 			for (int i = 0; i < children.Length; i++) {
 				var mi = children [i];
+
+				if (mi == null) {
+					continue;
+				}
+
 				int p = mi.Title.IndexOf (MenuBar.HotKeySpecifier);
 				if (p != -1 && p + 1 < mi.Title.RuneCount) {
 					if (Char.ToUpperInvariant ((char)mi.Title [p + 1]) == c) {

--- a/UnitTests/Menus/MenuTests.cs
+++ b/UnitTests/Menus/MenuTests.cs
@@ -1809,5 +1809,20 @@ Edit
 			Assert.True (menu.ProcessHotKey (new KeyEvent (menu.Key, new KeyModifiers ())));
 			Assert.False (menu.IsMenuOpen);
 		}
+
+		[Fact]
+		public void Separators_Does_Not_Throws_Pressing_Menu_Shortcut ()
+		{
+			var menu = new MenuBar (new MenuBarItem [] {
+				new MenuBarItem ("File", new MenuItem [] {
+					new MenuItem ("_New", "", null),
+					null,
+					new MenuItem ("_Quit", "", null)
+				})
+			});
+
+			var exception = Record.Exception (() => Assert.True (menu.ProcessHotKey (new KeyEvent (Key.AltMask | Key.Q, new KeyModifiers () { Alt = true }))));
+			Assert.Null (exception);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2892 for v1 - Fix null reference when pressing menu shortcuts when menus have separators.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
