### PR TITLE
Fixes #3011. TextFormatter doesn't handle combining and tab runes.

### DIFF
--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -978,7 +978,7 @@ namespace Terminal.Gui {
 		#endregion // Static Members
 
 		List<string> _lines = new List<string> ();
-		string _text;
+		string _text = null;
 		TextAlignment _textAlignment;
 		VerticalTextAlignment _textVerticalAlignment;
 		TextDirection _textDirection;
@@ -997,13 +997,17 @@ namespace Terminal.Gui {
 		public virtual string Text {
 			get => _text;
 			set {
+				if (AutoSize || (_text == null && value != null && Size.IsEmpty)) {
+					Size = CalcRect (0, 0, value, _textDirection).Size;
+				}
+
 				_text = value;
 
-				if (_text != null && _text.GetRuneCount () > 0 && (Size.Width == 0 || Size.Height == 0 || Size.Width != _text.GetColumns ())) {
-					// Provide a default size (width = length of longest line, height = 1)
-					// TODO: It might makes more sense for the default to be width = length of first line?
-					Size = new Size (TextFormatter.MaxWidth (Text, int.MaxValue), 1);
-				}
+				//if (_text != null && _text.GetRuneCount () > 0 && (Size.Width == 0 || Size.Height == 0 || Size.Width != _text.GetColumns ())) {
+				//	// Provide a default size (width = length of longest line, height = 1)
+				//	// TODO: It might makes more sense for the default to be width = length of first line?
+				//	Size = new Size (TextFormatter.MaxWidth (Text, int.MaxValue), 1);
+				//}
 
 				NeedsFormat = true;
 			}

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -620,21 +620,24 @@ namespace Terminal.Gui.TextTests {
 
 		[Theory]
 		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 51, 0, new string [] { "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ" })]
-		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 50, -1, new string [] { "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัา", "ำ" })]
+		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 50, -1, new string [] { "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ" })]
 		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 46, -5, new string [] { "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮ", "ฯะัาำ" })]
 		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 26, -25, new string [] { "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบ", "ปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ" })]
 		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 17, -34, new string [] { "กขฃคฅฆงจฉชซฌญฎฏฐฑ", "ฒณดตถทธนบปผฝพฟภมย", "รฤลฦวศษสหฬอฮฯะัาำ" })]
 		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 13, -38, new string [] { "กขฃคฅฆงจฉชซฌญ", "ฎฏฐฑฒณดตถทธนบ", "ปผฝพฟภมยรฤลฦว", "ศษสหฬอฮฯะัาำ" })]
-		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 1, -50, new string [] { "ก", "ข", "ฃ", "ค", "ฅ", "ฆ", "ง", "จ", "ฉ", "ช", "ซ", "ฌ", "ญ", "ฎ", "ฏ", "ฐ", "ฑ", "ฒ", "ณ", "ด", "ต", "ถ", "ท", "ธ", "น", "บ", "ป", "ผ", "ฝ", "พ", "ฟ", "ภ", "ม", "ย", "ร", "ฤ", "ล", "ฦ", "ว", "ศ", "ษ", "ส", "ห", "ฬ", "อ", "ฮ", "ฯ", "ะ", "ั", "า", "ำ" })]
+		[InlineData ("กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำ", 1, -50, new string [] { "ก", "ข", "ฃ", "ค", "ฅ", "ฆ", "ง", "จ", "ฉ", "ช", "ซ", "ฌ", "ญ", "ฎ", "ฏ", "ฐ", "ฑ", "ฒ", "ณ", "ด", "ต", "ถ", "ท", "ธ", "น", "บ", "ป", "ผ", "ฝ", "พ", "ฟ", "ภ", "ม", "ย", "ร", "ฤ", "ล", "ฦ", "ว", "ศ", "ษ", "ส", "ห", "ฬ", "อ", "ฮ", "ฯ", "ะั", "า", "ำ" })]
 		public void WordWrap_Unicode_SingleWordLine (string text, int maxWidth, int widthOffset, IEnumerable<string> resultLines)
 		{
 			List<string> wrappedLines;
 
+			var zeroWidth = text.EnumerateRunes ().Where (r => r.GetColumns () == 0);
+			Assert.Single (zeroWidth);
+			Assert.Equal ('ั', zeroWidth.ElementAt (0).Value);
 			Assert.Equal (maxWidth, text.GetRuneCount () + widthOffset);
 			var expectedClippedWidth = Math.Min (text.GetRuneCount (), maxWidth);
 			wrappedLines = TextFormatter.WordWrapText (text, maxWidth);
 			Assert.Equal (wrappedLines.Count, resultLines.Count ());
-			Assert.True (expectedClippedWidth >= (wrappedLines.Count > 0 ? wrappedLines.Max (l => l.GetRuneCount ()) : 0));
+			Assert.True (expectedClippedWidth >= (wrappedLines.Count > 0 ? wrappedLines.Max (l => l.GetRuneCount () + zeroWidth.Count () - 1 + widthOffset) : 0));
 			Assert.True (expectedClippedWidth >= (wrappedLines.Count > 0 ? wrappedLines.Max (l => l.GetColumns ()) : 0));
 			Assert.Equal (resultLines, wrappedLines);
 		}
@@ -1417,6 +1420,68 @@ namespace Terminal.Gui.TextTests {
 				// Rune array length is equal to string array
 				Assert.Equal (expected, text [index].ToString ());
 			}
+		}
+
+		[Fact]
+		public void GetLengthThatFits_With_Combining_Runes ()
+		{
+			var text = "Les Mise\u0328\u0301rables";
+			Assert.Equal (16, TextFormatter.GetLengthThatFits (text, 14));
+		}
+
+		[Fact]
+		public void GetMaxColsForWidth_With_Combining_Runes ()
+		{
+			var text = new List<string> () { "Les Mis", "e\u0328\u0301", "rables" };
+			Assert.Equal (1, TextFormatter.GetMaxColsForWidth (text, 1));
+		}
+
+		[Fact]
+		public void GetSumMaxCharWidth_With_Combining_Runes ()
+		{
+			var text = "Les Mise\u0328\u0301rables";
+			Assert.Equal (1, TextFormatter.GetSumMaxCharWidth (text, 1, 1));
+		}
+
+		[Fact]
+		public void GetSumMaxCharWidth_List_With_Combining_Runes ()
+		{
+			var text = new List<string> () { "Les Mis", "e\u0328\u0301", "rables" };
+			Assert.Equal (1, TextFormatter.GetSumMaxCharWidth (text, 1, 1));
+		}
+
+		[Theory]
+		[InlineData (14, 1, TextDirection.LeftRight_TopBottom)]
+		[InlineData (1, 14, TextDirection.TopBottom_LeftRight)]
+		public void CalcRect_With_Combining_Runes (int width, int height, TextDirection textDirection)
+		{
+			var text = "Les Mise\u0328\u0301rables";
+			Assert.Equal (new Rect (0, 0, width, height), TextFormatter.CalcRect (0, 0, text, textDirection));
+		}
+
+		[Theory, AutoInitShutdown]
+		[InlineData (14, 1, TextDirection.LeftRight_TopBottom, "Les Misęrables")]
+		[InlineData (1, 14, TextDirection.TopBottom_LeftRight, "L\ne\ns\n \nM\ni\ns\nę\nr\na\nb\nl\ne\ns")]
+		[InlineData (4, 4, TextDirection.TopBottom_LeftRight, @"
+LMre
+eias
+ssb 
+ ęl ")]
+		public void Draw_With_Combining_Runes (int width, int height, TextDirection textDirection, string expected)
+		{
+			var text = "Les Mise\u0328\u0301rables";
+
+			var tf = new TextFormatter ();
+			tf.Text = text;
+			tf.Direction = textDirection;
+
+			if (textDirection == TextDirection.LeftRight_TopBottom) {
+				Assert.Equal (new Size (width, height), tf.Size);
+			} else {
+				tf.Size = new Size (width, height);
+			}
+			tf.Draw (new Rect (0, 0, width, height), new Attribute (ColorName.White, ColorName.Black), new Attribute (ColorName.Blue, ColorName.Black));
+			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 		}
 	}
 }

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -1508,6 +1508,7 @@ ssb
 			tf.TabWidth = tabWidth;
 			tf.Text = text;
 
+			Assert.False (tf.WordWrap);
 			Assert.False (tf.PreserveTrailingSpaces);
 			Assert.Equal (new Size (width, height), tf.Size);
 			tf.Draw (new Rect (0, 0, width, height), new Attribute (ColorName.White, ColorName.Black), new Attribute (ColorName.Blue, ColorName.Black));
@@ -1526,6 +1527,26 @@ ssb
 			tf.Direction = textDirection;
 			tf.TabWidth = tabWidth;
 			tf.PreserveTrailingSpaces = true;
+			tf.Text = text;
+
+			Assert.False (tf.WordWrap);
+			Assert.Equal (new Size (width, height), tf.Size);
+			tf.Draw (new Rect (0, 0, width, height), new Attribute (ColorName.White, ColorName.Black), new Attribute (ColorName.Blue, ColorName.Black));
+			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+		}
+
+		[Theory, AutoInitShutdown]
+		[InlineData (17, 1, TextDirection.LeftRight_TopBottom, 4, "This is a     Tab")]
+		[InlineData (1, 17, TextDirection.TopBottom_LeftRight, 4, "T\nh\ni\ns\n \ni\ns\n \na\n \n \n \n \n \nT\na\nb")]
+		[InlineData (13, 1, TextDirection.LeftRight_TopBottom, 0, "This is a Tab")]
+		[InlineData (1, 13, TextDirection.TopBottom_LeftRight, 0, "T\nh\ni\ns\n \ni\ns\n \na\n \nT\na\nb")]
+		public void TabWith_WordWrap_True (int width, int height, TextDirection textDirection, int tabWidth, string expected)
+		{
+			var text = "This is a \tTab";
+			var tf = new TextFormatter ();
+			tf.Direction = textDirection;
+			tf.TabWidth = tabWidth;
+			tf.WordWrap = true;
 			tf.Text = text;
 
 			Assert.Equal (new Size (width, height), tf.Size);

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -65,13 +65,23 @@ namespace Terminal.Gui.TextTests {
 			Assert.NotEmpty (tf.Lines);
 		}
 
-		[Fact]
-		public void TestSize_TextChange ()
+		[Theory]
+		[InlineData (TextDirection.LeftRight_TopBottom, false)]
+		[InlineData (TextDirection.TopBottom_LeftRight, true)]
+		public void TestSize_TextChange (TextDirection textDirection, bool autoSize)
 		{
-			var tf = new TextFormatter () { Text = "你" };
+			var tf = new TextFormatter () { Direction = textDirection, Text = "你", AutoSize = autoSize };
 			Assert.Equal (2, tf.Size.Width);
 			tf.Text = "你你";
-			Assert.Equal (4, tf.Size.Width);
+			if (autoSize) {
+				if (textDirection == TextDirection.LeftRight_TopBottom) {
+					Assert.Equal (4, tf.Size.Width);
+				} else {
+					Assert.Equal (2, tf.Size.Width);
+				}
+			} else {
+				Assert.Equal (2, tf.Size.Width);
+			}
 		}
 
 		[Fact]
@@ -1472,12 +1482,13 @@ ssb
 			var text = "Les Mise\u0328\u0301rables";
 
 			var tf = new TextFormatter ();
-			tf.Text = text;
 			tf.Direction = textDirection;
+			tf.Text = text;
 
 			if (textDirection == TextDirection.LeftRight_TopBottom) {
 				Assert.Equal (new Size (width, height), tf.Size);
 			} else {
+				Assert.Equal (new Size (1, text.GetColumns ()), tf.Size);
 				tf.Size = new Size (width, height);
 			}
 			tf.Draw (new Rect (0, 0, width, height), new Attribute (ColorName.White, ColorName.Black), new Attribute (ColorName.Blue, ColorName.Black));

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -1494,5 +1494,43 @@ ssb
 			tf.Draw (new Rect (0, 0, width, height), new Attribute (ColorName.White, ColorName.Black), new Attribute (ColorName.Blue, ColorName.Black));
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 		}
+
+		[Theory, AutoInitShutdown]
+		[InlineData (17, 1, TextDirection.LeftRight_TopBottom, 4, "This is a     Tab")]
+		[InlineData (1, 17, TextDirection.TopBottom_LeftRight, 4, "T\nh\ni\ns\n \ni\ns\n \na\n \n \n \n \n \nT\na\nb")]
+		[InlineData (13, 1, TextDirection.LeftRight_TopBottom, 0, "This is a Tab")]
+		[InlineData (1, 13, TextDirection.TopBottom_LeftRight, 0, "T\nh\ni\ns\n \ni\ns\n \na\n \nT\na\nb")]
+		public void TabWith_PreserveTrailingSpaces_False (int width, int height, TextDirection textDirection, int tabWidth, string expected)
+		{
+			var text = "This is a \tTab";
+			var tf = new TextFormatter ();
+			tf.Direction = textDirection;
+			tf.TabWidth = tabWidth;
+			tf.Text = text;
+
+			Assert.False (tf.PreserveTrailingSpaces);
+			Assert.Equal (new Size (width, height), tf.Size);
+			tf.Draw (new Rect (0, 0, width, height), new Attribute (ColorName.White, ColorName.Black), new Attribute (ColorName.Blue, ColorName.Black));
+			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+		}
+
+		[Theory, AutoInitShutdown]
+		[InlineData (17, 1, TextDirection.LeftRight_TopBottom, 4, "This is a     Tab")]
+		[InlineData (1, 17, TextDirection.TopBottom_LeftRight, 4, "T\nh\ni\ns\n \ni\ns\n \na\n \n \n \n \n \nT\na\nb")]
+		[InlineData (13, 1, TextDirection.LeftRight_TopBottom, 0, "This is a Tab")]
+		[InlineData (1, 13, TextDirection.TopBottom_LeftRight, 0, "T\nh\ni\ns\n \ni\ns\n \na\n \nT\na\nb")]
+		public void TabWith_PreserveTrailingSpaces_True (int width, int height, TextDirection textDirection, int tabWidth, string expected)
+		{
+			var text = "This is a \tTab";
+			var tf = new TextFormatter ();
+			tf.Direction = textDirection;
+			tf.TabWidth = tabWidth;
+			tf.PreserveTrailingSpaces = true;
+			tf.Text = text;
+
+			Assert.Equal (new Size (width, height), tf.Size);
+			tf.Draw (new Rect (0, 0, width, height), new Attribute (ColorName.White, ColorName.Black), new Attribute (ColorName.Blue, ColorName.Black));
+			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3011- Include a terse summary of the change or which issue is fixed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
