### PR TITLE
Fixes #2954. Modal view is always refreshing only by moving the mouse.

### DIFF
--- a/Terminal.Gui/Application.cs
+++ b/Terminal.Gui/Application.cs
@@ -665,8 +665,6 @@ namespace Terminal.Gui {
 					OverlappedTop?.OnActivate (state.Toplevel);
 					Top.SetSubViewNeedsDisplay ();
 					Refresh ();
-				} else if (Current.SuperView == null && Current?.Modal == true) {
-					Refresh ();
 				}
 			}
 
@@ -690,7 +688,7 @@ namespace Terminal.Gui {
 				&& (Driver.Cols != state.Toplevel.Frame.Width || Driver.Rows != state.Toplevel.Frame.Height)
 				&& (state.Toplevel.NeedsDisplay || state.Toplevel.SubViewNeedsDisplay || state.Toplevel.LayoutNeeded)) {
 
-				state.Toplevel.Clear ();
+				state.Toplevel.Clear (new Rect (Point.Empty, new Size (Driver.Cols, Driver.Rows)));
 			}
 
 			if (state.Toplevel.NeedsDisplay ||

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -1,10 +1,11 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 // Alias Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
@@ -12,8 +13,11 @@ using Console = Terminal.Gui.FakeConsole;
 namespace Terminal.Gui.ApplicationTests;
 
 public class ApplicationTests {
-	public ApplicationTests ()
+	readonly ITestOutputHelper output;
+
+	public ApplicationTests (ITestOutputHelper output)
 	{
+		this.output = output;
 #if DEBUG_IDISPOSABLE
 		Responder.Instances.Clear ();
 		RunState.Instances.Clear ();
@@ -414,6 +418,107 @@ public class ApplicationTests {
 		Application.Run ();
 		Application.Shutdown ();
 		Assert.Equal (3, count);
+	}
+
+	[Fact]
+	public void Run_Toplevel_With_Modal_View_Does_Not_Refresh_If_Not_Dirty ()
+	{
+		Init ();
+		var count = 0;
+		Dialog d = null;
+		var top = Application.Top;
+		top.DrawContent += (s, a) => count++;
+		var iteration = -1;
+		Application.Iteration += (s, a) => {
+			iteration++;
+			if (iteration == 0) {
+				d = new Dialog ();
+				d.DrawContent += (s, a) => count++;
+				Application.Run (d);
+			} else if (iteration < 3) {
+				Application.OnMouseEvent (new (new () { X = 0, Y = 0, Flags = MouseFlags.ReportMousePosition }));
+				Assert.False (top.NeedsDisplay);
+				Assert.False (top.SubViewNeedsDisplay);
+				Assert.False (top.LayoutNeeded);
+				Assert.False (d.NeedsDisplay);
+				Assert.False (d.SubViewNeedsDisplay);
+				Assert.False (d.LayoutNeeded);
+			} else {
+				Application.RequestStop ();
+			}
+		};
+		Application.Run ();
+		Application.Shutdown ();
+		// 1 - First top load, 1 - Dialog load, 1 - Dialog unload, Total - 3.
+		Assert.Equal (3, count);
+	}
+
+	[Fact]
+	public void Run_A_Modal_Toplevel_Refresh_Background_On_Moving ()
+	{
+		Init ();
+		var d = new Dialog () { Width = 5, Height = 5 };
+		((FakeDriver)Application.Driver).SetBufferSize (10, 10);
+		var rs = Application.Begin (d);
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
+  ┌───┐
+  │   │
+  │   │
+  │   │
+  └───┘", output);
+
+		var attributes = new Attribute [] {
+			// 0
+			new Attribute (ColorName.White, ColorName.Black),
+			// 1
+			Colors.Dialog.Normal
+		};
+		TestHelpers.AssertDriverColorsAre (@"
+0000000000
+0000000000
+0011111000
+0011111000
+0011111000
+0011111000
+0011111000
+0000000000
+0000000000
+0000000000
+", null, attributes);
+
+		Application.OnMouseEvent (new MouseEventEventArgs (new MouseEvent () { X = 2, Y = 2, Flags = MouseFlags.Button1Pressed }));
+		Assert.Equal (d, Application.MouseGrabView);
+
+		Application.OnMouseEvent (new MouseEventEventArgs (new MouseEvent () { X = 1, Y = 1, Flags = MouseFlags.Button1Pressed | MouseFlags.ReportMousePosition }));
+		Application.Refresh ();
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
+ ┌───┐
+ │   │
+ │   │
+ │   │
+ └───┘", output);
+
+		attributes = new Attribute [] {
+			// 0
+			new Attribute (ColorName.White, ColorName.Black),
+			// 1
+			Colors.Dialog.Normal
+		};
+		TestHelpers.AssertDriverColorsAre (@"
+0000000000
+0111110000
+0111110000
+0111110000
+0111110000
+0111110000
+0000000000
+0000000000
+0000000000
+0000000000
+", null, attributes);
+
+		Application.End (rs);
+		Application.Shutdown ();
 	}
 
 	// TODO: Add tests for Run that test errorHandler


### PR DESCRIPTION
Fixes #2954 - The current and unique modal toplevel must clear all the terminal size and not only itself if it's dirty.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
