### PR TITLE
Line canvas exclude method

### DIFF
--- a/Terminal.Gui/Drawing/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas.cs
@@ -77,6 +77,15 @@ namespace Terminal.Gui {
 			ConfigurationManager.Applied += ConfigurationManager_Applied;
 		}
 
+		/// <summary>
+		/// Creates a new instance with the given <paramref name="lines"/>.
+		/// </summary>
+		/// <param name="lines">Initial lines for the canvas.</param>
+		public LineCanvas (IEnumerable<StraightLine> lines) : this()
+		{
+			_lines = lines.ToList();
+		}
+
 		private void ConfigurationManager_Applied (object? sender, ConfigurationManagerEventArgs e)
 		{
 			foreach (var irr in runeResolvers) {
@@ -85,6 +94,11 @@ namespace Terminal.Gui {
 		}
 
 		private List<StraightLine> _lines = new List<StraightLine> ();
+
+		/// <summary>
+		/// Gets the lines in the canvas.
+		/// </summary>
+		public IReadOnlyCollection<StraightLine> Lines { get { return _lines.AsReadOnly(); } }
 
 		Dictionary<IntersectionRuneType, IntersectionRuneResolver> runeResolvers = new Dictionary<IntersectionRuneType, IntersectionRuneResolver> {
 			{IntersectionRuneType.ULCorner,new ULIntersectionRuneResolver()},

--- a/Terminal.Gui/Drawing/StraightLine.cs
+++ b/Terminal.Gui/Drawing/StraightLine.cs
@@ -280,6 +280,7 @@ namespace Terminal.Gui {
 					// line is perpendicular to exclusion
 
 					// TODO: Cut out at most 1 cell
+					toReturn.Add (l);
 				}
 			}
 

--- a/Terminal.Gui/Drawing/StraightLine.cs
+++ b/Terminal.Gui/Drawing/StraightLine.cs
@@ -277,7 +277,7 @@ namespace Terminal.Gui {
 							if (lDiffMax > eDiffMax) {
 								// Create line up to exclusion point
 								int from = eDiffMax+1;
-								int len = lDiffMax - lDiffMax;
+								int len = lDiffMax - eDiffMax;
 
 								if(len>0) {
 									toReturn.Add (CreateLineFromDiff (l, from, len));

--- a/Terminal.Gui/View/ViewDrawing.cs
+++ b/Terminal.Gui/View/ViewDrawing.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -212,6 +213,20 @@ namespace Terminal.Gui {
 
 			return new Rect (x, y, w, h);
 		}
+
+		public IEnumerable<StraightLine> GetFrame (Rect rect, LineStyle lineStyle, Attribute? attribute = null)
+		{
+			var vts = ViewToScreen (rect);			
+			yield return new StraightLine(new Point (vts.X, vts.Y), vts.Width,
+				Orientation.Horizontal, lineStyle, attribute);
+			yield return new StraightLine (new Point (vts.Right - 1, vts.Y), vts.Height,
+				Orientation.Vertical, lineStyle, attribute);
+			yield return new StraightLine (new Point (vts.Right - 1, vts.Bottom - 1), -vts.Width,
+				Orientation.Horizontal, lineStyle, attribute);
+			yield return new StraightLine (new Point (vts.X, vts.Bottom - 1), -vts.Height,
+				Orientation.Vertical, lineStyle, attribute);
+		}
+		
 
 		/// <summary>
 		/// Expands the <see cref="ConsoleDriver"/>'s clip region to include <see cref="Bounds"/>.

--- a/UICatalog/Scenarios/LineDrawing.cs
+++ b/UICatalog/Scenarios/LineDrawing.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Terminal.Gui;
+using static Terminal.Gui.SpinnerStyle;
 
 namespace UICatalog.Scenarios {
 
@@ -76,10 +77,10 @@ namespace UICatalog.Scenarios {
 					X = 0,
 					Y = Pos.Bottom (_colorPicker)
 				};
-
 				_stylePicker.SelectedItemChanged += (s, a) => {
 					SetStyle?.Invoke ((LineStyle)a.SelectedItem);
 				};
+				_stylePicker.SelectedItem = 1;
 
 				_addLayerBtn = new Button () {
 					Text = "New Layer",
@@ -152,12 +153,14 @@ namespace UICatalog.Scenarios {
 			{
 				if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed)) {
 					if (_currentLine == null) {
-
+						// Mouse pressed down
 						_currentLine = new StraightLine (
 							new Point (mouseEvent.X - GetBoundsOffset ().X, mouseEvent.Y - GetBoundsOffset ().X),
 							0, Orientation.Vertical, LineStyle, new Attribute (_currentColor, GetNormalColor ().Background));
+						
 						_currentLayer.AddLine (_currentLine);
 					} else {
+						// Mouse dragged
 						var start = _currentLine.Start;
 						var end = new Point (mouseEvent.X - GetBoundsOffset ().X, mouseEvent.Y - GetBoundsOffset ().Y);
 						var orientation = Orientation.Vertical;
@@ -180,7 +183,23 @@ namespace UICatalog.Scenarios {
 						SetNeedsDisplay ();
 					}
 				} else {
+
+					// Mouse released
 					if (_currentLine != null) {
+
+						if(_currentLine.Style == LineStyle.None) {
+
+							// Treat none as eraser
+							var idx = _layers.IndexOf (_currentLayer);
+							_layers.Remove (_currentLayer);
+
+							_currentLayer = new LineCanvas(
+								_currentLayer.Lines.Exclude (_currentLine.Start, _currentLine.Length, _currentLine.Orientation)
+								);
+
+							_layers.Insert (idx, _currentLayer);
+						}
+
 						_currentLine = null;
 						undoHistory.Clear ();
 						SetNeedsDisplay ();

--- a/UnitTests/Drawing/LineCanvasTests.cs
+++ b/UnitTests/Drawing/LineCanvasTests.cs
@@ -766,13 +766,12 @@ namespace Terminal.Gui.DrawingTests {
 
 		[Fact,AutoInitShutdown]
 		public void TestExcludeParallel_LeftOnly()
-		{
-			var lc = new LineCanvas();
-			
-			// x=1 to x=11
+		{			
+			// x=1 to x=10
 			var l1 = new StraightLine(new Point(1,2),10,Orientation.Horizontal,LineStyle.Single);
-			var after = new StraightLine[]{l1}
-						.Exclude(new Point(3,2),100,Orientation.Horizontal)
+			var after = new StraightLine[]{l1 }
+						// exclude x=3 to x=103
+						.Exclude (new Point(3,2),100,Orientation.Horizontal)
 						.ToArray();
 			// x=1 to x=2
 			var afterLine = Assert.Single(after);
@@ -783,15 +782,14 @@ namespace Terminal.Gui.DrawingTests {
 
 		[Fact,AutoInitShutdown]
 		public void TestExcludeParallel_RightOnly()
-		{
-			var lc = new LineCanvas();
-			
-			// x=1 to x=11
+		{			
+			// x=1 to x=10
 			var l1 = new StraightLine(new Point(1,2),10,Orientation.Horizontal,LineStyle.Single);
-			var after = new StraightLine[]{l1}
-						.Exclude(new Point(0,2),3,Orientation.Horizontal)
+			var after = new StraightLine[]{l1 }
+						// exclude x=0 to x=2
+						.Exclude (new Point(0,2),3,Orientation.Horizontal)
 						.ToArray();
-			// x=3 to x=11
+			// x=3 to x=10
 			var afterLine = Assert.Single(after);
 			Assert.Equal(3,afterLine.Start.X);
 			Assert.Equal(2,afterLine.Start.Y);
@@ -801,16 +799,15 @@ namespace Terminal.Gui.DrawingTests {
 
 		[Fact,AutoInitShutdown]
 		public void TestExcludeParallel_HorizontalSplit()
-		{
-			var lc = new LineCanvas();
-			
-			// x=1 to x=11
+		{			
+			// x=1 to x=10
 			var l1 = new StraightLine(new Point(1,2),10,Orientation.Horizontal,LineStyle.Single);
 			var after = new StraightLine[]{l1}
+						// exclude x=4 to x=5
 						.Exclude(new Point(4,2),2,Orientation.Horizontal)
 						.ToArray();
 			// x=1 to x=3,
-			// x=6 to x=11
+			// x=6 to x=10
 			Assert.Equal(2,after.Length);
 			var afterLeft = after[0];
 			var afterRight = after[1];
@@ -821,7 +818,7 @@ namespace Terminal.Gui.DrawingTests {
 
 			Assert.Equal(6,afterRight.Start.X);
 			Assert.Equal(2,afterRight.Start.Y);
-			Assert.Equal(6,afterRight.Length);
+			Assert.Equal(5,afterRight.Length);
 		}
 
 

--- a/UnitTests/Drawing/LineCanvasTests.cs
+++ b/UnitTests/Drawing/LineCanvasTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Xunit;
 using Xunit.Abstractions;
@@ -762,6 +763,68 @@ namespace Terminal.Gui.DrawingTests {
 ";
 			TestHelpers.AssertDriverContentsAre (looksLike, output);
 		}
+
+		[Fact,AutoInitShutdown]
+		public void TestExcludeParallel_LeftOnly()
+		{
+			var lc = new LineCanvas();
+			
+			// x=1 to x=11
+			var l1 = new StraightLine(new Point(1,2),10,Orientation.Horizontal,LineStyle.Single);
+			var after = new StraightLine[]{l1}
+						.Exclude(new Point(3,2),100,Orientation.Horizontal)
+						.ToArray();
+			// x=1 to x=2
+			var afterLine = Assert.Single(after);
+			Assert.Equal(l1.Start,afterLine.Start);
+			Assert.Equal(2,afterLine.Length);
+		}
+
+
+		[Fact,AutoInitShutdown]
+		public void TestExcludeParallel_RightOnly()
+		{
+			var lc = new LineCanvas();
+			
+			// x=1 to x=11
+			var l1 = new StraightLine(new Point(1,2),10,Orientation.Horizontal,LineStyle.Single);
+			var after = new StraightLine[]{l1}
+						.Exclude(new Point(0,2),3,Orientation.Horizontal)
+						.ToArray();
+			// x=3 to x=11
+			var afterLine = Assert.Single(after);
+			Assert.Equal(3,afterLine.Start.X);
+			Assert.Equal(2,afterLine.Start.Y);
+			Assert.Equal(8,afterLine.Length);
+		}
+
+
+		[Fact,AutoInitShutdown]
+		public void TestExcludeParallel_HorizontalSplit()
+		{
+			var lc = new LineCanvas();
+			
+			// x=1 to x=11
+			var l1 = new StraightLine(new Point(1,2),10,Orientation.Horizontal,LineStyle.Single);
+			var after = new StraightLine[]{l1}
+						.Exclude(new Point(4,2),2,Orientation.Horizontal)
+						.ToArray();
+			// x=1 to x=3,
+			// x=6 to x=11
+			Assert.Equal(2,after.Length);
+			var afterLeft = after[0];
+			var afterRight = after[1];
+
+			Assert.Equal(1,afterLeft.Start.X);
+			Assert.Equal(2,afterLeft.Start.Y);
+			Assert.Equal(3,afterLeft.Length);
+
+			Assert.Equal(6,afterRight.Start.X);
+			Assert.Equal(2,afterRight.Start.Y);
+			Assert.Equal(6,afterRight.Length);
+		}
+
+
 
 		[Fact, AutoInitShutdown]
 		public void TestLineCanvas_LeaveMargin_Top1_Left1 ()


### PR DESCRIPTION
Fixes #_____ - Include a terse summary of the change or which issue is fixed.

This is a WIP.  Current implementation only works for parallel exclusion, perpendicular exclusion and more tests will be added before I mark this ready.

It is an alternative to the proposed `DrawIncompleteFrame`.

Use Case:
Ability to draw rectangles with parts of the boundary line snipped out e.g. for `TabView`.  Also in general, to apply an 'eraser' effect to a `LineCanvas`.

Approach:
Adds extension method `Exclude` to collections of `StraightLine` (this decouples the method from `LineCanvas`).

![exclude](https://github.com/gui-cs/Terminal.Gui/assets/31306100/e90b3037-bdae-4404-9efa-d802364552a8)



## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
