### PR TITLE
Fixes #3064. Pos.View returns PosCombine

### DIFF
--- a/Terminal.Gui/View/Layout/PosDim.cs
+++ b/Terminal.Gui/View/Layout/PosDim.cs
@@ -333,7 +333,7 @@ namespace Terminal.Gui {
 				default: tside = "unknown"; break;
 				}
 				// Note: We do not checkt `Target` for null here to intentionally throw if so
-				return $"View({tside},{Target.ToString ()})";
+				return $"View(side={tside},target={Target.ToString ()})";
 			}
 
 			public override int GetHashCode () => Target.GetHashCode ();
@@ -346,42 +346,42 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
 		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
-		public static Pos Left (View view) => new PosCombine (true, new PosView (view, 0), new Pos.PosAbsolute (0));
+		public static Pos Left (View view) => new PosView (view, 0);
 
 		/// <summary>
 		/// Returns a <see cref="Pos"/> object tracks the Left (X) position of the specified <see cref="View"/>.
 		/// </summary>
 		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
 		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
-		public static Pos X (View view) => new PosCombine (true, new PosView (view, 0), new Pos.PosAbsolute (0));
+		public static Pos X (View view) => new PosView (view, 0);
 
 		/// <summary>
 		/// Returns a <see cref="Pos"/> object tracks the Top (Y) position of the specified <see cref="View"/>.
 		/// </summary>
 		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
 		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
-		public static Pos Top (View view) => new PosCombine (true, new PosView (view, 1), new Pos.PosAbsolute (0));
+		public static Pos Top (View view) => new PosView (view, 1);
 
 		/// <summary>
 		/// Returns a <see cref="Pos"/> object tracks the Top (Y) position of the specified <see cref="View"/>.
 		/// </summary>
 		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
 		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
-		public static Pos Y (View view) => new PosCombine (true, new PosView (view, 1), new Pos.PosAbsolute (0));
+		public static Pos Y (View view) => new PosView(view, 1);
 
 		/// <summary>
 		/// Returns a <see cref="Pos"/> object tracks the Right (X+Width) coordinate of the specified <see cref="View"/>.
 		/// </summary>
 		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
 		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
-		public static Pos Right (View view) => new PosCombine (true, new PosView (view, 2), new Pos.PosAbsolute (0));
+		public static Pos Right (View view) => new PosView (view, 2);
 
 		/// <summary>
 		/// Returns a <see cref="Pos"/> object tracks the Bottom (Y+Height) coordinate of the specified <see cref="View"/> 
 		/// </summary>
 		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
 		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
-		public static Pos Bottom (View view) => new PosCombine (true, new PosView (view, 3), new Pos.PosAbsolute (0));
+		public static Pos Bottom (View view) => new PosView (view, 3);
 
 		/// <summary>Serves as the default hash function. </summary>
 		/// <returns>A hash code for the current object.</returns>

--- a/Terminal.Gui/View/View.cs
+++ b/Terminal.Gui/View/View.cs
@@ -493,7 +493,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public override string ToString ()
 		{
-			return $"{GetType ().Name}({Id})({Frame})";
+			return $"{GetType ().Name}({Id}){Frame}";
 		}
 
 		/// <inheritdoc/>

--- a/UnitTests/View/Layout/DimTests.cs
+++ b/UnitTests/View/Layout/DimTests.cs
@@ -87,15 +87,14 @@ namespace Terminal.Gui.ViewTests {
 			var testVal = Rect.Empty;
 			var testValView = new View (testVal);
 			var dim = Dim.Width (testValView);
-			Assert.Equal ($"View(Width,View()({testVal}))", dim.ToString ());
+			Assert.Equal ($"View(Width,View(){testVal})", dim.ToString ());
 			testValView.Dispose ();
 			
 			testVal = new Rect (1, 2, 3, 4);
 			testValView = new View (testVal);
 			dim = Dim.Width (testValView);
-			Assert.Equal ($"View(Width,View()({testVal}))", dim.ToString ());
+			Assert.Equal ($"View(Width,View(){testVal})", dim.ToString ());
 			testValView.Dispose ();
-
 		}
 
 		[Fact, TestRespondersDisposed]
@@ -157,13 +156,13 @@ namespace Terminal.Gui.ViewTests {
 			var testVal = Rect.Empty;
 			var testValview = new View (testVal);
 			var dim = Dim.Height (testValview);
-			Assert.Equal ($"View(Height,View()({testVal}))", dim.ToString ());
+			Assert.Equal ($"View(Height,View(){testVal})", dim.ToString ());
 			testValview.Dispose ();
 			
 			testVal = new Rect (1, 2, 3, 4);
 			testValview = new View (testVal);
 			dim = Dim.Height (testValview);
-			Assert.Equal ($"View(Height,View()({testVal}))", dim.ToString ());
+			Assert.Equal ($"View(Height,View(){testVal})", dim.ToString ());
 			testValview.Dispose ();
 		}
 
@@ -438,12 +437,12 @@ namespace Terminal.Gui.ViewTests {
 				Assert.Equal (49, f2.Frame.Width); // 50-1=49
 				Assert.Equal (5, f2.Frame.Height);
 
-				Assert.Equal ("Combine(View(Width,FrameView(f1)((0,0,49,5)))-Absolute(2))", v1.Width.ToString ());
+				Assert.Equal ("Combine(View(Width,FrameView(f1)(0,0,49,5))-Absolute(2))", v1.Width.ToString ());
 				Assert.Equal ("Combine(Fill(0)-Absolute(2))", v1.Height.ToString ());
 				Assert.Equal (47, v1.Frame.Width); // 49-2=47
 				Assert.Equal (89, v1.Frame.Height); // 98-5-2-2=89
 
-				Assert.Equal ("Combine(View(Width,FrameView(f2)((49,0,49,5)))-Absolute(2))", v2.Width.ToString ());
+				Assert.Equal ("Combine(View(Width,FrameView(f2)(49,0,49,5))-Absolute(2))", v2.Width.ToString ());
 				Assert.Equal ("Combine(Fill(0)-Absolute(2))", v2.Height.ToString ());
 				Assert.Equal (47, v2.Frame.Width); // 49-2=47
 				Assert.Equal (89, v2.Frame.Height); // 98-5-2-2=89
@@ -458,8 +457,8 @@ namespace Terminal.Gui.ViewTests {
 				Assert.Equal (50, v4.Frame.Width);
 				Assert.Equal (50, v4.Frame.Height);
 
-				Assert.Equal ("Combine(View(Width,Button(v1)((2,7,47,89)))-View(Width,Button(v3)((0,0,9,9))))", v5.Width.ToString ());
-				Assert.Equal ("Combine(View(Height,Button(v1)((2,7,47,89)))-View(Height,Button(v3)((0,0,9,9))))", v5.Height.ToString ());
+				Assert.Equal ("Combine(View(Width,Button(v1)(2,7,47,89))-View(Width,Button(v3)(0,0,9,9)))", v5.Width.ToString ());
+				Assert.Equal ("Combine(View(Height,Button(v1)(2,7,47,89))-View(Height,Button(v3)(0,0,9,9)))", v5.Height.ToString ());
 				Assert.Equal (38, v5.Frame.Width); // 47-9=38
 				Assert.Equal (80, v5.Frame.Height); // 89-9=80
 
@@ -491,13 +490,13 @@ namespace Terminal.Gui.ViewTests {
 				Assert.Equal (5, f2.Frame.Height);
 
 				v1.Text = "Button1";
-				Assert.Equal ("Combine(View(Width,FrameView(f1)((0,0,99,5)))-Absolute(2))", v1.Width.ToString ());
+				Assert.Equal ("Combine(View(Width,FrameView(f1)(0,0,99,5))-Absolute(2))", v1.Width.ToString ());
 				Assert.Equal ("Combine(Fill(0)-Absolute(2))", v1.Height.ToString ());
 				Assert.Equal (97, v1.Frame.Width); // 99-2=97
 				Assert.Equal (189, v1.Frame.Height); // 198-2-7=189
 
 				v2.Text = "Button2";
-				Assert.Equal ("Combine(View(Width,FrameView(f2)((99,0,99,5)))-Absolute(2))", v2.Width.ToString ());
+				Assert.Equal ("Combine(View(Width,FrameView(f2)(99,0,99,5))-Absolute(2))", v2.Width.ToString ());
 				Assert.Equal ("Combine(Fill(0)-Absolute(2))", v2.Height.ToString ());
 				Assert.Equal (97, v2.Frame.Width); // 99-2=97
 				Assert.Equal (189, v2.Frame.Height); // 198-2-7=189
@@ -521,8 +520,8 @@ namespace Terminal.Gui.ViewTests {
 				Assert.Equal (1, v4.Frame.Height); // 1 because is Dim.DimAbsolute
 
 				v5.Text = "Button5";
-				Assert.Equal ("Combine(View(Width,Button(v1)((2,7,97,189)))-View(Width,Button(v3)((0,0,19,19))))", v5.Width.ToString ());
-				Assert.Equal ("Combine(View(Height,Button(v1)((2,7,97,189)))-View(Height,Button(v3)((0,0,19,19))))", v5.Height.ToString ());
+				Assert.Equal ("Combine(View(Width,Button(v1)(2,7,97,189))-View(Width,Button(v3)(0,0,19,19)))", v5.Width.ToString ());
+				Assert.Equal ("Combine(View(Height,Button(v1)(2,7,97,189))-View(Height,Button(v3)(0,0,19,19)))", v5.Height.ToString ());
 				Assert.Equal (78, v5.Frame.Width); // 97-9=78
 				Assert.Equal (170, v5.Frame.Height); // 189-19=170
 

--- a/UnitTests/View/Layout/PosTests.cs
+++ b/UnitTests/View/Layout/PosTests.cs
@@ -390,140 +390,140 @@ namespace Terminal.Gui.ViewTests {
 			testInt = 0;
 			testRect = Rect.Empty;
 			pos = Pos.Left (new View ());
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			pos = Pos.Left (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			testRect = new Rect (1, 2, 3, 4);
 			pos = Pos.Left (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			// Pos.Left(win) + 0
 			pos = Pos.Left (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = 1;
 			// Pos.Left(win) +1
 			pos = Pos.Left (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = -1;
 			// Pos.Left(win) -1
 			pos = Pos.Left (new View (testRect)) - testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			// Pos.X
 			side = "x";
 			testInt = 0;
 			testRect = Rect.Empty;
 			pos = Pos.X (new View ());
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			pos = Pos.X (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			testRect = new Rect (1, 2, 3, 4);
 			pos = Pos.X (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			// Pos.X(win) + 0
 			pos = Pos.X (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = 1;
 			// Pos.X(win) +1
 			pos = Pos.X (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = -1;
 			// Pos.X(win) -1
 			pos = Pos.X (new View (testRect)) - testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			// Pos.Top
 			side = "y";
 			testInt = 0;
 			testRect = Rect.Empty;
 			pos = Pos.Top (new View ());
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			pos = Pos.Top (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			testRect = new Rect (1, 2, 3, 4);
 			pos = Pos.Top (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			// Pos.Top(win) + 0
 			pos = Pos.Top (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = 1;
 			// Pos.Top(win) +1
 			pos = Pos.Top (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = -1;
 			// Pos.Top(win) -1
 			pos = Pos.Top (new View (testRect)) - testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			// Pos.Y
 			side = "y";
 			testInt = 0;
 			testRect = Rect.Empty;
 			pos = Pos.Y (new View ());
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			pos = Pos.Y (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			testRect = new Rect (1, 2, 3, 4);
 			pos = Pos.Y (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			// Pos.Y(win) + 0
 			pos = Pos.Y (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = 1;
 			// Pos.Y(win) +1
 			pos = Pos.Y (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = -1;
 			// Pos.Y(win) -1
 			pos = Pos.Y (new View (testRect)) - testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			// Pos.Bottom
 			side = "bottom";
 			testRect = Rect.Empty;
 			testInt = 0;
 			pos = Pos.Bottom (new View ());
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			pos = Pos.Bottom (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			testRect = new Rect (1, 2, 3, 4);
 			pos = Pos.Bottom (new View (testRect));
-			Assert.Equal ($"Combine(View({side},View()({testRect})){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"View(side={side},target=View(){testRect})", pos.ToString ());
 
 			// Pos.Bottom(win) + 0
 			pos = Pos.Bottom (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = 1;
 			// Pos.Bottom(win) +1
 			pos = Pos.Bottom (new View (testRect)) + testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 			testInt = -1;
 			// Pos.Bottom(win) -1
 			pos = Pos.Bottom (new View (testRect)) - testInt;
-			Assert.Equal ($"Combine(Combine(View({side},View()({testRect}))+Absolute(0)){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
+			Assert.Equal ($"Combine(View(side={side},target=View(){testRect}){(testInt < 0 ? '-' : '+')}Absolute({testInt}))", pos.ToString ());
 
 #if DEBUG_IDISPOSABLE
 			// HACK: Force clean up of Responders to avoid having to Dispose all the Views created above.
@@ -1083,6 +1083,42 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal (new Rect (8, 0, 2, 2), view2.Frame);
 
 			super.Dispose ();
+		}
+
+		[Fact]
+		public void DoNotReturnPosCombine ()
+		{
+			var v = new View () { Id = "V" };
+
+			var pos = Pos.Left (v);
+			Assert.Equal (
+				"View(side=x,target=View(V)(0,0,0,0))",
+				pos.ToString ());
+
+			pos = Pos.X (v);
+			Assert.Equal (
+				"View(side=x,target=View(V)(0,0,0,0))",
+				pos.ToString ());
+
+			pos = Pos.Top (v);
+			Assert.Equal (
+				"View(side=y,target=View(V)(0,0,0,0))",
+				pos.ToString ());
+
+			pos = Pos.Y (v);
+			Assert.Equal (
+				"View(side=y,target=View(V)(0,0,0,0))",
+				pos.ToString ());
+
+			pos = Pos.Right (v);
+			Assert.Equal (
+				"View(side=right,target=View(V)(0,0,0,0))",
+				pos.ToString ());
+
+			pos = Pos.Bottom (v);
+			Assert.Equal (
+				"View(side=bottom,target=View(V)(0,0,0,0))",
+				pos.ToString ());
 		}
 	}
 }

--- a/UnitTests/View/ViewTests.cs
+++ b/UnitTests/View/ViewTests.cs
@@ -22,7 +22,7 @@ namespace Terminal.Gui.ViewTests {
 			var r = new View ();
 			Assert.NotNull (r);
 			Assert.Equal (LayoutStyle.Computed, r.LayoutStyle);
-			Assert.Equal ("View()((0,0,0,0))", r.ToString ());
+			Assert.Equal ("View()(0,0,0,0)", r.ToString ());
 			Assert.False (r.CanFocus);
 			Assert.False (r.HasFocus);
 			Assert.Equal (new Rect (0, 0, 0, 0), r.Bounds);
@@ -47,7 +47,7 @@ namespace Terminal.Gui.ViewTests {
 			r = new View (Rect.Empty);
 			Assert.NotNull (r);
 			Assert.Equal (LayoutStyle.Absolute, r.LayoutStyle);
-			Assert.Equal ("View()((0,0,0,0))", r.ToString ());
+			Assert.Equal ("View()(0,0,0,0)", r.ToString ());
 			Assert.False (r.CanFocus);
 			Assert.False (r.HasFocus);
 			Assert.Equal (new Rect (0, 0, 0, 0), r.Bounds);
@@ -72,7 +72,7 @@ namespace Terminal.Gui.ViewTests {
 			r = new View (new Rect (1, 2, 3, 4));
 			Assert.NotNull (r);
 			Assert.Equal (LayoutStyle.Absolute, r.LayoutStyle);
-			Assert.Equal ("View()((1,2,3,4))", r.ToString ());
+			Assert.Equal ("View()(1,2,3,4)", r.ToString ());
 			Assert.False (r.CanFocus);
 			Assert.False (r.HasFocus);
 			Assert.Equal (new Rect (0, 0, 3, 4), r.Bounds);
@@ -97,7 +97,7 @@ namespace Terminal.Gui.ViewTests {
 			r = new View ("Vertical View", TextDirection.TopBottom_LeftRight);
 			Assert.NotNull (r);
 			Assert.Equal (LayoutStyle.Computed, r.LayoutStyle);
-			Assert.Equal ("View(Vertical View)((0,0,1,13))", r.ToString ());
+			Assert.Equal ("View(Vertical View)(0,0,1,13)", r.ToString ());
 			Assert.False (r.CanFocus);
 			Assert.False (r.HasFocus);
 			Assert.Equal (new Rect (0, 0, 1, 13), r.Bounds);
@@ -117,7 +117,6 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Null (r.MostFocused);
 			Assert.Equal (TextDirection.TopBottom_LeftRight, r.TextDirection);
 			r.Dispose ();
-		
 		}
 
 		[Fact, TestRespondersDisposed]

--- a/UnitTests/Views/ScrollBarViewTests.cs
+++ b/UnitTests/Views/ScrollBarViewTests.cs
@@ -539,12 +539,12 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.True (_scrollBar.Visible);
 			Assert.Equal ("Absolute(1)", _scrollBar.Width.ToString ());
 			Assert.Equal (1, _scrollBar.Bounds.Width);
-			Assert.Equal ("Combine(View(Height,HostView()((0,0,80,25)))-Absolute(1))",
+			Assert.Equal ("Combine(View(Height,HostView()(0,0,80,25))-Absolute(1))",
 				_scrollBar.Height.ToString ());
 			Assert.Equal (24, _scrollBar.Bounds.Height);
 			Assert.True (_scrollBar.OtherScrollBarView.ShowScrollIndicator);
 			Assert.True (_scrollBar.OtherScrollBarView.Visible);
-			Assert.Equal ("Combine(View(Width,HostView()((0,0,80,25)))-Absolute(1))",
+			Assert.Equal ("Combine(View(Width,HostView()(0,0,80,25))-Absolute(1))",
 				_scrollBar.OtherScrollBarView.Width.ToString ());
 			Assert.Equal (79, _scrollBar.OtherScrollBarView.Bounds.Width);
 			Assert.Equal ("Absolute(1)", _scrollBar.OtherScrollBarView.Height.ToString ());
@@ -556,12 +556,12 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.False (_scrollBar.Visible);
 			Assert.Equal ("Absolute(1)", _scrollBar.Width.ToString ());
 			Assert.Equal (1, _scrollBar.Bounds.Width);
-			Assert.Equal ("Combine(View(Height,HostView()((0,0,80,25)))-Absolute(1))",
+			Assert.Equal ("Combine(View(Height,HostView()(0,0,80,25))-Absolute(1))",
 				_scrollBar.Height.ToString ());
 			Assert.Equal (24, _scrollBar.Bounds.Height);
 			Assert.True (_scrollBar.OtherScrollBarView.ShowScrollIndicator);
 			Assert.True (_scrollBar.OtherScrollBarView.Visible);
-			Assert.Equal ("View(Width,HostView()((0,0,80,25)))",
+			Assert.Equal ("View(Width,HostView()(0,0,80,25))",
 				_scrollBar.OtherScrollBarView.Width.ToString ());
 			Assert.Equal (80, _scrollBar.OtherScrollBarView.Bounds.Width);
 			Assert.Equal ("Absolute(1)", _scrollBar.OtherScrollBarView.Height.ToString ());
@@ -573,12 +573,12 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.False (_scrollBar.Visible);
 			Assert.Equal ("Absolute(1)", _scrollBar.Width.ToString ());
 			Assert.Equal (1, _scrollBar.Bounds.Width);
-			Assert.Equal ("Combine(View(Height,HostView()((0,0,80,25)))-Absolute(1))",
+			Assert.Equal ("Combine(View(Height,HostView()(0,0,80,25))-Absolute(1))",
 				_scrollBar.Height.ToString ());
 			Assert.Equal (24, _scrollBar.Bounds.Height);
 			Assert.False (_scrollBar.OtherScrollBarView.ShowScrollIndicator);
 			Assert.False (_scrollBar.OtherScrollBarView.Visible);
-			Assert.Equal ("View(Width,HostView()((0,0,80,25)))",
+			Assert.Equal ("View(Width,HostView()(0,0,80,25))",
 				_scrollBar.OtherScrollBarView.Width.ToString ());
 			Assert.Equal (80, _scrollBar.OtherScrollBarView.Bounds.Width);
 			Assert.Equal ("Absolute(1)", _scrollBar.OtherScrollBarView.Height.ToString ());
@@ -590,12 +590,12 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.True (_scrollBar.Visible);
 			Assert.Equal ("Absolute(1)", _scrollBar.Width.ToString ());
 			Assert.Equal (1, _scrollBar.Bounds.Width);
-			Assert.Equal ("View(Height,HostView()((0,0,80,25)))",
+			Assert.Equal ("View(Height,HostView()(0,0,80,25))",
 				_scrollBar.Height.ToString ());
 			Assert.Equal (25, _scrollBar.Bounds.Height);
 			Assert.False (_scrollBar.OtherScrollBarView.ShowScrollIndicator);
 			Assert.False (_scrollBar.OtherScrollBarView.Visible);
-			Assert.Equal ("View(Width,HostView()((0,0,80,25)))",
+			Assert.Equal ("View(Width,HostView()(0,0,80,25))",
 				_scrollBar.OtherScrollBarView.Width.ToString ());
 			Assert.Equal (80, _scrollBar.OtherScrollBarView.Bounds.Width);
 			Assert.Equal ("Absolute(1)", _scrollBar.OtherScrollBarView.Height.ToString ());
@@ -607,12 +607,12 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.True (_scrollBar.Visible);
 			Assert.Equal ("Absolute(1)", _scrollBar.Width.ToString ());
 			Assert.Equal (1, _scrollBar.Bounds.Width);
-			Assert.Equal ("Combine(View(Height,HostView()((0,0,80,25)))-Absolute(1))",
+			Assert.Equal ("Combine(View(Height,HostView()(0,0,80,25))-Absolute(1))",
 				_scrollBar.Height.ToString ());
 			Assert.Equal (24, _scrollBar.Bounds.Height);
 			Assert.True (_scrollBar.OtherScrollBarView.ShowScrollIndicator);
 			Assert.True (_scrollBar.OtherScrollBarView.Visible);
-			Assert.Equal ("Combine(View(Width,HostView()((0,0,80,25)))-Absolute(1))",
+			Assert.Equal ("Combine(View(Width,HostView()(0,0,80,25))-Absolute(1))",
 				_scrollBar.OtherScrollBarView.Width.ToString ());
 			Assert.Equal (79, _scrollBar.OtherScrollBarView.Bounds.Width);
 			Assert.Equal ("Absolute(1)", _scrollBar.OtherScrollBarView.Height.ToString ());

--- a/UnitTests/Views/TileViewTests.cs
+++ b/UnitTests/Views/TileViewTests.cs
@@ -526,7 +526,7 @@ namespace Terminal.Gui.ViewsTests
             var tileView = Get11By3TileView();
 
             var ex = Assert.Throws<ArgumentException>(() => tileView.SetSplitterPos(0, Pos.Right(tileView)));
-            Assert.Equal("Only Percent and Absolute values are supported. Passed value was PosCombine", ex.Message);
+            Assert.Equal("Only Percent and Absolute values are supported. Passed value was PosView", ex.Message);
 
             ex = Assert.Throws<ArgumentException>(() => tileView.SetSplitterPos(0, Pos.Function(() => 1)));
             Assert.Equal("Only Percent and Absolute values are supported. Passed value was PosFunc", ex.Message);

--- a/UnitTests/Views/WindowTests.cs
+++ b/UnitTests/Views/WindowTests.cs
@@ -24,7 +24,7 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.NotNull (r);
 			Assert.Equal (string.Empty, r.Title);
 			Assert.Equal (LayoutStyle.Computed, r.LayoutStyle);
-			Assert.Equal ("Window()((0,0,0,0))", r.ToString ());
+			Assert.Equal ("Window()(0,0,0,0)", r.ToString ());
 			Assert.True (r.CanFocus);
 			Assert.False (r.HasFocus);
 			Assert.Equal (new Rect (0, 0, 0, 0), r.Bounds);
@@ -48,7 +48,7 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.NotNull (r);
 			Assert.Equal ("title", r.Title);
 			Assert.Equal (LayoutStyle.Absolute, r.LayoutStyle);
-			Assert.Equal ("Window(title)((0,0,0,0))", r.ToString ());
+			Assert.Equal ("Window(title)(0,0,0,0)", r.ToString ());
 			Assert.True (r.CanFocus);
 			Assert.False (r.HasFocus);
 			Assert.Equal (new Rect (0, 0, 0, 0), r.Bounds);
@@ -72,7 +72,7 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.Equal ("title", r.Title);
 			Assert.NotNull (r);
 			Assert.Equal (LayoutStyle.Absolute, r.LayoutStyle);
-			Assert.Equal ("Window(title)((1,2,3,4))", r.ToString ());
+			Assert.Equal ("Window(title)(1,2,3,4)", r.ToString ());
 			Assert.True (r.CanFocus);
 			Assert.False (r.HasFocus);
 			Assert.Equal (new Rect (0, 0, 1, 2), r.Bounds);


### PR DESCRIPTION
Fixes #3064- Really there is no sense to create a `PosCombine` with only `Pos.Absolute(0)`. `DimView` doesn't do that.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
