### PR TITLE
Fixes #2961. v2 - WindowsDriver isn't render well on conhost terminal size.

### DIFF
--- a/UICatalog/Properties/launchSettings.json
+++ b/UICatalog/Properties/launchSettings.json
@@ -1,10 +1,13 @@
 {
   "profiles": {
-    "UICatalog": {
+    "UICatalog WT": {
       "commandName": "Project",
       "environmentVariables": {
         "WT_SESSION": "yes"
       }
+    },
+    "UICatalog CH": {
+      "commandName": "Project"
     },
     "WSL : UICatalog": {
       "commandName": "Executable",


### PR DESCRIPTION
Fixes #2961 - Two profile setting are needed for `WindowsDriver`, one for `Windows Terminal` (`WT`) and other for `conhost` (`CH`).

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

https://github.com/gui-cs/Terminal.Gui/assets/13117724/4ef03a9e-0cef-434b-ab38-9b5d4f76bc48

