### PR TITLE
Support for publishing UICatalog as single file

### DIFF
--- a/UICatalog/Scenarios/Animation.cs
+++ b/UICatalog/Scenarios/Animation.cs
@@ -39,7 +39,15 @@ namespace UICatalog.Scenarios {
 			};
 			Win.Add (lbl2);
 
-			var dir = new DirectoryInfo (Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location));
+			DirectoryInfo dir;
+
+			var assemblyLocation = Assembly.GetExecutingAssembly ().Location;
+
+			if (!string.IsNullOrEmpty (assemblyLocation)) {
+				dir = new DirectoryInfo (Path.GetDirectoryName (assemblyLocation));
+			} else {
+				dir = new DirectoryInfo (System.AppContext.BaseDirectory);
+			}
 
 			var f = new FileInfo (
 				Path.Combine (dir.FullName, "Scenarios", "Spinning_globe_dark_small.gif"));

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -147,8 +147,18 @@ class UICatalogApp {
 	{
 		// Setup a file system watcher for `./.tui/`
 		_currentDirWatcher.NotifyFilter = NotifyFilters.LastWrite;
-		var f = new FileInfo (Assembly.GetExecutingAssembly ().Location);
-		string tuiDir = Path.Combine (f.Directory!.FullName, ".tui");
+
+		var assemblyLocation = Assembly.GetExecutingAssembly ().Location;
+		string tuiDir;
+
+		if (!string.IsNullOrEmpty (assemblyLocation)) {
+			var assemblyFile = new FileInfo (assemblyLocation);
+			tuiDir = Path.Combine (assemblyFile.Directory!.FullName, ".tui");
+		} else {
+			tuiDir = Path.Combine (System.AppContext.BaseDirectory, ".tui");
+		}
+
+
 
 		if (!Directory.Exists (tuiDir)) {
 			Directory.CreateDirectory (tuiDir);
@@ -158,7 +168,7 @@ class UICatalogApp {
 
 		// Setup a file system watcher for `~/.tui/`
 		_homeDirWatcher.NotifyFilter = NotifyFilters.LastWrite;
-		f = new FileInfo (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
+		var f = new FileInfo (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 		tuiDir = Path.Combine (f.FullName, ".tui");
 
 		if (!Directory.Exists (tuiDir)) {


### PR DESCRIPTION
I was experimenting with `<PublishSingleFile>true</PublishSingleFile>` and UICatalog.  I have discovered that it more or less works.  Only barrier I had was [IL3000](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000)

Solution is here just to fallback on `System.AppContext.BaseDirectory`.

This PR does not itself change to single file, it just strengthens the existing code so that if it were run under such build options then it would not crash.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
