### PR TITLE
Fixes #3034. Text remains "invisible" in the TextView when WordWrap is activated.

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -2881,7 +2881,9 @@ namespace Terminal.Gui {
 				_selectionStartRow = nStartRow;
 				_selectionStartColumn = nStartCol;
 				_wrapNeeded = true;
-			}
+
+                SetNeedsDisplay();
+            }
 			if (_currentCaller != null)
 				throw new InvalidOperationException ($"WordWrap settings was changed after the {_currentCaller} call.");
 		}

--- a/UnitTests/Views/TextViewTests.cs
+++ b/UnitTests/Views/TextViewTests.cs
@@ -7002,7 +7002,7 @@ Line 2.", output);
 			TestHelpers.AssertDriverContentsWithFrameAre ("Line 2.", output);
 
 			Assert.True (_textView.ProcessKey (new KeyEvent (Key.H, new KeyModifiers ())));
-			Assert.NotEqual (Rect.Empty, _textView.NeedDisplay);
+			Assert.NotEqual (Rect.Empty, _textView._needsDisplayRect);
 			Application.Refresh ();
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 H      

--- a/UnitTests/Views/TextViewTests.cs
+++ b/UnitTests/Views/TextViewTests.cs
@@ -6977,5 +6977,36 @@ This is the second line.
 				Assert.True (_textView.WordWrap);
 			}
 		}
+
+		[Theory]
+		[TextViewTestsAutoInitShutdown]
+		[InlineData (Key.Delete)]
+		[InlineData (Key.DeleteChar)]
+		public void WordWrap_Draw_Typed_Keys_After_Text_Is_Deleted (Key del)
+		{
+			Application.Top.Add (_textView);
+			_textView.Text = "Line 1.\nLine 2.";
+			_textView.WordWrap = true;
+			Application.Begin (Application.Top);
+
+			Assert.True (_textView.WordWrap);
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+Line 1.
+Line 2.", output);
+
+			Assert.True (_textView.ProcessKey (new KeyEvent (Key.End | Key.ShiftMask, new KeyModifiers () { Shift = true })));
+			Assert.Equal ("Line 1.", _textView.SelectedText);
+
+			Assert.True (_textView.ProcessKey (new KeyEvent (del, new KeyModifiers ())));
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre ("Line 2.", output);
+
+			Assert.True (_textView.ProcessKey (new KeyEvent (Key.H, new KeyModifiers ())));
+			Assert.NotEqual (Rect.Empty, _textView.NeedDisplay);
+			Application.Refresh ();
+			TestHelpers.AssertDriverContentsWithFrameAre (@"
+H      
+Line 2.", output);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3034 - A cherry pick from #3035.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
