### PR TITLE
Fixes #2967. Not all views are removing his subviews upon disposing on both versions.

### DIFF
--- a/Terminal.Gui/Core/Border.cs
+++ b/Terminal.Gui/Core/Border.cs
@@ -234,7 +234,11 @@ namespace Terminal.Gui {
 
 				SetNeedsDisplay ();
 				var touched = view.Frame;
-				Border.Child.Remove (view);
+				if (view == Border.Child) {
+					base.Remove (view);
+				} else {
+					Border.Child.Remove (view);
+				}
 
 				if (Border.Child.InternalSubviews.Count < 1) {
 					CanFocus = false;

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 using NStack;
 
 namespace Terminal.Gui {
@@ -2944,6 +2943,7 @@ namespace Terminal.Gui {
 				subview.Dispose ();
 			}
 			base.Dispose (disposing);
+			System.Diagnostics.Debug.Assert (InternalSubviews.Count == 0);
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Core/Window.cs
+++ b/Terminal.Gui/Core/Window.cs
@@ -10,7 +10,6 @@
 // Any udpates done here should probably be done in FrameView as well; TODO: Merge these classes
 
 using System;
-using System.Collections;
 using System.Linq;
 using NStack;
 
@@ -271,7 +270,11 @@ namespace Terminal.Gui {
 			}
 
 			SetNeedsDisplay ();
-			contentView.Remove (view);
+			if (view == contentView) {
+				base.Remove (view);
+			} else {
+				contentView.Remove (view);
+			}
 
 			RemoveMenuStatusBar (view);
 			if (view != contentView && Focused == null) {

--- a/Terminal.Gui/Views/FrameView.cs
+++ b/Terminal.Gui/Views/FrameView.cs
@@ -9,7 +9,6 @@
 //  - Does not support IEnumerable
 // Any udpates done here should probably be done in Window as well; TODO: Merge these classes
 
-using System;
 using System.Linq;
 using NStack;
 
@@ -202,7 +201,11 @@ namespace Terminal.Gui {
 
 			SetNeedsDisplay ();
 			var touched = view.Frame;
-			contentView.Remove (view);
+			if (view == contentView) {
+				base.Remove (view);
+			} else {
+				contentView.Remove (view);
+			}
 
 			if (contentView.InternalSubviews.Count < 1)
 				this.CanFocus = false;

--- a/Terminal.Gui/Windows/Wizard.cs
+++ b/Terminal.Gui/Windows/Wizard.cs
@@ -316,7 +316,11 @@ namespace Terminal.Gui {
 
 				SetNeedsDisplay ();
 				var touched = view.Frame;
-				contentView.Remove (view);
+				if (view == contentView || view.GetType().Name == "ContentView") {
+					base.Remove (view);
+				} else {
+					contentView.Remove (view);
+				}
 
 				if (contentView.InternalSubviews.Count < 1)
 					this.CanFocus = false;


### PR DESCRIPTION
Fixes #2967 for v1 - The correct container wasn't being called to remove the subview.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
