### PR TITLE
Fixes #2967. V2 - Not all views are removing his subviews upon disposing

### DIFF
--- a/Terminal.Gui/View/View.cs
+++ b/Terminal.Gui/View/View.cs
@@ -495,7 +495,7 @@ namespace Terminal.Gui {
 		protected override void Dispose (bool disposing)
 		{
 			LineCanvas.Dispose ();
-			
+
 			Margin?.Dispose ();
 			Margin = null;
 			Border?.Dispose ();
@@ -513,8 +513,9 @@ namespace Terminal.Gui {
 				Remove (subview);
 				subview.Dispose ();
 			}
-			
+
 			base.Dispose (disposing);
+			System.Diagnostics.Debug.Assert (InternalSubviews.Count == 0);
 		}
 	}
 }

--- a/Terminal.Gui/Views/Wizard/WizardStep.cs
+++ b/Terminal.Gui/Views/Wizard/WizardStep.cs
@@ -1,4 +1,4 @@
-﻿namespace Terminal.Gui; 
+﻿namespace Terminal.Gui;
 
 /// <summary>
 /// Represents a basic step that is displayed in a <see cref="Wizard"/>. The <see cref="WizardStep"/> view is divided horizontally in two. On the left is the
@@ -39,7 +39,7 @@ public class WizardStep : FrameView {
 	//private string title = string.Empty;
 
 	// The contentView works like the ContentView in FrameView.
-	private View contentView = new View () { Data = "WizardContentView" };
+	private View contentView = new View () { Id = "WizardContentView" };
 
 	/// <summary>
 	/// Sets or gets help text for the <see cref="WizardStep"/>.If <see cref="WizardStep.HelpText"/> is empty
@@ -185,8 +185,12 @@ public class WizardStep : FrameView {
 		}
 
 		SetNeedsDisplay ();
-		var touched = view.Frame;
-		contentView.Remove (view);
+		var container = view?.SuperView;
+		if (container == this) {
+			base.Remove (view);
+		} else {
+			container?.Remove (view);
+		}
 
 		if (contentView.InternalSubviews.Count < 1) {
 			this.CanFocus = false;


### PR DESCRIPTION
Fixes #2967 for v2 - The correct container wasn't being called to remove the subview.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
