### PR TITLE
Fix MouseEvent.ToString()

### DIFF
--- a/Terminal.Gui/Input/Mouse.cs
+++ b/Terminal.Gui/Input/Mouse.cs
@@ -180,6 +180,6 @@ public class MouseEvent {
 	/// <returns>A <see cref="T:System.String"/> that represents the current <see cref="MouseEvent"/>.</returns>
 	public override string ToString ()
 	{
-		return $"({X},{Y}:{Flags}";
+		return $"({X},{Y}):{Flags}";
 	}
 }


### PR DESCRIPTION
Add a missing bracket