### PR TITLE
Fixes #3034. Text remains "invisible" in the TextView when WordWrap is activated.

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -2344,6 +2344,8 @@ namespace Terminal.Gui {
 				selectionStartRow = nStartRow;
 				selectionStartColumn = nStartCol;
 				wrapNeeded = true;
+
+				SetNeedsDisplay ();
 			}
 			if (currentCaller != null)
 				throw new InvalidOperationException ($"WordWrap settings was changed after the {currentCaller} call.");
@@ -2531,7 +2533,6 @@ namespace Terminal.Gui {
 			if (!wrapNeeded) {
 				SetNeedsDisplay (new Rect (0, prow, Math.Max (Frame.Width, 0), Math.Max (prow + 1, 0)));
 			}
-
 		}
 
 		ustring StringFromRunes (List<Rune> runes)

--- a/UnitTests/Views/TextViewTests.cs
+++ b/UnitTests/Views/TextViewTests.cs
@@ -6857,5 +6857,36 @@ TAB to jump between text field", output);
  to jump between text fields.
  to jump between text fields.", output);
 		}
+
+		[Theory]
+		[TextViewTestsAutoInitShutdown]
+		[InlineData (Key.Delete)]
+		[InlineData (Key.DeleteChar)]
+		public void WordWrap_Draw_Typed_Keys_After_Text_Is_Deleted (Key del)
+		{
+			Application.Top.Add (_textView);
+			_textView.Text = "Line 1.\nLine 2.";
+			_textView.WordWrap = true;
+			Application.Begin (Application.Top);
+
+			Assert.True (_textView.WordWrap);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+Line 1.
+Line 2.", output);
+
+			Assert.True (_textView.ProcessKey (new KeyEvent (Key.End | Key.ShiftMask, new KeyModifiers () { Shift = true })));
+			Assert.Equal ("Line 1.", _textView.SelectedText);
+
+			Assert.True (_textView.ProcessKey (new KeyEvent (del, new KeyModifiers ())));
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre ("Line 2.", output);
+
+			Assert.True (_textView.ProcessKey (new KeyEvent (Key.H, new KeyModifiers ())));
+			Assert.NotEqual (Rect.Empty, _textView.NeedDisplay);
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+H      
+Line 2.", output);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3034 - The `SetNeedsDisplay` wasn't being called. I also added a unit test.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
