### PR TITLE
Fixes #2985. Application.RunState must be responsible for dispose the Toplevel property.

### DIFF
--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -86,7 +86,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		public static Toplevel MdiTop {
 			get {
-				if (Top.IsMdiContainer) {
+				if (Top?.IsMdiContainer == true) {
 					return Top;
 				}
 				return null;
@@ -516,11 +516,8 @@ namespace Terminal.Gui {
 			protected virtual void Dispose (bool disposing)
 			{
 				if (Toplevel != null && disposing) {
-					throw new InvalidOperationException ("You must clean up (Dispose) the Toplevel before calling Application.RunState.Dispose");
-					// BUGBUG: It's insidious that we call EndFirstTopLevel here so I moved it to End.
-					//EndFirstTopLevel (Toplevel);
-					//Toplevel.Dispose ();
-					//Toplevel = null;
+					Toplevel.Dispose ();
+					Toplevel = null;
 				}
 			}
 		}
@@ -1062,6 +1059,7 @@ namespace Terminal.Gui {
 			// Set Current and Top to the next TopLevel on the stack
 			if (toplevels.Count == 0) {
 				Current = null;
+				Top = null;
 			} else {
 				Current = toplevels.Peek ();
 				if (toplevels.Count == 1 && Current == MdiTop) {
@@ -1074,8 +1072,6 @@ namespace Terminal.Gui {
 				Refresh ();
 			}
 
-			runState.Toplevel?.Dispose ();
-			runState.Toplevel = null;
 			runState.Dispose ();
 		}
 

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1441,8 +1441,10 @@ namespace Terminal.Gui {
 		{
 			Autocomplete.HostControl = this;
 
-			Application.Top.AlternateForwardKeyChanged += Top_AlternateForwardKeyChanged;
-			Application.Top.AlternateBackwardKeyChanged += Top_AlternateBackwardKeyChanged;
+			if (Application.Top != null) {
+				Application.Top.AlternateForwardKeyChanged += Top_AlternateForwardKeyChanged;
+				Application.Top.AlternateBackwardKeyChanged += Top_AlternateBackwardKeyChanged;
+			}
 			OnContentsChanged ();
 		}
 

--- a/UICatalog/Scenarios/SingleBackgroundWorker.cs
+++ b/UICatalog/Scenarios/SingleBackgroundWorker.cs
@@ -15,7 +15,7 @@ namespace UICatalog.Scenarios {
 
 			Application.Run<MainApp> ();
 
-			Application.Top.Dispose ();
+			System.Diagnostics.Debug.Assert (Application.Top == null);
 		}
 
 		public class MainApp : Toplevel {

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -159,13 +159,12 @@ namespace Terminal.Gui.ApplicationTests {
 			Application.End (runstate);
 
 			Assert.Null (Application.Current);
-			Assert.NotNull (Application.Top);
+			Assert.Null (Application.Top);
 			Assert.NotNull (Application.MainLoop);
 			Assert.NotNull (Application.Driver);
 
 			Shutdown ();
 
-			Assert.Null (Application.Top);
 			Assert.Null (Application.MainLoop);
 			Assert.Null (Application.Driver);
 		}
@@ -203,13 +202,12 @@ namespace Terminal.Gui.ApplicationTests {
 			Application.End (runstate);
 
 			Assert.Null (Application.Current);
-			Assert.NotNull (Application.Top);
+			Assert.Null (Application.Top);
 			Assert.NotNull (Application.MainLoop);
 			Assert.NotNull (Application.Driver);
 
 			Shutdown ();
 
-			Assert.Null (Application.Top);
 			Assert.Null (Application.MainLoop);
 			Assert.Null (Application.Driver);
 		}
@@ -529,7 +527,10 @@ namespace Terminal.Gui.ApplicationTests {
 
 			Application.Run (t1);
 
-			Assert.Equal (t1, Application.Top);
+			Assert.Null (Application.Top);
+#if DEBUG_IDISPOSABLE
+			Assert.True (t1.WasDisposed);
+#endif
 		}
 
 		[Fact]

--- a/UnitTests/Views/ButtonTests.cs
+++ b/UnitTests/Views/ButtonTests.cs
@@ -16,8 +16,9 @@ namespace Terminal.Gui.ViewTests {
 		{
 			var btn = new Button ();
 			Assert.Equal (string.Empty, btn.Text);
-			Application.Top.Add (btn);
-			var rs = Application.Begin (Application.Top);
+			var top = Application.Top;
+			top.Add (btn);
+			var rs = Application.Begin (top);
 
 			Assert.Equal ("[  ]", btn.TextFormatter.Text);
 			Assert.False (btn.IsDefault);
@@ -34,8 +35,8 @@ namespace Terminal.Gui.ViewTests {
 			Application.End (rs);
 			btn = new Button ("ARGS", true) { Text = "Test" };
 			Assert.Equal ("Test", btn.Text);
-			Application.Top.Add (btn);
-			rs = Application.Begin (Application.Top);
+			top.Add (btn);
+			rs = Application.Begin (top);
 
 			Assert.Equal ("[◦ Test ◦]", btn.TextFormatter.Text);
 			Assert.True (btn.IsDefault);
@@ -52,8 +53,8 @@ namespace Terminal.Gui.ViewTests {
 			Application.End (rs);
 			btn = new Button (3, 4, "Test", true);
 			Assert.Equal ("Test", btn.Text);
-			Application.Top.Add (btn);
-			rs = Application.Begin (Application.Top);
+			top.Add (btn);
+			rs = Application.Begin (top);
 
 			Assert.Equal ("[◦ Test ◦]", btn.TextFormatter.Text);
 			Assert.True (btn.IsDefault);


### PR DESCRIPTION
Fixes #2985 - `Application.Top` can be null as the `Application.Current` if the toplevels stack is empty. Thus avoids call `Application.Shutdown` method to set `Application.Top` to null.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
