### PR TITLE
Fixes #2983. View need a alternative DrawFrame for the v2.

### DIFF
--- a/Terminal.Gui/View/ViewDrawing.cs
+++ b/Terminal.Gui/View/ViewDrawing.cs
@@ -503,5 +503,25 @@ namespace Terminal.Gui {
 			DrawContentComplete?.Invoke (this, new DrawEventArgs (contentArea));
 		}
 
+		/// <summary>
+		/// Draw a frame based on the passed bounds to the screen relative.
+		/// </summary>
+		/// <param name="bounds">The bounds view relative.</param>
+		/// <param name="lineStyle">The line style.</param>
+		/// <param name="attribute">The color to use.</param>
+		public void DrawFrame (Rect bounds, LineStyle lineStyle, Attribute? attribute = null)
+		{
+			var vts = ViewToScreen (bounds);
+			LineCanvas.AddLine (new Point (vts.X, vts.Y), vts.Width,
+				Orientation.Horizontal, lineStyle, attribute);
+			LineCanvas.AddLine (new Point (vts.Right - 1, vts.Y), vts.Height,
+				Orientation.Vertical, lineStyle, attribute);
+			LineCanvas.AddLine (new Point (vts.X, vts.Bottom - 1), vts.Width,
+				Orientation.Horizontal, lineStyle, attribute);
+			LineCanvas.AddLine (new Point (vts.X, vts.Y), vts.Height,
+				Orientation.Vertical, lineStyle, attribute);
+
+			OnRenderLineCanvas ();
+		}
 	}
 }

--- a/UnitTests/View/DrawTests.cs
+++ b/UnitTests/View/DrawTests.cs
@@ -334,6 +334,23 @@ t     ", output);
 			Application.Refresh ();
 			TestHelpers.AssertDriverContentsWithFrameAre ("", output);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void DrawFrame_Test ()
+		{
+			var label = new View () { X = Pos.Center (), Y = Pos.Center (), Text = "test", AutoSize = true };
+			var view = new View () { Width = 10, Height = 5 };
+			view.DrawContentComplete += (s, e) => view.DrawFrame (view.Bounds, LineStyle.Single);
+			view.Add (label);
+			Application.Top.Add (view);
+			Application.Begin (Application.Top);
+
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+┌────────┐
+│        │
+│  test  │
+│        │
+└────────┘", output);
+		}
 	}
 }
-


### PR DESCRIPTION
Fixes #2983 - Use `LineCanvas` to draw the frame and supersede the obsolete method.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
