### PR TITLE
Fixes #2987. Set a MdiChild visible to false still processes keystrokes.

### DIFF
--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -531,7 +531,7 @@ namespace Terminal.Gui {
 				return;
 			}
 
-			var chain = toplevels.ToList ();
+			var chain = toplevels.Where (t => t.Visible).ToList ();
 			foreach (var topLevel in chain) {
 				if (topLevel.ProcessHotKey (ke)) {
 					EnsuresMdiTopOnFrontIfMdiTopMostFocused ();


### PR DESCRIPTION
Fixes #2987 - `Application` should only propagate keystrokes for visible toplevels.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
