### PR TITLE
Fixes #2970. ScrollView doesn't remove a view that was previously added on both versions.

### DIFF
--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -237,6 +237,39 @@ namespace Terminal.Gui {
 			SetNeedsLayout ();
 		}
 
+		/// <summary>
+		/// Removes the view from the scrollview.
+		/// </summary>
+		/// <param name="view">The view to remove from the scrollview.</param>
+		public override void Remove (View view)
+		{
+			if (view == null) {
+				return;
+			}
+
+			SetNeedsDisplay ();
+			var container = view?.SuperView;
+			if (container == this) {
+				base.Remove (view);
+			} else {
+				container?.Remove (view);
+			}
+
+			if (contentView.InternalSubviews.Count < 1) {
+				this.CanFocus = false;
+			}
+		}
+
+		/// <summary>
+		///   Removes all widgets from this container.
+		/// </summary>
+		/// <remarks>
+		/// </remarks>
+		public override void RemoveAll ()
+		{
+			contentView.RemoveAll ();
+		}
+
 		void View_MouseLeave (MouseEventArgs e)
 		{
 			if (Application.MouseGrabView != null && Application.MouseGrabView != vertical && Application.MouseGrabView != horizontal) {
@@ -278,16 +311,6 @@ namespace Terminal.Gui {
 				}
 				vertical.Height = Dim.Fill (showHorizontalScrollIndicator ? 1 : 0);
 			}
-		}
-
-		/// <summary>
-		///   Removes all widgets from this container.
-		/// </summary>
-		/// <remarks>
-		/// </remarks>
-		public override void RemoveAll ()
-		{
-			contentView.RemoveAll ();
 		}
 
 		/// <summary>

--- a/UnitTests/Views/ScrollViewTests.cs
+++ b/UnitTests/Views/ScrollViewTests.cs
@@ -498,5 +498,28 @@ namespace Terminal.Gui.ViewTests {
 00000000000000000000000
 00000000000000000000000", attributes);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void Remove_Added_View_Is_Allowed ()
+		{
+			var sv = new ScrollView () {
+				Width = 20,
+				Height = 20,
+				ContentSize = new Size (100, 100)
+			};
+			sv.Add (new View () { Width = Dim.Fill (), Height = Dim.Fill (50), Id = "View1" },
+				new View () { Y = 51, Width = Dim.Fill (), Height = Dim.Fill (), Id = "View2" });
+
+			Application.Top.Add (sv);
+			Application.Begin (Application.Top);
+
+			Assert.Equal (3, sv.Subviews.Count);
+			Assert.Equal (2, sv.Subviews [0].Subviews.Count);
+
+			sv.Remove (sv.Subviews [0].Subviews [1]);
+			Assert.Equal (3, sv.Subviews.Count);
+			Assert.Single (sv.Subviews [0].Subviews);
+			Assert.Equal ("View1", sv.Subviews [0].Subviews [0].Id);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2970  for v1 - The `Remove` method wasn't override.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
