### PR TITLE
Add unit test for the #2892 fix.

### DIFF
--- a/UnitTests/Views/MenuTests.cs
+++ b/UnitTests/Views/MenuTests.cs
@@ -2758,5 +2758,20 @@ wo
 			Assert.True (menu.ProcessHotKey (new KeyEvent (menu.Key, new KeyModifiers ())));
 			Assert.False (menu.IsMenuOpen);
 		}
+
+		[Fact]
+		public void Separators_Does_Not_Throws_Pressing_Menu_Shortcut ()
+		{
+			var menu = new MenuBar (new MenuBarItem [] {
+				new MenuBarItem ("File", new MenuItem [] {
+					new MenuItem ("_New", "", null),
+					null,
+					new MenuItem ("_Quit", "", null)
+				})
+			});
+
+			var exception = Record.Exception (() => Assert.True (menu.ProcessHotKey (new KeyEvent (Key.AltMask | Key.Q, new KeyModifiers () { Alt = true }))));
+			Assert.Null (exception);
+		}
 	}
 }


### PR DESCRIPTION
Add unit test for the #2892 in v2 - Fix null reference when pressing menu shortcuts when menus have separators.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
