### PR TITLE
Fixes #3071 & #3079. Key cast and static props are not correct 

### DIFF
--- a/Terminal.Gui/Configuration/ConfigurationManager.cs
+++ b/Terminal.Gui/Configuration/ConfigurationManager.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using static Terminal.Gui.SpinnerStyle;
@@ -70,8 +71,13 @@ public static partial class ConfigurationManager {
 				// We override the standard Rune converter to support specifying Glyphs in
 				// a flexible way
 				new RuneJsonConverter(),
+				// Override Key to support "Ctrl+Q" format.
+				new KeyJsonConverter()
 			},
-	};
+		// Enables Key to be "Ctrl+Q" vs "Ctrl\u002BQ"
+		Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+
+};
 
 	/// <summary>
 	/// A dictionary of all properties in the Terminal.Gui project that are decorated with the <see cref="SerializableConfigurationProperty"/> attribute.

--- a/Terminal.Gui/Configuration/KeyJsonConverter.cs
+++ b/Terminal.Gui/Configuration/KeyJsonConverter.cs
@@ -3,46 +3,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Terminal.Gui;
-class KeyJsonConverter : JsonConverter<Key> {
-	
-	public override Key Read (ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-	{
-		if (reader.TokenType == JsonTokenType.StartObject) {
-			Key key = Key.Empty;
-			while (reader.Read ()) {
-				if (reader.TokenType == JsonTokenType.EndObject) {
-					break;
-				}
 
-				if (reader.TokenType == JsonTokenType.PropertyName) {
-					string propertyName = reader.GetString ();
-					reader.Read ();
+/// <summary>
+/// Support for <see cref="Key"/> in JSON in the form of "Ctrl-X" or "Alt-Shift-F1".
+/// </summary>
+public class KeyJsonConverter : JsonConverter<Key> {
+	public override Key Read (ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => Key.TryParse (reader.GetString (), out var key) ? key : Key.Empty;
 
-					switch (propertyName?.ToLowerInvariant ()) {
-					case "key":
-						if (reader.TokenType == JsonTokenType.String) {
-							string keyValue = reader.GetString ();
-							if (Key.TryParse (keyValue, out key)) {
-								break;
-							}
-							throw new JsonException ($"Error parsing Key: {keyValue}.");
-
-						}
-						break;
-					default:
-						throw new JsonException ($"Unexpected Key property \"{propertyName}\".");
-					}
-				}
-			}
-			return key;
-		}
-		throw new JsonException ($"Unexpected StartObject token when parsing Key: {reader.TokenType}.");
-	}
-
-	public override void Write (Utf8JsonWriter writer, Key value, JsonSerializerOptions options)
-	{
-		writer.WriteStartObject ();
-		writer.WriteString ("Key", value.ToString ());
-		writer.WriteEndObject ();
-	}
+	public override void Write (Utf8JsonWriter writer, Key value, JsonSerializerOptions options) => writer.WriteStringValue (value.ToString ());
 }

--- a/Terminal.Gui/ConsoleDrivers/ConsoleDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/ConsoleDriver.cs
@@ -649,7 +649,6 @@ public enum CursorVisibility {
 /// Lowercase alpha keys are encoded as values between 65 and 90 corresponding to the un-shifted A to Z keys on a keyboard. Enum values
 /// are provided for these (e.g. <see cref="KeyCode.A"/>, <see cref="KeyCode.B"/>, etc.). Even though the values are the same as the ASCII
 /// values for uppercase characters, these enum values represent *lowercase*, un-shifted characters.
-/// TODO: Strongly consider renaming these from .A to .Z to .A_Lowercase to .Z_Lowercase (or .a to .z).
 /// </para>
 /// <para>
 /// Numeric keys are the values between 48 and 57 corresponding to 0 to 9 (e.g. <see cref="KeyCode.D0"/>, <see cref="KeyCode.D1"/>, etc.).
@@ -680,7 +679,7 @@ public enum KeyCode : uint {
 
 	/// <summary>
 	/// If the <see cref="SpecialMask"/> is set, then the value is that of the special mask,
-	/// otherwise, the value is the one of the lower bits (as extracted by <see cref="CharMask"/>).
+	/// otherwise, the value is in the the lower bits (as extracted by <see cref="CharMask"/>).
 	/// </summary>
 	SpecialMask = 0xfff00000,
 
@@ -791,111 +790,111 @@ public enum KeyCode : uint {
 	D9,
 
 	/// <summary>
-	/// The key code for the user pressing Shift-A
+	/// The key code for the A key
 	/// </summary>
 	A = 65,
 	/// <summary>
-	/// The key code for the user pressing Shift-B
+	/// The key code for the B key
 	/// </summary>
 	B,
 	/// <summary>
-	/// The key code for the user pressing Shift-C
+	/// The key code for the C key
 	/// </summary>
 	C,
 	/// <summary>
-	/// The key code for the user pressing Shift-D
+	/// The key code for the D key
 	/// </summary>
 	D,
 	/// <summary>
-	/// The key code for the user pressing Shift-E
+	/// The key code for the E key
 	/// </summary>
 	E,
 	/// <summary>
-	/// The key code for the user pressing Shift-F
+	/// The key code for the F key
 	/// </summary>
 	F,
 	/// <summary>
-	/// The key code for the user pressing Shift-G
+	/// The key code for the G key
 	/// </summary>
 	G,
 	/// <summary>
-	/// The key code for the user pressing Shift-H
+	/// The key code for the H key
 	/// </summary>
 	H,
 	/// <summary>
-	/// The key code for the user pressing Shift-I
+	/// The key code for the I key
 	/// </summary>
 	I,
 	/// <summary>
-	/// The key code for the user pressing Shift-J
+	/// The key code for the J key
 	/// </summary>
 	J,
 	/// <summary>
-	/// The key code for the user pressing Shift-K
+	/// The key code for the K key
 	/// </summary>
 	K,
 	/// <summary>
-	/// The key code for the user pressing Shift-L
+	/// The key code for the L key
 	/// </summary>
 	L,
 	/// <summary>
-	/// The key code for the user pressing Shift-M
+	/// The key code for the M key
 	/// </summary>
 	M,
 	/// <summary>
-	/// The key code for the user pressing Shift-N
+	/// The key code for the N key
 	/// </summary>
 	N,
 	/// <summary>
-	/// The key code for the user pressing Shift-O
+	/// The key code for the O key
 	/// </summary>
 	O,
 	/// <summary>
-	/// The key code for the user pressing Shift-P
+	/// The key code for the P key
 	/// </summary>
 	P,
 	/// <summary>
-	/// The key code for the user pressing Shift-Q
+	/// The key code for the Q key
 	/// </summary>
 	Q,
 	/// <summary>
-	/// The key code for the user pressing Shift-R
+	/// The key code for the R key
 	/// </summary>
 	R,
 	/// <summary>
-	/// The key code for the user pressing Shift-S
+	/// The key code for the S key
 	/// </summary>
 	S,
 	/// <summary>
-	/// The key code for the user pressing Shift-T
+	/// The key code for the T key
 	/// </summary>
 	T,
 	/// <summary>
-	/// The key code for the user pressing Shift-U
+	/// The key code for the U key
 	/// </summary>
 	U,
 	/// <summary>
-	/// The key code for the user pressing Shift-V
+	/// The key code for the V key
 	/// </summary>
 	V,
 	/// <summary>
-	/// The key code for the user pressing Shift-W
+	/// The key code for the W key
 	/// </summary>
 	W,
 	/// <summary>
-	/// The key code for the user pressing Shift-X
+	/// The key code for the X key
 	/// </summary>
 	X,
 	/// <summary>
-	/// The key code for the user pressing Shift-Y
+	/// The key code for the Y key
 	/// </summary>
 	Y,
 	/// <summary>
-	/// The key code for the user pressing Shift-Z
+	/// The key code for the Z key
 	/// </summary>
 	Z,
 	/// <summary>
-	/// The key code for the user pressing A
+	/// The key code for the Delete key.
 	/// </summary>
 	Delete = 127,
 

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1051,6 +1051,7 @@ internal class WindowsDriver : ConsoleDriver {
 			return (KeyCode)((uint)KeyCode.F1 + delta);
 		}
 
+		// If the key is JUST a modifier, return it as that key
 		if (key == (ConsoleKey)16) { // Shift
 			return KeyCode.ShiftKey;
 		}

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1052,15 +1052,15 @@ internal class WindowsDriver : ConsoleDriver {
 		}
 
 		if (key == (ConsoleKey)16) { // Shift
-			return KeyCode.Null | KeyCode.ShiftMask;
+			return KeyCode.ShiftKey;
 		}
 
 		if (key == (ConsoleKey)17) { // Ctrl
-			return KeyCode.Null | KeyCode.CtrlMask;
+			return KeyCode.CtrlKey;
 		}
 
 		if (key == (ConsoleKey)18) { // Alt
-			return KeyCode.Null | KeyCode.AltMask;
+			return KeyCode.AltKey;
 		}
 
 		return ConsoleKeyMapping.MapKeyModifiers (keyInfo, (KeyCode)((uint)keyInfo.KeyChar));

--- a/Terminal.Gui/Input/Key.cs
+++ b/Terminal.Gui/Input/Key.cs
@@ -72,10 +72,19 @@ public class Key : EventArgs, IEquatable<Key> {
 	public Key () : this (KeyCode.Null) { }
 
 	/// <summary>
-	///   Constructs a new <see cref="Key"/> from the provided Key value
+	/// Constructs a new <see cref="Key"/> from the provided Key value
 	/// </summary>
 	/// <param name="k">The key</param>
 	public Key (KeyCode k) => KeyCode = k;
+
+	/// <summary>
+	/// Constructs a new <see cref="Key"/> from a char.
+	/// </summary>
+	/// <param name="ch"></param>
+	public Key (char ch)
+	{
+		KeyCode = (KeyCode)ch;
+	}
 
 	/// <summary>
 	/// Indicates if the current Key event has already been processed and the driver should stop notifying any other event subscriber.
@@ -280,11 +289,11 @@ public class Key : EventArgs, IEquatable<Key> {
 	public static implicit operator Key (KeyCode keyCode) => new (keyCode);
 
 
-	/// <summary>
-	/// Cast <see langword="char"/> to a <see cref="Key"/>. 
-	/// </summary>
-	/// <param name="ch"></param>
-	public static implicit operator Key (char ch) => new ((KeyCode)ch);
+	///// <summary>
+	///// Cast <see langword="char"/> to a <see cref="Key"/>. 
+	///// </summary>
+	///// <param name="ch"></param>
+	//public static implicit operator Key (char ch) => new ((KeyCode)ch);
 
 	/// <inheritdoc/>
 	public override bool Equals (object obj) => obj is Key k && k.KeyCode == KeyCode;

--- a/Terminal.Gui/Input/Key.cs
+++ b/Terminal.Gui/Input/Key.cs
@@ -109,6 +109,21 @@ public class Key : EventArgs, IEquatable<Key> {
 	}
 
 	/// <summary>
+	/// Constructs a new Key from a string describing the key.
+	/// See <see cref="TryParse(string, out Terminal.Gui.Key)"/> for information
+	/// on the format of the string.
+	/// </summary>
+	/// <param name="str">The string describing the key.</param>
+	public Key (string str)
+	{
+		var result = Key.TryParse (str, out Key key);
+		if (!result) {
+			throw new ArgumentException (@$"Invalid key string: {str}", nameof (str));
+		}
+		KeyCode = key.KeyCode;
+	}
+
+	/// <summary>
 	/// Indicates if the current Key event has already been processed and the driver should stop notifying any other event subscriber.
 	/// Its important to set this value to true specially when updating any View's layout from inside the subscriber method.
 	/// </summary>

--- a/Terminal.Gui/Input/Key.cs
+++ b/Terminal.Gui/Input/Key.cs
@@ -65,7 +65,6 @@ namespace Terminal.Gui;
 /// </list>
 /// </para>
 /// </remarks>
-[JsonConverter (typeof (KeyJsonConverter))]
 public class Key : EventArgs, IEquatable<Key> {
 	/// <summary>
 	/// Constructs a new <see cref="Key"/>
@@ -140,8 +139,6 @@ public class Key : EventArgs, IEquatable<Key> {
 	/// <remarks>
 	/// This property is the backing data for the <see cref="Key"/>. It is a <see cref="KeyCode"/> enum value.
 	/// </remarks>
-	[JsonInclude]
-	[JsonConverter (typeof (KeyCodeJsonConverter))]
 	public KeyCode KeyCode { get; init; }
 
 	/// <summary>

--- a/Terminal.Gui/Input/Key.cs
+++ b/Terminal.Gui/Input/Key.cs
@@ -327,7 +327,7 @@ public class Key : EventArgs, IEquatable<Key> {
 	/// Cast <see cref="KeyCode"/> to a <see cref="Key"/>. 
 	/// </summary>
 	/// <param name="keyCode"></param>
-	public static implicit operator Key (KeyCode keyCode) => new Key( keyCode);
+	public static implicit operator Key (KeyCode keyCode) => new Key (keyCode);
 
 	/// <summary>
 	/// Cast <see langword="char"/> to a <see cref="Key"/>. 
@@ -337,6 +337,24 @@ public class Key : EventArgs, IEquatable<Key> {
 	/// </remarks>
 	/// <param name="ch"></param>
 	public static implicit operator Key (char ch) => new Key (ch);
+
+	/// <summary>
+	/// Cast <see langword="string"/> to a <see cref="Key"/>. 
+	/// </summary>
+	/// <remarks>
+	/// See <see cref="Key(string)"/> for more information.
+	/// </remarks>
+	/// <param name="str"></param>
+	public static implicit operator Key (string str) => new Key (str);
+
+	/// <summary>
+	/// Cast a <see cref="Key"/> to a <see langword="string"/>. 
+	/// </summary>
+	/// <remarks>
+	/// See <see cref="Key(string)"/> for more information.
+	/// </remarks>
+	/// <param name="key"></param>
+	public static implicit operator string (Key key) => key.ToString ();
 
 	/// <inheritdoc/>
 	public override bool Equals (object obj) => obj is Key k && k.KeyCode == KeyCode;

--- a/Terminal.Gui/Input/Key.cs
+++ b/Terminal.Gui/Input/Key.cs
@@ -603,416 +603,416 @@ public class Key : EventArgs, IEquatable<Key> {
 	/// <summary>
 	/// An uninitialized The <see cref="Key"/> object.
 	/// </summary>
-	public new static readonly Key Empty = new ();
+	public new static Key Empty => new ();
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Backspace key.
 	/// </summary>
-	public static readonly Key Backspace = new (KeyCode.Backspace);
+	public static Key Backspace => new (KeyCode.Backspace);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the tab key (forwards tab key).
 	/// </summary>
-	public static readonly Key Tab = new (KeyCode.Tab);
+	public static Key Tab => new (KeyCode.Tab);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the return key.
 	/// </summary>
-	public static readonly Key Enter = new (KeyCode.Enter);
+	public static Key Enter => new (KeyCode.Enter);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the clear key.
 	/// </summary>
-	public static readonly Key Clear = new (KeyCode.Clear);
+	public static Key Clear => new (KeyCode.Clear);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Shift key.
 	/// </summary>
-	public static readonly Key Shift = new (KeyCode.ShiftKey);
+	public static Key Shift => new (KeyCode.ShiftKey);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Ctrl key.
 	/// </summary>
-	public static readonly Key Ctrl = new (KeyCode.CtrlKey);
+	public static Key Ctrl => new (KeyCode.CtrlKey);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Alt key.
 	/// </summary>
-	public static readonly Key Alt = new (KeyCode.AltKey);
+	public static Key Alt => new (KeyCode.AltKey);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the CapsLock key.
 	/// </summary>
-	public static readonly Key CapsLock = new (KeyCode.CapsLock);
+	public static Key CapsLock => new (KeyCode.CapsLock);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Escape key.
 	/// </summary>
-	public static readonly Key Esc = new (KeyCode.Esc);
+	public static Key Esc => new (KeyCode.Esc);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Space bar key.
 	/// </summary>
-	public static readonly Key Space = new (KeyCode.Space);
+	public static Key Space => new (KeyCode.Space);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 0 key.
 	/// </summary>
-	public static readonly Key D0 = new (KeyCode.D0);
+	public static Key D0 => new (KeyCode.D0);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 1 key.
 	/// </summary>
-	public static readonly Key D1 = new (KeyCode.D1);
+	public static Key D1 => new (KeyCode.D1);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 2 key.
 	/// </summary>
-	public static readonly Key D2 = new (KeyCode.D2);
+	public static Key D2 => new (KeyCode.D2);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 3 key.
 	/// </summary>
-	public static readonly Key D3 = new (KeyCode.D3);
+	public static Key D3 => new (KeyCode.D3);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 4 key.
 	/// </summary>
-	public static readonly Key D4 = new (KeyCode.D4);
+	public static Key D4 => new (KeyCode.D4);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 5 key.
 	/// </summary>
-	public static readonly Key D5 = new (KeyCode.D5);
+	public static Key D5 => new (KeyCode.D5);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 6 key.
 	/// </summary>
-	public static readonly Key D6 = new (KeyCode.D6);
+	public static Key D6 => new (KeyCode.D6);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 7 key.
 	/// </summary>
-	public static readonly Key D7 = new (KeyCode.D7);
+	public static Key D7 => new (KeyCode.D7);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 8 key.
 	/// </summary>
-	public static readonly Key D8 = new (KeyCode.D8);
+	public static Key D8 => new (KeyCode.D8);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for 9 key.
 	/// </summary>
-	public static readonly Key D9 = new (KeyCode.D9);
+	public static Key D9 => new (KeyCode.D9);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the A key (un-shifted). Use <c>Key.A.WithShift</c> for uppercase 'A'.
 	/// </summary>
-	public static readonly Key A = new (KeyCode.A);
+	public static Key A => new (KeyCode.A);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the B key (un-shifted). Use <c>Key.B.WithShift</c> for uppercase 'B'.
 	/// </summary>
-	public static readonly Key B = new (KeyCode.B);
+	public static Key B => new (KeyCode.B);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the C key (un-shifted). Use <c>Key.C.WithShift</c> for uppercase 'C'.
 	/// </summary>
-	public static readonly Key C = new (KeyCode.C);
+	public static Key C => new (KeyCode.C);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the D key (un-shifted). Use <c>Key.D.WithShift</c> for uppercase 'D'.
 	/// </summary>
-	public static readonly Key D = new (KeyCode.D);
+	public static Key D => new (KeyCode.D);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the E key (un-shifted). Use <c>Key.E.WithShift</c> for uppercase 'E'.
 	/// </summary>
-	public static readonly Key E = new (KeyCode.E);
+	public static Key E => new (KeyCode.E);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the F key (un-shifted). Use <c>Key.F.WithShift</c> for uppercase 'F'.
 	/// </summary>
-	public static readonly Key F = new (KeyCode.F);
+	public static Key F => new (KeyCode.F);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the G key (un-shifted). Use <c>Key.G.WithShift</c> for uppercase 'G'.
 	/// </summary>
-	public static readonly Key G = new (KeyCode.G);
+	public static Key G => new (KeyCode.G);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the H key (un-shifted). Use <c>Key.H.WithShift</c> for uppercase 'H'.
 	/// </summary>
-	public static readonly Key H = new (KeyCode.H);
+	public static Key H => new (KeyCode.H);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the I key (un-shifted). Use <c>Key.I.WithShift</c> for uppercase 'I'.
 	/// </summary>
-	public static readonly Key I = new (KeyCode.I);
+	public static Key I => new (KeyCode.I);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the J key (un-shifted). Use <c>Key.J.WithShift</c> for uppercase 'J'.
 	/// </summary>
-	public static readonly Key J = new (KeyCode.J);
+	public static Key J => new (KeyCode.J);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the K key (un-shifted). Use <c>Key.K.WithShift</c> for uppercase 'K'.
 	/// </summary>
-	public static readonly Key K = new (KeyCode.K);
+	public static Key K => new (KeyCode.K);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the L key (un-shifted). Use <c>Key.L.WithShift</c> for uppercase 'L'.
 	/// </summary>
-	public static readonly Key L = new (KeyCode.L);
+	public static Key L => new (KeyCode.L);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the M key (un-shifted). Use <c>Key.M.WithShift</c> for uppercase 'M'.
 	/// </summary>
-	public static readonly Key M = new (KeyCode.M);
+	public static Key M => new (KeyCode.M);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the N key (un-shifted). Use <c>Key.N.WithShift</c> for uppercase 'N'.
 	/// </summary>
-	public static readonly Key N = new (KeyCode.N);
+	public static Key N => new (KeyCode.N);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the O key (un-shifted). Use <c>Key.O.WithShift</c> for uppercase 'O'.
 	/// </summary>
-	public static readonly Key O = new (KeyCode.O);
+	public static Key O => new (KeyCode.O);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the P key (un-shifted). Use <c>Key.P.WithShift</c> for uppercase 'P'.
 	/// </summary>
-	public static readonly Key P = new (KeyCode.P);
+	public static Key P => new (KeyCode.P);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Q key (un-shifted). Use <c>Key.Q.WithShift</c> for uppercase 'Q'.
 	/// </summary>
-	public static readonly Key Q = new (KeyCode.Q);
+	public static Key Q => new (KeyCode.Q);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the R key (un-shifted). Use <c>Key.R.WithShift</c> for uppercase 'R'.
 	/// </summary>
-	public static readonly Key R = new (KeyCode.R);
+	public static Key R => new (KeyCode.R);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the S key (un-shifted). Use <c>Key.S.WithShift</c> for uppercase 'S'.
 	/// </summary>
-	public static readonly Key S = new (KeyCode.S);
+	public static Key S => new (KeyCode.S);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the T key (un-shifted). Use <c>Key.T.WithShift</c> for uppercase 'T'.
 	/// </summary>
-	public static readonly Key T = new (KeyCode.T);
+	public static Key T => new (KeyCode.T);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the U key (un-shifted). Use <c>Key.U.WithShift</c> for uppercase 'U'.
 	/// </summary>
-	public static readonly Key U = new (KeyCode.U);
+	public static Key U => new (KeyCode.U);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the V key (un-shifted). Use <c>Key.V.WithShift</c> for uppercase 'V'.
 	/// </summary>
-	public static readonly Key V = new (KeyCode.V);
+	public static Key V => new (KeyCode.V);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the W key (un-shifted). Use <c>Key.W.WithShift</c> for uppercase 'W'.
 	/// </summary>
-	public static readonly Key W = new (KeyCode.W);
+	public static Key W => new (KeyCode.W);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the X key (un-shifted). Use <c>Key.X.WithShift</c> for uppercase 'X'.
 	/// </summary>
-	public static readonly Key X = new (KeyCode.X);
+	public static Key X => new (KeyCode.X);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Y key (un-shifted). Use <c>Key.Y.WithShift</c> for uppercase 'Y'.
 	/// </summary>
-	public static readonly Key Y = new (KeyCode.Y);
+	public static Key Y => new (KeyCode.Y);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Z key (un-shifted). Use <c>Key.Z.WithShift</c> for uppercase 'Z'.
 	/// </summary>
-	public static readonly Key Z = new (KeyCode.Z);
+	public static Key Z => new (KeyCode.Z);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Delete key.
 	/// </summary>
-	public static readonly Key Delete = new (KeyCode.Delete);
+	public static Key Delete => new (KeyCode.Delete);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for the Cursor up key.
 	/// </summary>
-	public static readonly Key CursorUp = new (KeyCode.CursorUp);
+	public static Key CursorUp => new (KeyCode.CursorUp);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Cursor down key.
 	/// </summary>
-	public static readonly Key CursorDown = new (KeyCode.CursorDown);
+	public static Key CursorDown => new (KeyCode.CursorDown);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Cursor left key.
 	/// </summary>
-	public static readonly Key CursorLeft = new (KeyCode.CursorLeft);
+	public static Key CursorLeft => new (KeyCode.CursorLeft);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Cursor right key.
 	/// </summary>
-	public static readonly Key CursorRight = new (KeyCode.CursorRight);
+	public static Key CursorRight => new (KeyCode.CursorRight);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Page Up key.
 	/// </summary>
-	public static readonly Key PageUp = new (KeyCode.PageUp);
+	public static Key PageUp => new (KeyCode.PageUp);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Page Down key.
 	/// </summary>
-	public static readonly Key PageDown = new (KeyCode.PageDown);
+	public static Key PageDown => new (KeyCode.PageDown);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Home key.
 	/// </summary>
-	public static readonly Key Home = new (KeyCode.Home);
+	public static Key Home => new (KeyCode.Home);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for End key.
 	/// </summary>
-	public static readonly Key End = new (KeyCode.End);
+	public static Key End => new (KeyCode.End);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Insert Character key.
 	/// </summary>
-	public static readonly Key InsertChar = new (KeyCode.InsertChar);
+	public static Key InsertChar => new (KeyCode.InsertChar);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Delete Character key.
 	/// </summary>
-	public static readonly Key DeleteChar = new (KeyCode.DeleteChar);
+	public static Key DeleteChar => new (KeyCode.DeleteChar);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for Print Screen key.
 	/// </summary>
-	public static readonly Key PrintScreen = new (KeyCode.PrintScreen);
+	public static Key PrintScreen => new (KeyCode.PrintScreen);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F1 key.
 	/// </summary>
-	public static readonly Key F1 = new (KeyCode.F1);
+	public static Key F1 => new (KeyCode.F1);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F2 key.
 	/// </summary>
-	public static readonly Key F2 = new (KeyCode.F2);
+	public static Key F2 => new (KeyCode.F2);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F3 key.
 	/// </summary>
-	public static readonly Key F3 = new (KeyCode.F3);
+	public static Key F3 => new (KeyCode.F3);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F4 key.
 	/// </summary>
-	public static readonly Key F4 = new (KeyCode.F4);
+	public static Key F4 => new (KeyCode.F4);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F5 key.
 	/// </summary>
-	public static readonly Key F5 = new (KeyCode.F5);
+	public static Key F5 => new (KeyCode.F5);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F6 key.
 	/// </summary>
-	public static readonly Key F6 = new (KeyCode.F6);
+	public static Key F6 => new (KeyCode.F6);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F7 key.
 	/// </summary>
-	public static readonly Key F7 = new (KeyCode.F7);
+	public static Key F7 => new (KeyCode.F7);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F8 key.
 	/// </summary>
-	public static readonly Key F8 = new (KeyCode.F8);
+	public static Key F8 => new (KeyCode.F8);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F9 key.
 	/// </summary>
-	public static readonly Key F9 = new (KeyCode.F9);
+	public static Key F9 => new (KeyCode.F9);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F10 key.
 	/// </summary>
-	public static readonly Key F10 = new (KeyCode.F10);
+	public static Key F10 => new (KeyCode.F10);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F11 key.
 	/// </summary>
-	public static readonly Key F11 = new (KeyCode.F11);
+	public static Key F11 => new (KeyCode.F11);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F12 key.
 	/// </summary>
-	public static readonly Key F12 = new (KeyCode.F12);
+	public static Key F12 => new (KeyCode.F12);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F13 key.
 	/// </summary>
-	public static readonly Key F13 = new (KeyCode.F13);
+	public static Key F13 => new (KeyCode.F13);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F14 key.
 	/// </summary>
-	public static readonly Key F14 = new (KeyCode.F14);
+	public static Key F14 => new (KeyCode.F14);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F15 key.
 	/// </summary>
-	public static readonly Key F15 = new (KeyCode.F15);
+	public static Key F15 => new (KeyCode.F15);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F16 key.
 	/// </summary>
-	public static readonly Key F16 = new (KeyCode.F16);
+	public static Key F16 => new (KeyCode.F16);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F17 key.
 	/// </summary>
-	public static readonly Key F17 = new (KeyCode.F17);
+	public static Key F17 => new (KeyCode.F17);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F18 key.
 	/// </summary>
-	public static readonly Key F18 = new (KeyCode.F18);
+	public static Key F18 => new (KeyCode.F18);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F19 key.
 	/// </summary>
-	public static readonly Key F19 = new (KeyCode.F19);
+	public static Key F19 => new (KeyCode.F19);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F20 key.
 	/// </summary>
-	public static readonly Key F20 = new (KeyCode.F20);
+	public static Key F20 => new (KeyCode.F20);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F21 key.
 	/// </summary>
-	public static readonly Key F21 = new (KeyCode.F21);
+	public static Key F21 => new (KeyCode.F21);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F22 key.
 	/// </summary>
-	public static readonly Key F22 = new (KeyCode.F22);
+	public static Key F22 => new (KeyCode.F22);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F23 key.
 	/// </summary>
-	public static readonly Key F23 = new (KeyCode.F23);
+	public static Key F23 => new (KeyCode.F23);
 
 	/// <summary>
 	/// The <see cref="Key"/> object for F24 key.
 	/// </summary>
-	public static readonly Key F24 = new (KeyCode.F24);
+	public static Key F24 => new (KeyCode.F24);
 	#endregion
 }

--- a/Terminal.Gui/Resources/config.json
+++ b/Terminal.Gui/Resources/config.json
@@ -16,15 +16,9 @@
   // to throw exceptions. 
   "ConfigurationManager.ThrowOnJsonErrors": false,
 
-  "Application.AlternateBackwardKey": {
-    "Key": "Ctrl+PageUp"
-  },
-  "Application.AlternateForwardKey": {
-    "Key": "Ctrl+PageDown"
-  },
-  "Application.QuitKey": {
-    "Key": "Ctrl+Q"
-  },
+  "Application.AlternateBackwardKey": "Ctrl+PageUp",
+  "Application.AlternateForwardKey": "Ctrl+PageDown",
+  "Application.QuitKey": "Ctrl+Q",
   "Application.IsMouseDisabled": false,
   "Theme": "Default",
   "Themes": [

--- a/UICatalog/Resources/config.json
+++ b/UICatalog/Resources/config.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://gui-cs.github.io/Terminal.Gui/schemas/tui-config-schema.json",
-  "Application.QuitKey": {
-    "Key": "Esc"
-  },
+  "Application.QuitKey": "Esc",
   "FileDialog.MaxSearchResults": 10000,
   "FileDialogStyle.DefaultUseColors": false,
   "FileDialogStyle.DefaultUseUnicodeCharacters": false,

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -506,7 +506,7 @@ class UICatalogApp {
 			miIsMenuBorderDisabled = new MenuItem {
 				Title = "Disable Menu _Border"
 			};
-			miIsMenuBorderDisabled.Shortcut = (KeyCode)((Key)miIsMenuBorderDisabled!.Title!.Substring (14, 1) [0]).WithAlt.WithCtrl;
+			miIsMenuBorderDisabled.Shortcut = (KeyCode)(new Key (miIsMenuBorderDisabled!.Title!.Substring (14, 1) [0])).WithAlt.WithCtrl;
 			miIsMenuBorderDisabled.CheckType |= MenuItemCheckStyle.Checked;
 			miIsMenuBorderDisabled.Action += () => {
 				miIsMenuBorderDisabled.Checked = (bool)!miIsMenuBorderDisabled.Checked!;
@@ -543,7 +543,7 @@ class UICatalogApp {
 			miIsMouseDisabled = new MenuItem {
 				Title = "_Disable Mouse"
 			};
-			miIsMouseDisabled.Shortcut = (KeyCode)((Key)miIsMouseDisabled!.Title!.Substring (1, 1) [0]).WithAlt.WithCtrl;
+			miIsMouseDisabled.Shortcut = (KeyCode)(new Key (miIsMouseDisabled!.Title!.Substring (1, 1) [0])).WithAlt.WithCtrl;
 			miIsMouseDisabled.CheckType |= MenuItemCheckStyle.Checked;
 			miIsMouseDisabled.Action += () => {
 				miIsMouseDisabled.Checked = Application.IsMouseDisabled = (bool)!miIsMouseDisabled.Checked!;
@@ -582,7 +582,7 @@ class UICatalogApp {
 			foreach (Enum diag in Enum.GetValues (_diagnosticFlags.GetType ())) {
 				var item = new MenuItem {
 					Title = GetDiagnosticsTitle (diag),
-					Shortcut = (KeyCode)((Key)index.ToString () [0]).WithAlt
+					Shortcut = (KeyCode)(new Key(index.ToString () [0])).WithAlt
 				};
 				index++;
 				item.CheckType |= MenuItemCheckStyle.Checked;
@@ -675,7 +675,7 @@ class UICatalogApp {
 			foreach (var theme in Themes!) {
 				var item = new MenuItem {
 					Title = $"_{theme.Key}",
-					Shortcut = (KeyCode)((Key)((int)KeyCode.D1 + schemeCount++)).WithCtrl
+					Shortcut = (KeyCode)(new Key ((KeyCode)((uint)KeyCode.D1 + (schemeCount++))).WithCtrl)
 				};
 				item.CheckType |= MenuItemCheckStyle.Checked;
 				item.Checked = theme.Key == _cachedTheme; // CM.Themes.Theme;

--- a/UnitTests/Configuration/ConfigurationMangerTests.cs
+++ b/UnitTests/Configuration/ConfigurationMangerTests.cs
@@ -7,359 +7,357 @@ using System.Text.Json;
 using Xunit;
 using static Terminal.Gui.ConfigurationManager;
 
-namespace Terminal.Gui.ConfigurationTests {
-	public class ConfigurationManagerTests {
+namespace Terminal.Gui.ConfigurationTests; 
 
-		public static readonly JsonSerializerOptions _jsonOptions = new () {
-			Converters = {
-				new AttributeJsonConverter (),
-				new ColorJsonConverter (),
-				}
-		};
-
-		[Fact ()]
-		public void DeepMemberwiseCopyTest ()
-		{
-			// Value types
-			var stringDest = "Destination";
-			var stringSrc = "Source";
-			var stringCopy = DeepMemberwiseCopy (stringSrc, stringDest);
-			Assert.Equal (stringSrc, stringCopy);
-
-			stringDest = "Destination";
-			stringSrc = "Destination";
-			stringCopy = DeepMemberwiseCopy (stringSrc, stringDest);
-			Assert.Equal (stringSrc, stringCopy);
-
-			stringDest = "Destination";
-			stringSrc = null;
-			stringCopy = DeepMemberwiseCopy (stringSrc, stringDest);
-			Assert.Equal (stringSrc, stringCopy);
-
-			stringDest = "Destination";
-			stringSrc = string.Empty;
-			stringCopy = DeepMemberwiseCopy (stringSrc, stringDest);
-			Assert.Equal (stringSrc, stringCopy);
-
-			var boolDest = true;
-			var boolSrc = false;
-			var boolCopy = DeepMemberwiseCopy (boolSrc, boolDest);
-			Assert.Equal (boolSrc, boolCopy);
-
-			boolDest = false;
-			boolSrc = true;
-			boolCopy = DeepMemberwiseCopy (boolSrc, boolDest);
-			Assert.Equal (boolSrc, boolCopy);
-
-			boolDest = true;
-			boolSrc = true;
-			boolCopy = DeepMemberwiseCopy (boolSrc, boolDest);
-			Assert.Equal (boolSrc, boolCopy);
-
-			boolDest = false;
-			boolSrc = false;
-			boolCopy = DeepMemberwiseCopy (boolSrc, boolDest);
-			Assert.Equal (boolSrc, boolCopy);
-
-			// Structs
-			var attrDest = new Attribute (Color.Black);
-			var attrSrc = new Attribute (Color.White);
-			var attrCopy = DeepMemberwiseCopy (attrSrc, attrDest);
-			Assert.Equal (attrSrc, attrCopy);
-
-			// Classes
-			var colorschemeDest = new ColorScheme () { Disabled = new Attribute (Color.Black) };
-			var colorschemeSrc = new ColorScheme () { Disabled = new Attribute (Color.White) };
-			var colorschemeCopy = DeepMemberwiseCopy (colorschemeSrc, colorschemeDest);
-			Assert.Equal (colorschemeSrc, colorschemeCopy);
-
-			// Dictionaries
-			var dictDest = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.Black) } };
-			var dictSrc = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.White) } };
-			var dictCopy = (Dictionary<string, Attribute>)DeepMemberwiseCopy (dictSrc, dictDest);
-			Assert.Equal (dictSrc, dictCopy);
-
-			dictDest = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.Black) } };
-			dictSrc = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.White) }, { "Normal", new Attribute (Color.Blue) } };
-			dictCopy = (Dictionary<string, Attribute>)DeepMemberwiseCopy (dictSrc, dictDest);
-			Assert.Equal (dictSrc, dictCopy);
-
-			// src adds an item
-			dictDest = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.Black) } };
-			dictSrc = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.White) }, { "Normal", new Attribute (Color.Blue) } };
-			dictCopy = (Dictionary<string, Attribute>)DeepMemberwiseCopy (dictSrc, dictDest);
-			Assert.Equal (2, dictCopy.Count);
-			Assert.Equal (dictSrc ["Disabled"], dictCopy ["Disabled"]);
-			Assert.Equal (dictSrc ["Normal"], dictCopy ["Normal"]);
-
-			// src updates only one item
-			dictDest = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.Black) }, { "Normal", new Attribute (Color.White) } };
-			dictSrc = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.White) } };
-			dictCopy = (Dictionary<string, Attribute>)DeepMemberwiseCopy (dictSrc, dictDest);
-			Assert.Equal (2, dictCopy.Count);
-			Assert.Equal (dictSrc ["Disabled"], dictCopy ["Disabled"]);
-			Assert.Equal (dictDest ["Normal"], dictCopy ["Normal"]);
+public class ConfigurationManagerTests {
+	public static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions {
+		Converters = {
+			new AttributeJsonConverter (),
+			new ColorJsonConverter ()
 		}
+	};
 
-		//[Fact ()]
-		//public void LoadFromJsonTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+	[Fact ()]
+	public void DeepMemberwiseCopyTest ()
+	{
+		// Value types
+		string stringDest = "Destination";
+		string stringSrc = "Source";
+		object stringCopy = DeepMemberwiseCopy (stringSrc, stringDest);
+		Assert.Equal (stringSrc, stringCopy);
 
-		//[Fact ()]
-		//public void ToJsonTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		stringDest = "Destination";
+		stringSrc = "Destination";
+		stringCopy = DeepMemberwiseCopy (stringSrc, stringDest);
+		Assert.Equal (stringSrc, stringCopy);
 
-		//[Fact ()]
-		//public void UpdateConfigurationTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		stringDest = "Destination";
+		stringSrc = null;
+		stringCopy = DeepMemberwiseCopy (stringSrc, stringDest);
+		Assert.Equal (stringSrc, stringCopy);
 
-		//[Fact ()]
-		//public void UpdateConfigurationFromFileTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		stringDest = "Destination";
+		stringSrc = string.Empty;
+		stringCopy = DeepMemberwiseCopy (stringSrc, stringDest);
+		Assert.Equal (stringSrc, stringCopy);
 
-		//[Fact ()]
-		//public void SaveHardCodedDefaultsTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		bool boolDest = true;
+		bool boolSrc = false;
+		object boolCopy = DeepMemberwiseCopy (boolSrc, boolDest);
+		Assert.Equal (boolSrc, boolCopy);
 
-		//[Fact ()]
-		//public void LoadGlobalFromLibraryResourceTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		boolDest = false;
+		boolSrc = true;
+		boolCopy = DeepMemberwiseCopy (boolSrc, boolDest);
+		Assert.Equal (boolSrc, boolCopy);
 
-		//[Fact ()]
-		//public void LoadGlobalFromAppDirectoryTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		boolDest = true;
+		boolSrc = true;
+		boolCopy = DeepMemberwiseCopy (boolSrc, boolDest);
+		Assert.Equal (boolSrc, boolCopy);
 
-		//[Fact ()]
-		//public void LoadGlobalFromHomeDirectoryTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		boolDest = false;
+		boolSrc = false;
+		boolCopy = DeepMemberwiseCopy (boolSrc, boolDest);
+		Assert.Equal (boolSrc, boolCopy);
 
-		//[Fact ()]
-		//public void LoadAppFromAppResourcesTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		// Structs
+		var attrDest = new Attribute (Color.Black);
+		var attrSrc = new Attribute (Color.White);
+		object attrCopy = DeepMemberwiseCopy (attrSrc, attrDest);
+		Assert.Equal (attrSrc, attrCopy);
 
-		//[Fact ()]
-		//public void LoadAppFromAppDirectoryTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		// Classes
+		var colorschemeDest = new ColorScheme () { Disabled = new Attribute (Color.Black) };
+		var colorschemeSrc = new ColorScheme () { Disabled = new Attribute (Color.White) };
+		object colorschemeCopy = DeepMemberwiseCopy (colorschemeSrc, colorschemeDest);
+		Assert.Equal (colorschemeSrc, colorschemeCopy);
 
-		//[Fact ()]
-		//public void LoadAppFromHomeDirectoryTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		// Dictionaries
+		var dictDest = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.Black) } };
+		var dictSrc = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.White) } };
+		var dictCopy = (Dictionary<string, Attribute>)DeepMemberwiseCopy (dictSrc, dictDest);
+		Assert.Equal (dictSrc, dictCopy);
 
-		//[Fact ()]
-		//public void LoadTest ()
-		//{
-		//	Assert.True (false, "This test needs an implementation");
-		//}
+		dictDest = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.Black) } };
+		dictSrc = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.White) }, { "Normal", new Attribute (Color.Blue) } };
+		dictCopy = (Dictionary<string, Attribute>)DeepMemberwiseCopy (dictSrc, dictDest);
+		Assert.Equal (dictSrc, dictCopy);
 
-		/// <summary>
-		/// Save the `config.json` file; this can be used to update the file in `Terminal.Gui.Resources.config.json'.
-		/// </summary>
-		/// <remarks>
-		/// IMPORTANT: For the file generated to be valid, this must be the ONLY test run. Config Properties
-		/// are all static and thus can be overwritten by other tests.</remarks>
-		[Fact]
-		public void SaveDefaults ()
-		{
-			ConfigurationManager.Initialize ();
-			ConfigurationManager.Reset ();
+		// src adds an item
+		dictDest = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.Black) } };
+		dictSrc = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.White) }, { "Normal", new Attribute (Color.Blue) } };
+		dictCopy = (Dictionary<string, Attribute>)DeepMemberwiseCopy (dictSrc, dictDest);
+		Assert.Equal (2, dictCopy.Count);
+		Assert.Equal (dictSrc ["Disabled"], dictCopy ["Disabled"]);
+		Assert.Equal (dictSrc ["Normal"], dictCopy ["Normal"]);
 
-			// Get the hard coded settings
-			ConfigurationManager.GetHardCodedDefaults ();
+		// src updates only one item
+		dictDest = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.Black) }, { "Normal", new Attribute (Color.White) } };
+		dictSrc = new Dictionary<string, Attribute> () { { "Disabled", new Attribute (Color.White) } };
+		dictCopy = (Dictionary<string, Attribute>)DeepMemberwiseCopy (dictSrc, dictDest);
+		Assert.Equal (2, dictCopy.Count);
+		Assert.Equal (dictSrc ["Disabled"], dictCopy ["Disabled"]);
+		Assert.Equal (dictDest ["Normal"], dictCopy ["Normal"]);
+	}
 
-			// Serialize to a JSON string
-			string json = ConfigurationManager.ToJson ();
+	//[Fact ()]
+	//public void LoadFromJsonTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-			// Write the JSON string to the file 
-			File.WriteAllText ("config.json", json);
-		}
+	//[Fact ()]
+	//public void ToJsonTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-		[Fact]
-		public void UseWithoutResetAsserts ()
-		{
-			ConfigurationManager.Initialize ();
-			Assert.Throws<InvalidOperationException> (() => _ = ConfigurationManager.Settings);
-		}
+	//[Fact ()]
+	//public void UpdateConfigurationTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-		[Fact]
-		public void Reset_Resets ()
-		{
-			ConfigurationManager.Locations = ConfigLocations.DefaultOnly;
-			ConfigurationManager.Reset ();
-			Assert.NotEmpty (ConfigurationManager.Themes);
-			Assert.Equal ("Default", ConfigurationManager.Themes.Theme);
-		}
+	//[Fact ()]
+	//public void UpdateConfigurationFromFileTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-		[Fact]
-		public void Reset_and_ResetLoadWithLibraryResourcesOnly_are_same ()
-		{
-			ConfigurationManager.Locations = ConfigLocations.DefaultOnly;
-			// arrange
-			ConfigurationManager.Reset ();
-			ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
-			ConfigurationManager.Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
-			ConfigurationManager.Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
-			ConfigurationManager.Settings ["Application.IsMouseDisabled"].PropertyValue = true;
-			ConfigurationManager.Settings.Apply ();
+	//[Fact ()]
+	//public void SaveHardCodedDefaultsTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-			// assert apply worked
-			Assert.Equal (KeyCode.Q, Application.QuitKey.KeyCode);
-			Assert.Equal (KeyCode.F, Application.AlternateForwardKey.KeyCode);
-			Assert.Equal (KeyCode.B, Application.AlternateBackwardKey.KeyCode);
-			Assert.True (Application.IsMouseDisabled);
+	//[Fact ()]
+	//public void LoadGlobalFromLibraryResourceTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-			//act
-			ConfigurationManager.Reset ();
+	//[Fact ()]
+	//public void LoadGlobalFromAppDirectoryTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-			// assert
-			Assert.NotEmpty (ConfigurationManager.Themes);
-			Assert.Equal ("Default", ConfigurationManager.Themes.Theme);
-			Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
-			Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, Application.AlternateForwardKey.KeyCode);
-			Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, Application.AlternateBackwardKey.KeyCode);
-			Assert.False (Application.IsMouseDisabled);
+	//[Fact ()]
+	//public void LoadGlobalFromHomeDirectoryTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-			// arrange
-			ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
-			ConfigurationManager.Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
-			ConfigurationManager.Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
-			ConfigurationManager.Settings ["Application.IsMouseDisabled"].PropertyValue = true;
-			ConfigurationManager.Settings.Apply ();
+	//[Fact ()]
+	//public void LoadAppFromAppResourcesTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-			ConfigurationManager.Locations = ConfigLocations.DefaultOnly;
+	//[Fact ()]
+	//public void LoadAppFromAppDirectoryTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-			// act
-			ConfigurationManager.Reset ();
-			ConfigurationManager.Load ();
+	//[Fact ()]
+	//public void LoadAppFromHomeDirectoryTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-			// assert
-			Assert.NotEmpty (ConfigurationManager.Themes);
-			Assert.Equal ("Default", ConfigurationManager.Themes.Theme);
-			Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
-			Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, Application.AlternateForwardKey.KeyCode);
-			Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, Application.AlternateBackwardKey.KeyCode);
-			Assert.False (Application.IsMouseDisabled);
+	//[Fact ()]
+	//public void LoadTest ()
+	//{
+	//	Assert.True (false, "This test needs an implementation");
+	//}
 
-		}
+	/// <summary>
+	/// Save the `config.json` file; this can be used to update the file in `Terminal.Gui.Resources.config.json'.
+	/// </summary>
+	/// <remarks>
+	/// IMPORTANT: For the file generated to be valid, this must be the ONLY test run. Config Properties
+	/// are all static and thus can be overwritten by other tests.</remarks>
+	[Fact]
+	public void SaveDefaults ()
+	{
+		Initialize ();
+		Reset ();
 
-		[Fact]
-		public void TestConfigProperties ()
-		{
-			ConfigurationManager.Locations = ConfigLocations.All;
-			ConfigurationManager.Reset ();
+		// Get the hard coded settings
+		GetHardCodedDefaults ();
 
-			Assert.NotEmpty (ConfigurationManager.Settings);
-			// test that all ConfigProperites have our attribute
-			Assert.All (ConfigurationManager.Settings, item => Assert.NotEmpty (item.Value.PropertyInfo.CustomAttributes.Where (a => a.AttributeType == typeof (SerializableConfigurationProperty))));
-			Assert.Empty (ConfigurationManager.Settings.Where (cp => cp.Value.PropertyInfo.GetCustomAttribute (typeof (SerializableConfigurationProperty)) == null));
+		// Serialize to a JSON string
+		string json = ToJson ();
 
-			// Application is a static class
-			PropertyInfo pi = typeof (Application).GetProperty ("QuitKey");
-			Assert.Equal (pi, ConfigurationManager.Settings ["Application.QuitKey"].PropertyInfo);
+		// Write the JSON string to the file 
+		File.WriteAllText ("config.json", json);
+	}
 
-			// FrameView is not a static class and DefaultBorderStyle is Scope.Scheme
-			pi = typeof (FrameView).GetProperty ("DefaultBorderStyle");
-			Assert.False (ConfigurationManager.Settings.ContainsKey ("FrameView.DefaultBorderStyle"));
-			Assert.True (ConfigurationManager.Themes ["Default"].ContainsKey ("FrameView.DefaultBorderStyle"));
-		}
+	[Fact]
+	public void UseWithoutResetAsserts ()
+	{
+		Initialize ();
+		Assert.Throws<InvalidOperationException> (() => _ = Settings);
+	}
 
-		[Fact]
-		public void TestConfigPropertyOmitClassName ()
-		{
-			// Color.ColorShemes is serialzied as "ColorSchemes", not "Colors.ColorSchemes"
-			PropertyInfo pi = typeof (Colors).GetProperty ("ColorSchemes");
-			var scp = ((SerializableConfigurationProperty)pi.GetCustomAttribute (typeof (SerializableConfigurationProperty)));
-			Assert.True (scp.Scope == typeof (ThemeScope));
-			Assert.True (scp.OmitClassName);
+	[Fact]
+	public void Reset_Resets ()
+	{
+		Locations = ConfigLocations.DefaultOnly;
+		Reset ();
+		Assert.NotEmpty (Themes);
+		Assert.Equal ("Default", Themes.Theme);
+	}
 
-			ConfigurationManager.Reset ();
-			Assert.Equal (pi, ConfigurationManager.Themes ["Default"] ["ColorSchemes"].PropertyInfo);
-		}
+	[Fact]
+	public void Reset_and_ResetLoadWithLibraryResourcesOnly_are_same ()
+	{
+		Locations = ConfigLocations.DefaultOnly;
+		// arrange
+		Reset ();
+		Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
+		Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
+		Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
+		Settings ["Application.IsMouseDisabled"].PropertyValue = true;
+		Settings.Apply ();
 
-		[Fact, AutoInitShutdown]
-		public void TestConfigurationManagerToJson ()
-		{
-			ConfigurationManager.Reset ();
-			ConfigurationManager.GetHardCodedDefaults ();
-			var stream = ConfigurationManager.ToStream ();
+		// assert apply worked
+		Assert.Equal (KeyCode.Q, Application.QuitKey.KeyCode);
+		Assert.Equal (KeyCode.F, Application.AlternateForwardKey.KeyCode);
+		Assert.Equal (KeyCode.B, Application.AlternateBackwardKey.KeyCode);
+		Assert.True (Application.IsMouseDisabled);
 
-			ConfigurationManager.Settings.Update (stream, "TestConfigurationManagerToJson");
-		}
+		//act
+		Reset ();
 
-		[Fact, AutoInitShutdown (configLocation: ConfigLocations.None)]
-		public void TestConfigurationManagerInitDriver_NoLocations ()
-		{
+		// assert
+		Assert.NotEmpty (Themes);
+		Assert.Equal ("Default", Themes.Theme);
+		Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
+		Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, Application.AlternateForwardKey.KeyCode);
+		Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, Application.AlternateBackwardKey.KeyCode);
+		Assert.False (Application.IsMouseDisabled);
+
+		// arrange
+		Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
+		Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
+		Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
+		Settings ["Application.IsMouseDisabled"].PropertyValue = true;
+		Settings.Apply ();
+
+		Locations = ConfigLocations.DefaultOnly;
+
+		// act
+		Reset ();
+		Load ();
+
+		// assert
+		Assert.NotEmpty (Themes);
+		Assert.Equal ("Default", Themes.Theme);
+		Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
+		Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, Application.AlternateForwardKey.KeyCode);
+		Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, Application.AlternateBackwardKey.KeyCode);
+		Assert.False (Application.IsMouseDisabled);
+
+	}
+
+	[Fact]
+	public void TestConfigProperties ()
+	{
+		Locations = ConfigLocations.All;
+		Reset ();
+
+		Assert.NotEmpty (Settings);
+		// test that all ConfigProperites have our attribute
+		Assert.All (Settings, item => Assert.NotEmpty (item.Value.PropertyInfo.CustomAttributes.Where (a => a.AttributeType == typeof (SerializableConfigurationProperty))));
+		Assert.Empty (Settings.Where (cp => cp.Value.PropertyInfo.GetCustomAttribute (typeof (SerializableConfigurationProperty)) == null));
+
+		// Application is a static class
+		var pi = typeof (Application).GetProperty ("QuitKey");
+		Assert.Equal (pi, Settings ["Application.QuitKey"].PropertyInfo);
+
+		// FrameView is not a static class and DefaultBorderStyle is Scope.Scheme
+		pi = typeof (FrameView).GetProperty ("DefaultBorderStyle");
+		Assert.False (Settings.ContainsKey ("FrameView.DefaultBorderStyle"));
+		Assert.True (Themes ["Default"].ContainsKey ("FrameView.DefaultBorderStyle"));
+	}
+
+	[Fact]
+	public void TestConfigPropertyOmitClassName ()
+	{
+		// Color.ColorShemes is serialzied as "ColorSchemes", not "Colors.ColorSchemes"
+		var pi = typeof (Colors).GetProperty ("ColorSchemes");
+		var scp = (SerializableConfigurationProperty)pi.GetCustomAttribute (typeof (SerializableConfigurationProperty));
+		Assert.True (scp.Scope == typeof (ThemeScope));
+		Assert.True (scp.OmitClassName);
+
+		Reset ();
+		Assert.Equal (pi, Themes ["Default"] ["ColorSchemes"].PropertyInfo);
+	}
+
+	[Fact] [AutoInitShutdown]
+	public void TestConfigurationManagerToJson ()
+	{
+		Reset ();
+		GetHardCodedDefaults ();
+		var stream = ToStream ();
+
+		Settings.Update (stream, "TestConfigurationManagerToJson");
+	}
+
+	[Fact] [AutoInitShutdown (configLocation: ConfigLocations.None)]
+	public void TestConfigurationManagerInitDriver_NoLocations ()
+	{
 
 
-		}
+	}
 
-		[Fact, AutoInitShutdown (configLocation: ConfigLocations.DefaultOnly)]
-		public void TestConfigurationManagerInitDriver ()
-		{
-			Assert.Equal ("Default", ConfigurationManager.Themes.Theme);
-			Assert.True (ConfigurationManager.Themes.ContainsKey ("Default"));
+	[Fact] [AutoInitShutdown (configLocation: ConfigLocations.DefaultOnly)]
+	public void TestConfigurationManagerInitDriver ()
+	{
+		Assert.Equal ("Default", Themes.Theme);
+		Assert.True (Themes.ContainsKey ("Default"));
 
-			Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
+		Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
 
-			Assert.Equal (new Color (Color.White), Colors.ColorSchemes ["Base"].Normal.Foreground);
-			Assert.Equal (new Color (Color.Blue), Colors.ColorSchemes ["Base"].Normal.Background);
+		Assert.Equal (new Color (Color.White), Colors.ColorSchemes ["Base"].Normal.Foreground);
+		Assert.Equal (new Color (Color.Blue), Colors.ColorSchemes ["Base"].Normal.Background);
 
-			// Change Base
-			var json = ConfigurationManager.ToStream ();
+		// Change Base
+		var json = ToStream ();
 
-			ConfigurationManager.Settings.Update (json, "TestConfigurationManagerInitDriver");
+		Settings.Update (json, "TestConfigurationManagerInitDriver");
 
-			var colorSchemes = ((Dictionary<string, ColorScheme>)ConfigurationManager.Themes [ConfigurationManager.Themes.Theme] ["ColorSchemes"].PropertyValue);
-			Assert.Equal (Colors.Base, colorSchemes ["Base"]);
-			Assert.Equal (Colors.TopLevel, colorSchemes ["TopLevel"]);
-			Assert.Equal (Colors.Error, colorSchemes ["Error"]);
-			Assert.Equal (Colors.Dialog, colorSchemes ["Dialog"]);
-			Assert.Equal (Colors.Menu, colorSchemes ["Menu"]);
+		var colorSchemes = (Dictionary<string, ColorScheme>)Themes [Themes.Theme] ["ColorSchemes"].PropertyValue;
+		Assert.Equal (Colors.Base, colorSchemes ["Base"]);
+		Assert.Equal (Colors.TopLevel, colorSchemes ["TopLevel"]);
+		Assert.Equal (Colors.Error, colorSchemes ["Error"]);
+		Assert.Equal (Colors.Dialog, colorSchemes ["Dialog"]);
+		Assert.Equal (Colors.Menu, colorSchemes ["Menu"]);
 
-			Colors.Base = colorSchemes ["Base"];
-			Colors.TopLevel = colorSchemes ["TopLevel"];
-			Colors.Error = colorSchemes ["Error"];
-			Colors.Dialog = colorSchemes ["Dialog"];
-			Colors.Menu = colorSchemes ["Menu"];
+		Colors.Base = colorSchemes ["Base"];
+		Colors.TopLevel = colorSchemes ["TopLevel"];
+		Colors.Error = colorSchemes ["Error"];
+		Colors.Dialog = colorSchemes ["Dialog"];
+		Colors.Menu = colorSchemes ["Menu"];
 
-			Assert.Equal (colorSchemes ["Base"], Colors.Base);
-			Assert.Equal (colorSchemes ["TopLevel"], Colors.TopLevel);
-			Assert.Equal (colorSchemes ["Error"], Colors.Error);
-			Assert.Equal (colorSchemes ["Dialog"], Colors.Dialog);
-			Assert.Equal (colorSchemes ["Menu"], Colors.Menu);
-		}
+		Assert.Equal (colorSchemes ["Base"], Colors.Base);
+		Assert.Equal (colorSchemes ["TopLevel"], Colors.TopLevel);
+		Assert.Equal (colorSchemes ["Error"], Colors.Error);
+		Assert.Equal (colorSchemes ["Dialog"], Colors.Dialog);
+		Assert.Equal (colorSchemes ["Menu"], Colors.Menu);
+	}
 
-		[Fact]
-		public void TestConfigurationManagerUpdateFromJson ()
-		{
-			// Arrange
-			string json = @"
+	[Fact]
+	public void TestConfigurationManagerUpdateFromJson ()
+	{
+		// Arrange
+		string json = @"
 {
   ""$schema"": ""https://gui-cs.github.io/Terminal.Gui/schemas/tui-config-schema.json"",
-  ""Application.QuitKey"": {
-    ""Key"": ""Alt-Z""
-  },
+  ""Application.QuitKey"": ""Alt-Z"",
   ""Theme"": ""Default"",
   ""Themes"": [
     {
@@ -493,39 +491,39 @@ namespace Terminal.Gui.ConfigurationTests {
 }					
 			";
 
-			ConfigurationManager.Reset ();
-			ConfigurationManager.ThrowOnJsonErrors = true;
+		Reset ();
+		ThrowOnJsonErrors = true;
 
-			ConfigurationManager.Settings.Update (json, "TestConfigurationManagerUpdateFromJson");
-			
-			Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
-			Assert.Equal (KeyCode.Z | KeyCode.AltMask, ((Key)ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue).KeyCode);
+		Settings.Update (json, "TestConfigurationManagerUpdateFromJson");
 
-			Assert.Equal ("Default", ConfigurationManager.Themes.Theme);
+		Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
+		Assert.Equal (KeyCode.Z | KeyCode.AltMask, ((Key)Settings ["Application.QuitKey"].PropertyValue).KeyCode);
 
-			Assert.Equal (new Color (Color.White), Colors.ColorSchemes ["Base"].Normal.Foreground);
-			Assert.Equal (new Color (Color.Blue), Colors.ColorSchemes ["Base"].Normal.Background);
+		Assert.Equal ("Default", Themes.Theme);
 
-			var colorSchemes = (Dictionary<string, ColorScheme>)Themes.First ().Value ["ColorSchemes"].PropertyValue;
-			Assert.Equal (new Color (Color.White), colorSchemes ["Base"].Normal.Foreground);
-			Assert.Equal (new Color (Color.Blue), colorSchemes ["Base"].Normal.Background);
+		Assert.Equal (new Color (Color.White), Colors.ColorSchemes ["Base"].Normal.Foreground);
+		Assert.Equal (new Color (Color.Blue), Colors.ColorSchemes ["Base"].Normal.Background);
 
-			// Now re-apply
-			ConfigurationManager.Apply ();
+		var colorSchemes = (Dictionary<string, ColorScheme>)Themes.First ().Value ["ColorSchemes"].PropertyValue;
+		Assert.Equal (new Color (Color.White), colorSchemes ["Base"].Normal.Foreground);
+		Assert.Equal (new Color (Color.Blue), colorSchemes ["Base"].Normal.Background);
 
-			Assert.Equal (KeyCode.Z | KeyCode.AltMask, Application.QuitKey.KeyCode);
-			Assert.Equal ("Default", ConfigurationManager.Themes.Theme);
+		// Now re-apply
+		Apply ();
 
-			Assert.Equal (new Color (Color.White), Colors.ColorSchemes ["Base"].Normal.Foreground);
-			Assert.Equal (new Color (Color.Blue), Colors.ColorSchemes ["Base"].Normal.Background);
-		}
+		Assert.Equal (KeyCode.Z | KeyCode.AltMask, Application.QuitKey.KeyCode);
+		Assert.Equal ("Default", Themes.Theme);
 
-		[Fact, AutoInitShutdown]
-		public void TestConfigurationManagerInvalidJsonThrows ()
-		{
-			ConfigurationManager.ThrowOnJsonErrors = true;
-			// "yellow" is not a color
-			string json = @"
+		Assert.Equal (new Color (Color.White), Colors.ColorSchemes ["Base"].Normal.Foreground);
+		Assert.Equal (new Color (Color.Blue), Colors.ColorSchemes ["Base"].Normal.Background);
+	}
+
+	[Fact] [AutoInitShutdown]
+	public void TestConfigurationManagerInvalidJsonThrows ()
+	{
+		ThrowOnJsonErrors = true;
+		// "yellow" is not a color
+		string json = @"
 			{
 				""Themes"" : [
                                         {
@@ -545,11 +543,11 @@ namespace Terminal.Gui.ConfigurationTests {
 				]
 			}";
 
-			JsonException jsonException = Assert.Throws<JsonException> (() => ConfigurationManager.Settings.Update (json, "test"));
-			Assert.Equal ("Unexpected color name: brown.", jsonException.Message);
+		var jsonException = Assert.Throws<JsonException> (() => Settings.Update (json, "test"));
+		Assert.Equal ("Unexpected color name: brown.", jsonException.Message);
 
-			// AbNormal is not a ColorScheme attribute
-			json = @"
+		// AbNormal is not a ColorScheme attribute
+		json = @"
 			{
 				""Themes"" : [ 
                                         {
@@ -569,11 +567,11 @@ namespace Terminal.Gui.ConfigurationTests {
 				]
 			}";
 
-			jsonException = Assert.Throws<JsonException> (() => ConfigurationManager.Settings.Update (json, "test"));
-			Assert.Equal ("Unrecognized ColorScheme Attribute name: AbNormal.", jsonException.Message);
+		jsonException = Assert.Throws<JsonException> (() => Settings.Update (json, "test"));
+		Assert.Equal ("Unrecognized ColorScheme Attribute name: AbNormal.", jsonException.Message);
 
-			// Modify hotNormal background only 
-			json = @"
+		// Modify hotNormal background only 
+		json = @"
 			{
 				""Themes"" : [ 
                                         {
@@ -592,31 +590,31 @@ namespace Terminal.Gui.ConfigurationTests {
 				]
 			}";
 
-			jsonException = Assert.Throws<JsonException> (() => ConfigurationManager.Settings.Update (json, "test"));
-			Assert.Equal ("Both Foreground and Background colors must be provided.", jsonException.Message);
+		jsonException = Assert.Throws<JsonException> (() => Settings.Update (json, "test"));
+		Assert.Equal ("Both Foreground and Background colors must be provided.", jsonException.Message);
 
-			// Unknown proeprty
-			json = @"
+		// Unknown proeprty
+		json = @"
 			{
 				""Unknown"" : ""Not known""
 			}";
 
-			jsonException = Assert.Throws<JsonException> (() => ConfigurationManager.Settings.Update (json, "test"));
-			Assert.StartsWith ("Unknown property", jsonException.Message);
+		jsonException = Assert.Throws<JsonException> (() => Settings.Update (json, "test"));
+		Assert.StartsWith ("Unknown property", jsonException.Message);
 
-			Assert.Equal (0, ConfigurationManager.jsonErrors.Length);
+		Assert.Equal (0, jsonErrors.Length);
 
-			ConfigurationManager.ThrowOnJsonErrors = false;
-		}
+		ThrowOnJsonErrors = false;
+	}
 
-		[Fact]
-		public void TestConfigurationManagerInvalidJsonLogs ()
-		{
-			Application.Init (new FakeDriver ());
+	[Fact]
+	public void TestConfigurationManagerInvalidJsonLogs ()
+	{
+		Application.Init (new FakeDriver ());
 
-			ConfigurationManager.ThrowOnJsonErrors = false;
-			// "brown" is not a color
-			string json = @"
+		ThrowOnJsonErrors = false;
+		// "brown" is not a color
+		string json = @"
 			{
 				""Themes"" : [ 
                                         {
@@ -636,10 +634,10 @@ namespace Terminal.Gui.ConfigurationTests {
 				}
 			}";
 
-			ConfigurationManager.Settings.Update (json, "test");
+		Settings.Update (json, "test");
 
-			// AbNormal is not a ColorScheme attribute
-			json = @"
+		// AbNormal is not a ColorScheme attribute
+		json = @"
 			{
 				""Themes"" : [ 
                                         {
@@ -659,10 +657,10 @@ namespace Terminal.Gui.ConfigurationTests {
 				}
 			}";
 
-			ConfigurationManager.Settings.Update (json, "test");
+		Settings.Update (json, "test");
 
-			// Modify hotNormal background only 
-			json = @"
+		// Modify hotNormal background only 
+		json = @"
 			{
 				""Themes"" :  [ 
                                         {
@@ -681,111 +679,109 @@ namespace Terminal.Gui.ConfigurationTests {
 				}
 			}";
 
-			ConfigurationManager.Settings.Update (json, "test");
+		Settings.Update (json, "test");
 
-			ConfigurationManager.Settings.Update ("{}}", "test");
+		Settings.Update ("{}}", "test");
 
-			Assert.NotEqual (0, ConfigurationManager.jsonErrors.Length);
+		Assert.NotEqual (0, jsonErrors.Length);
 
-			Application.Shutdown ();
+		Application.Shutdown ();
 
-			ConfigurationManager.ThrowOnJsonErrors = false;
-		}
+		ThrowOnJsonErrors = false;
+	}
 
-		[Fact, AutoInitShutdown]
-		public void LoadConfigurationFromAllSources_ShouldLoadSettingsFromAllSources ()
+	[Fact] [AutoInitShutdown]
+	public void LoadConfigurationFromAllSources_ShouldLoadSettingsFromAllSources ()
+	{
+		//var _configFilename = "config.json";
+		//// Arrange
+		//// Create a mock of the configuration files in all sources
+		//// Home directory
+		//string homeDir = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), ".tui");
+		//if (!Directory.Exists (homeDir)) {
+		//	Directory.CreateDirectory (homeDir);
+		//}
+		//string globalConfigFile = Path.Combine (homeDir, _configFilename);
+		//string appSpecificConfigFile = Path.Combine (homeDir, "appname.config.json");
+		//File.WriteAllText (globalConfigFile, "{\"Settings\": {\"TestSetting\":\"Global\"}}");
+		//File.WriteAllText (appSpecificConfigFile, "{\"Settings\": {\"TestSetting\":\"AppSpecific\"}}");
+
+		//// App directory
+		//string appDir = Directory.GetCurrentDirectory ();
+		//string appDirGlobalConfigFile = Path.Combine (appDir, _configFilename);
+		//string appDirAppSpecificConfigFile = Path.Combine (appDir, "appname.config.json");
+		//File.WriteAllText (appDirGlobalConfigFile, "{\"Settings\": {\"TestSetting\":\"GlobalAppDir\"}}");
+		//File.WriteAllText (appDirAppSpecificConfigFile, "{\"Settings\": {\"TestSetting\":\"AppSpecificAppDir\"}}");
+
+		//// App resources
+		//// ...
+
+		//// Act
+		//ConfigurationManager.Locations = ConfigurationManager.ConfigLocation.All;
+		//ConfigurationManager.Load ();
+
+		//// Assert
+		//// Check that the settings from the highest precedence source are loaded
+		//Assert.Equal ("AppSpecific", ConfigurationManager.Config.Settings.TestSetting);
+	}
+
+	[Fact]
+	public void Load_FiresUpdated ()
+	{
+		Reset ();
+
+		Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
+		Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
+		Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
+		Settings ["Application.IsMouseDisabled"].PropertyValue = true;
+
+		Updated += ConfigurationManager_Updated;
+		bool fired = false;
+		void ConfigurationManager_Updated (object sender, ConfigurationManagerEventArgs obj)
 		{
-			//var _configFilename = "config.json";
-			//// Arrange
-			//// Create a mock of the configuration files in all sources
-			//// Home directory
-			//string homeDir = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), ".tui");
-			//if (!Directory.Exists (homeDir)) {
-			//	Directory.CreateDirectory (homeDir);
-			//}
-			//string globalConfigFile = Path.Combine (homeDir, _configFilename);
-			//string appSpecificConfigFile = Path.Combine (homeDir, "appname.config.json");
-			//File.WriteAllText (globalConfigFile, "{\"Settings\": {\"TestSetting\":\"Global\"}}");
-			//File.WriteAllText (appSpecificConfigFile, "{\"Settings\": {\"TestSetting\":\"AppSpecific\"}}");
-
-			//// App directory
-			//string appDir = Directory.GetCurrentDirectory ();
-			//string appDirGlobalConfigFile = Path.Combine (appDir, _configFilename);
-			//string appDirAppSpecificConfigFile = Path.Combine (appDir, "appname.config.json");
-			//File.WriteAllText (appDirGlobalConfigFile, "{\"Settings\": {\"TestSetting\":\"GlobalAppDir\"}}");
-			//File.WriteAllText (appDirAppSpecificConfigFile, "{\"Settings\": {\"TestSetting\":\"AppSpecificAppDir\"}}");
-
-			//// App resources
-			//// ...
-
-			//// Act
-			//ConfigurationManager.Locations = ConfigurationManager.ConfigLocation.All;
-			//ConfigurationManager.Load ();
-
-			//// Assert
-			//// Check that the settings from the highest precedence source are loaded
-			//Assert.Equal ("AppSpecific", ConfigurationManager.Config.Settings.TestSetting);
-		}
-
-		[Fact]
-		public void Load_FiresUpdated ()
-		{
-			ConfigurationManager.Reset ();
-
-			ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
-			ConfigurationManager.Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
-			ConfigurationManager.Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
-			ConfigurationManager.Settings ["Application.IsMouseDisabled"].PropertyValue = true;
-
-			ConfigurationManager.Updated += ConfigurationManager_Updated;
-			bool fired = false;
-			void ConfigurationManager_Updated (object sender, ConfigurationManagerEventArgs obj)
-			{
-				fired = true;
-				// assert
-				Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, ((Key)ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue).KeyCode);
-				Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, ((Key)ConfigurationManager.Settings ["Application.AlternateForwardKey"].PropertyValue).KeyCode);
-				Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, ((Key)ConfigurationManager.Settings ["Application.AlternateBackwardKey"].PropertyValue).KeyCode);
-				Assert.False ((bool)ConfigurationManager.Settings ["Application.IsMouseDisabled"].PropertyValue);
-			}
-
-			ConfigurationManager.Load (true);
-
+			fired = true;
 			// assert
-			Assert.True (fired);
-
-			ConfigurationManager.Updated -= ConfigurationManager_Updated;
+			Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, ((Key)Settings ["Application.QuitKey"].PropertyValue).KeyCode);
+			Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, ((Key)Settings ["Application.AlternateForwardKey"].PropertyValue).KeyCode);
+			Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, ((Key)Settings ["Application.AlternateBackwardKey"].PropertyValue).KeyCode);
+			Assert.False ((bool)Settings ["Application.IsMouseDisabled"].PropertyValue);
 		}
 
-		[Fact]
-		public void Apply_FiresApplied ()
+		Load (true);
+
+		// assert
+		Assert.True (fired);
+
+		Updated -= ConfigurationManager_Updated;
+	}
+
+	[Fact]
+	public void Apply_FiresApplied ()
+	{
+		Reset ();
+		Applied += ConfigurationManager_Applied;
+		bool fired = false;
+		void ConfigurationManager_Applied (object sender, ConfigurationManagerEventArgs obj)
 		{
-			ConfigurationManager.Reset ();
-			ConfigurationManager.Applied += ConfigurationManager_Applied;
-			bool fired = false;
-			void ConfigurationManager_Applied (object sender, ConfigurationManagerEventArgs obj)
-			{
-				fired = true;
-				// assert
-				Assert.Equal (KeyCode.Q, Application.QuitKey.KeyCode);
-				Assert.Equal (KeyCode.F, Application.AlternateForwardKey.KeyCode);
-				Assert.Equal (KeyCode.B, Application.AlternateBackwardKey.KeyCode);
-				Assert.True (Application.IsMouseDisabled);
-			}
-
-			// act
-			ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
-			ConfigurationManager.Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
-			ConfigurationManager.Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
-			ConfigurationManager.Settings ["Application.IsMouseDisabled"].PropertyValue = true;
-
-			ConfigurationManager.Apply ();
-
+			fired = true;
 			// assert
-			Assert.True (fired);
-
-			ConfigurationManager.Applied -= ConfigurationManager_Applied;
+			Assert.Equal (KeyCode.Q, Application.QuitKey.KeyCode);
+			Assert.Equal (KeyCode.F, Application.AlternateForwardKey.KeyCode);
+			Assert.Equal (KeyCode.B, Application.AlternateBackwardKey.KeyCode);
+			Assert.True (Application.IsMouseDisabled);
 		}
+
+		// act
+		Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
+		Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
+		Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
+		Settings ["Application.IsMouseDisabled"].PropertyValue = true;
+
+		Apply ();
+
+		// assert
+		Assert.True (fired);
+
+		Applied -= ConfigurationManager_Applied;
 	}
 }
-

--- a/UnitTests/Configuration/JsonConverterTests.cs
+++ b/UnitTests/Configuration/JsonConverterTests.cs
@@ -278,16 +278,16 @@ public class KeyCodeJsonConverterTests {
 
 public class KeyJsonConverterTests {
 	[Theory]
-	[InlineData (KeyCode.A, "{\"Key\":\"a\"}")]
-	[InlineData ((KeyCode)'â', "{\"Key\":\"â\"}")]
-	[InlineData (KeyCode.A | KeyCode.ShiftMask, "{\"Key\":\"A\"}")]
-	[InlineData (KeyCode.A | KeyCode.CtrlMask, "{\"Key\":\"Ctrl+A\"}")]
-	[InlineData (KeyCode.A | KeyCode.AltMask | KeyCode.CtrlMask, "{\"Key\":\"Ctrl+Alt+A\"}")]
-	[InlineData ((KeyCode)'a' | KeyCode.AltMask | KeyCode.CtrlMask, "{\"Key\":\"Ctrl+Alt+A\"}")]
-	[InlineData ((KeyCode)'a' | KeyCode.ShiftMask, "{\"Key\":\"A\"}")]
-	[InlineData (KeyCode.Delete | KeyCode.AltMask | KeyCode.CtrlMask, "{\"Key\":\"Ctrl+Alt+Delete\"}")]
-	[InlineData (KeyCode.D4, "{\"Key\":\"4\"}")]
-	[InlineData (KeyCode.Esc, "{\"Key\":\"Esc\"}")]
+	[InlineData (KeyCode.A, "\"a\"")]
+	[InlineData ((KeyCode)'â', "\"â\"")]
+	[InlineData (KeyCode.A | KeyCode.ShiftMask, "\"A\"")]
+	[InlineData (KeyCode.A | KeyCode.CtrlMask, "\"Ctrl+A\"")]
+	[InlineData (KeyCode.A | KeyCode.AltMask | KeyCode.CtrlMask, "\"Ctrl+Alt+A\"")]
+	[InlineData ((KeyCode)'a' | KeyCode.AltMask | KeyCode.CtrlMask, "\"Ctrl+Alt+A\"")]
+	[InlineData ((KeyCode)'a' | KeyCode.ShiftMask, "\"A\"")]
+	[InlineData (KeyCode.Delete | KeyCode.AltMask | KeyCode.CtrlMask, "\"Ctrl+Alt+Delete\"")]
+	[InlineData (KeyCode.D4, "\"4\"")]
+	[InlineData (KeyCode.Esc, "\"Esc\"")]
 	public void TestKey_Serialize (KeyCode key, string expected)
 	{
 		// Arrange

--- a/UnitTests/Configuration/SettingsScopeTests.cs
+++ b/UnitTests/Configuration/SettingsScopeTests.cs
@@ -7,74 +7,74 @@ using System.Text;
 using System.Threading.Tasks;
 using static Terminal.Gui.ConfigurationManager;
 
-namespace Terminal.Gui.ConfigurationTests {
-	public class SettingsScopeTests {
+namespace Terminal.Gui.ConfigurationTests; 
 
-		[Fact]
-		public void GetHardCodedDefaults_ShouldSetProperties ()
-		{
-			ConfigurationManager.Reset ();
+public class SettingsScopeTests {
+	[Fact]
+	public void GetHardCodedDefaults_ShouldSetProperties ()
+	{
+		Reset ();
 
-			Assert.Equal (3, ((Dictionary<string, ThemeScope>)ConfigurationManager.Settings ["Themes"].PropertyValue).Count);
+		Assert.Equal (3, ((Dictionary<string, ThemeScope>)Settings ["Themes"].PropertyValue).Count);
 
-			ConfigurationManager.GetHardCodedDefaults ();
-			Assert.NotEmpty (ConfigurationManager.Themes);
-			Assert.Equal ("Default", ConfigurationManager.Themes.Theme);
+		GetHardCodedDefaults ();
+		Assert.NotEmpty (Themes);
+		Assert.Equal ("Default", Themes.Theme);
 
-			Assert.True (ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue is Key);
-			Assert.True (ConfigurationManager.Settings ["Application.AlternateForwardKey"].PropertyValue is Key);
-			Assert.True (ConfigurationManager.Settings ["Application.AlternateBackwardKey"].PropertyValue is Key);
-			Assert.True (ConfigurationManager.Settings ["Application.IsMouseDisabled"].PropertyValue is bool);
+		Assert.True (Settings ["Application.QuitKey"].PropertyValue is Key);
+		Assert.True (Settings ["Application.AlternateForwardKey"].PropertyValue is Key);
+		Assert.True (Settings ["Application.AlternateBackwardKey"].PropertyValue is Key);
+		Assert.True (Settings ["Application.IsMouseDisabled"].PropertyValue is bool);
 
-			Assert.True (ConfigurationManager.Settings ["Theme"].PropertyValue is string);
-			Assert.Equal ("Default", ConfigurationManager.Settings ["Theme"].PropertyValue as string);
+		Assert.True (Settings ["Theme"].PropertyValue is string);
+		Assert.Equal ("Default", Settings ["Theme"].PropertyValue as string);
 
-			Assert.True (ConfigurationManager.Settings ["Themes"].PropertyValue is Dictionary<string, ThemeScope>);
-			Assert.Single (((Dictionary<string, ThemeScope>)ConfigurationManager.Settings ["Themes"].PropertyValue));
+		Assert.True (Settings ["Themes"].PropertyValue is Dictionary<string, ThemeScope>);
+		Assert.Single ((Dictionary<string, ThemeScope>)Settings ["Themes"].PropertyValue);
 
-		}
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Apply_ShouldApplyProperties ()
-		{
-			// arrange
-			Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, ((Key)ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue).KeyCode);
-			Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, ((Key)ConfigurationManager.Settings ["Application.AlternateForwardKey"].PropertyValue).KeyCode);
-			Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, ((Key)ConfigurationManager.Settings ["Application.AlternateBackwardKey"].PropertyValue).KeyCode);
-			Assert.False ((bool)ConfigurationManager.Settings ["Application.IsMouseDisabled"].PropertyValue);
+	[Fact] [AutoInitShutdown]
+	public void Apply_ShouldApplyProperties ()
+	{
+		// arrange
+		Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, ((Key)Settings ["Application.QuitKey"].PropertyValue).KeyCode);
+		Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, ((Key)Settings ["Application.AlternateForwardKey"].PropertyValue).KeyCode);
+		Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, ((Key)Settings ["Application.AlternateBackwardKey"].PropertyValue).KeyCode);
+		Assert.False ((bool)Settings ["Application.IsMouseDisabled"].PropertyValue);
 
-			// act
-			ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
-			ConfigurationManager.Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
-			ConfigurationManager.Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
-			ConfigurationManager.Settings ["Application.IsMouseDisabled"].PropertyValue = true;
+		// act
+		Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.Q);
+		Settings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
+		Settings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
+		Settings ["Application.IsMouseDisabled"].PropertyValue = true;
 
-			ConfigurationManager.Settings.Apply ();
+		Settings.Apply ();
 
-			// assert
-			Assert.Equal (KeyCode.Q, Application.QuitKey.KeyCode);
-			Assert.Equal (KeyCode.F, Application.AlternateForwardKey.KeyCode);
-			Assert.Equal (KeyCode.B, Application.AlternateBackwardKey.KeyCode);
-			Assert.True (Application.IsMouseDisabled);
-		}
+		// assert
+		Assert.Equal (KeyCode.Q, Application.QuitKey.KeyCode);
+		Assert.Equal (KeyCode.F, Application.AlternateForwardKey.KeyCode);
+		Assert.Equal (KeyCode.B, Application.AlternateBackwardKey.KeyCode);
+		Assert.True (Application.IsMouseDisabled);
+	}
 
-		[Fact, AutoInitShutdown]
-		public void CopyUpdatedProperitesFrom_ShouldCopyChangedPropertiesOnly ()
-		{
-			ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.End); ;
+	[Fact] [AutoInitShutdown]
+	public void CopyUpdatedPropertiesFrom_ShouldCopyChangedPropertiesOnly ()
+	{
+		Settings ["Application.QuitKey"].PropertyValue = new Key (KeyCode.End);
+		;
 
-			var updatedSettings = new SettingsScope ();
+		var updatedSettings = new SettingsScope ();
 
-			///Don't set Quitkey
-			updatedSettings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
-			updatedSettings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
-			updatedSettings ["Application.IsMouseDisabled"].PropertyValue = true;
+		///Don't set Quitkey
+		updatedSettings ["Application.AlternateForwardKey"].PropertyValue = new Key (KeyCode.F);
+		updatedSettings ["Application.AlternateBackwardKey"].PropertyValue = new Key (KeyCode.B);
+		updatedSettings ["Application.IsMouseDisabled"].PropertyValue = true;
 
-			ConfigurationManager.Settings.Update (updatedSettings);
-			Assert.Equal (KeyCode.End, ((Key)ConfigurationManager.Settings ["Application.QuitKey"].PropertyValue).KeyCode);
-			Assert.Equal (KeyCode.F,  ((Key)updatedSettings ["Application.AlternateForwardKey"].PropertyValue).KeyCode);
-			Assert.Equal (KeyCode.B, ((Key)updatedSettings ["Application.AlternateBackwardKey"].PropertyValue).KeyCode);
-			Assert.True ((bool)updatedSettings ["Application.IsMouseDisabled"].PropertyValue);
-		}
+		Settings.Update (updatedSettings);
+		Assert.Equal (KeyCode.End, ((Key)Settings ["Application.QuitKey"].PropertyValue).KeyCode);
+		Assert.Equal (KeyCode.F, ((Key)updatedSettings ["Application.AlternateForwardKey"].PropertyValue).KeyCode);
+		Assert.Equal (KeyCode.B, ((Key)updatedSettings ["Application.AlternateBackwardKey"].PropertyValue).KeyCode);
+		Assert.True ((bool)updatedSettings ["Application.IsMouseDisabled"].PropertyValue);
 	}
 }

--- a/UnitTests/Input/KeyTests.cs
+++ b/UnitTests/Input/KeyTests.cs
@@ -27,6 +27,58 @@ public class KeyTests {
 		Assert.Equal (key, eventArgs.KeyCode);
 	}
 
+	[Theory]
+	[InlineData ('a', KeyCode.A)] 
+	[InlineData ('A', KeyCode.A | KeyCode.ShiftMask)] 
+	[InlineData ('z', KeyCode.Z)]
+	[InlineData ('Z', KeyCode.Z | KeyCode.ShiftMask)]
+	[InlineData (' ', KeyCode.Space)]
+	[InlineData ('1', KeyCode.D1)]
+	[InlineData ('!', (KeyCode)'!')]
+	[InlineData ('\n', KeyCode.Enter)]
+	[InlineData ('\t', KeyCode.Tab)]
+	[InlineData ('\r', (KeyCode)13)]
+	[InlineData ('ó', (KeyCode)'ó')]
+	[InlineData ('Ó', (KeyCode)'Ó')]
+	[InlineData ('❿', (KeyCode)'❿')]
+	[InlineData ('☑', (KeyCode)'☑')]
+	[InlineData ('英', (KeyCode)'英')]
+	[InlineData ('{', (KeyCode)'{')]
+	[InlineData ('\'', (KeyCode)'\'')]
+	[InlineData ('\xFFFF', (KeyCode)0xFFFF)]
+	[InlineData ('\x0', (KeyCode)0x0)]
+	public void Constructor_Char (char ch, KeyCode expectedKeyCode)
+	{
+		var key = new Key (ch);
+		Assert.Equal (expectedKeyCode, key.KeyCode);
+	}
+
+	[Theory]
+	[InlineData ('a', KeyCode.A)]
+	[InlineData ('A', KeyCode.A | KeyCode.ShiftMask)]
+	[InlineData ('z', KeyCode.Z)]
+	[InlineData ('Z', KeyCode.Z | KeyCode.ShiftMask)]
+	[InlineData (' ', KeyCode.Space)]
+	[InlineData ('1', KeyCode.D1)]
+	[InlineData ('!', (KeyCode)'!')]
+	[InlineData ('\n', KeyCode.Enter)]
+	[InlineData ('\t', KeyCode.Tab)]
+	[InlineData ('\r', (KeyCode)13)]
+	[InlineData ('ó', (KeyCode)'ó')]
+	[InlineData ('Ó', (KeyCode)'Ó')]
+	[InlineData ('❿', (KeyCode)'❿')]
+	[InlineData ('☑', (KeyCode)'☑')]
+	[InlineData ('英', (KeyCode)'英')]
+	[InlineData ('{', (KeyCode)'{')]
+	[InlineData ('\'', (KeyCode)'\'')]
+	[InlineData ('\xFFFF', (KeyCode)0xFFFF)]
+	[InlineData ('\x0', (KeyCode)0x0)]
+	public void Cast_Char_To_Key (char ch, KeyCode expectedKeyCode)
+	{
+		var key = (Key)ch;
+		Assert.Equal (expectedKeyCode, key.KeyCode);
+	}
+
 	// IsValid
 	[Theory]
 	[InlineData (KeyCode.A, true)]
@@ -255,14 +307,6 @@ public class KeyTests {
 	[InlineData (KeyCode.ShiftMask | KeyCode.AltMask | KeyCode.CursorUp, "Alt+Shift+CursorUp")]
 	[InlineData (KeyCode.AltMask | KeyCode.CtrlMask | KeyCode.CursorUp, "Ctrl+Alt+CursorUp")]
 	[InlineData (KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask | KeyCode.CursorUp, "Ctrl+Alt+Shift+CursorUp")]
-	[InlineData (KeyCode.Null, "Null")]
-	[InlineData (KeyCode.ShiftMask | KeyCode.Null, "Null")]
-	[InlineData (KeyCode.CtrlMask | KeyCode.Null, "Null")]
-	[InlineData (KeyCode.AltMask | KeyCode.Null, "Null")]
-	[InlineData (KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.Null, "Null")]
-	[InlineData (KeyCode.ShiftMask | KeyCode.AltMask | KeyCode.Null, "Null")]
-	[InlineData (KeyCode.AltMask | KeyCode.CtrlMask | KeyCode.Null, "Null")]
-	[InlineData (KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask | KeyCode.Null, "Null")]
 	[InlineData (KeyCode.Null, "Null")]
 	[InlineData (KeyCode.ShiftMask | KeyCode.Null, "Null")]
 	[InlineData (KeyCode.CtrlMask | KeyCode.Null, "Null")]

--- a/UnitTests/Input/KeyTests.cs
+++ b/UnitTests/Input/KeyTests.cs
@@ -101,9 +101,9 @@ public class KeyTests {
 
 	[Theory]
 	[InlineData("Barf")]
-	public void Constructor_String_Invalid_Throws (string kyString)
+	public void Constructor_String_Invalid_Throws (string keyString)
 	{
-
+		Assert.Throws<ArgumentException> (() => new Key (keyString));
 	}
 
 	[Theory]
@@ -130,6 +130,21 @@ public class KeyTests {
 	{
 		var key = (Key)ch;
 		Assert.Equal (expectedKeyCode, key.KeyCode);
+	}
+
+	// string cast operators
+	[Fact]
+	public void Cast_String_To_Key ()
+	{
+		var key = (Key)"Ctrl+Q";
+		Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, key.KeyCode);
+	}
+
+	[Fact]
+	public void Cast_Key_ToString ()
+	{
+		var str = (string)Key.Q.WithCtrl;
+		Assert.Equal ("Ctrl+Q", str);
 	}
 
 	// IsValid

--- a/UnitTests/Input/KeyTests.cs
+++ b/UnitTests/Input/KeyTests.cs
@@ -53,6 +53,59 @@ public class KeyTests {
 		Assert.Equal (expectedKeyCode, key.KeyCode);
 	}
 
+
+	// TryParse
+	[Theory]
+	[InlineData ("a", KeyCode.A)]
+	[InlineData ("Ctrl+A", KeyCode.A | KeyCode.CtrlMask)]
+	[InlineData ("Alt+A", KeyCode.A | KeyCode.AltMask)]
+	[InlineData ("Shift+A", KeyCode.A | KeyCode.ShiftMask)]
+	[InlineData ("A", KeyCode.A | KeyCode.ShiftMask)]
+	[InlineData ("â", (KeyCode)'â')]
+	[InlineData ("Shift+â", (KeyCode)'â' | KeyCode.ShiftMask)]
+	[InlineData ("Shift+Â", (KeyCode)'Â' | KeyCode.ShiftMask)]
+	[InlineData ("Ctrl+Shift+CursorUp", KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.CursorUp)]
+	[InlineData ("Ctrl+Alt+Shift+CursorUp", KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask | KeyCode.CursorUp)]
+	[InlineData ("ctrl+alt+shift+cursorup", KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask | KeyCode.CursorUp)]
+	[InlineData ("CTRL+ALT+SHIFT+CURSORUP", KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask | KeyCode.CursorUp)]
+	[InlineData ("Ctrl+Alt+Shift+Delete", KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask | KeyCode.Delete)]
+	[InlineData ("Ctrl+Alt+Shift+Enter", KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask | KeyCode.Enter)]
+	[InlineData ("Tab", KeyCode.Tab)]
+	[InlineData ("Shift+Tab", KeyCode.Tab | KeyCode.ShiftMask)]
+	[InlineData ("Ctrl+Tab", KeyCode.Tab | KeyCode.CtrlMask)]
+	[InlineData ("Alt+Tab", KeyCode.Tab | KeyCode.AltMask)]
+	[InlineData ("Ctrl+Shift+Tab", KeyCode.Tab | KeyCode.ShiftMask | KeyCode.CtrlMask)]
+	[InlineData ("Ctrl+Alt+Tab", KeyCode.Tab | KeyCode.AltMask | KeyCode.CtrlMask)]
+	[InlineData ("", KeyCode.Null)]
+	[InlineData (" ", KeyCode.Space)]
+	[InlineData ("Shift+ ", KeyCode.Space | KeyCode.ShiftMask)]
+	[InlineData ("Ctrl+ ", KeyCode.Space | KeyCode.CtrlMask)]
+	[InlineData ("Alt+ ", KeyCode.Space | KeyCode.AltMask)]
+	[InlineData ("F1", KeyCode.F1)]
+	[InlineData ("0", KeyCode.D0)]
+	[InlineData ("9", KeyCode.D9)]
+	[InlineData ("D0", KeyCode.D0)]
+	[InlineData ("65", KeyCode.A | KeyCode.ShiftMask)]
+	[InlineData ("97", KeyCode.A)]
+	[InlineData ("Shift", KeyCode.ShiftKey)]
+	[InlineData ("Ctrl", KeyCode.CtrlKey)]
+	[InlineData ("Ctrl-A", KeyCode.A | KeyCode.CtrlMask)]
+	[InlineData ("Alt-A", KeyCode.A | KeyCode.AltMask)]
+	[InlineData ("A-Ctrl", KeyCode.A | KeyCode.CtrlMask)]
+	[InlineData ("Alt-A-Ctrl", KeyCode.A | KeyCode.CtrlMask | KeyCode.AltMask)]
+	public void Constructor_String_Valid (string keyString, Key expected)
+	{
+		Key key = new Key (keyString);
+		Assert.Equal (((Key)expected).ToString (), key.ToString ());
+	}
+
+	[Theory]
+	[InlineData("Barf")]
+	public void Constructor_String_Invalid_Throws (string kyString)
+	{
+
+	}
+
 	[Theory]
 	[InlineData ('a', KeyCode.A)]
 	[InlineData ('A', KeyCode.A | KeyCode.ShiftMask)]

--- a/UnitTests/Input/KeyTests.cs
+++ b/UnitTests/Input/KeyTests.cs
@@ -28,8 +28,8 @@ public class KeyTests {
 	}
 
 	[Theory]
-	[InlineData ('a', KeyCode.A)] 
-	[InlineData ('A', KeyCode.A | KeyCode.ShiftMask)] 
+	[InlineData ('a', KeyCode.A)]
+	[InlineData ('A', KeyCode.A | KeyCode.ShiftMask)]
 	[InlineData ('z', KeyCode.Z)]
 	[InlineData ('Z', KeyCode.Z | KeyCode.ShiftMask)]
 	[InlineData (' ', KeyCode.Space)]
@@ -116,6 +116,28 @@ public class KeyTests {
 		Assert.Equal (expected.ToString (), key.ToString ());
 	}
 
+	[Fact]
+	public void Standard_Keys_Always_New ()
+	{
+		// Make two local keys, and grab Key.A, which is a reference to a singleton.
+		Key aKey1 = Key.A;
+		Key aKey2 = Key.A;
+
+		// Assert the starting state that is expected
+		Assert.False (aKey1.Handled);
+		Assert.False (aKey2.Handled);
+		Assert.False (Key.A.Handled);
+
+		// Now set Handled true on one of our local keys
+		aKey1.Handled = true;
+
+		// Assert the newly-expected case
+		// The last two assertions will fail, because we have actually modified a singleton
+		Assert.True (aKey1.Handled);
+		Assert.False (aKey2.Handled);
+		Assert.False (Key.A.Handled);
+	}
+
 	[Theory]
 	[InlineData ((KeyCode)'a', true)]
 	[InlineData ((KeyCode)'a' | KeyCode.ShiftMask, true)]
@@ -148,7 +170,7 @@ public class KeyTests {
 	[InlineData ((KeyCode)'ç' | KeyCode.ShiftMask | KeyCode.AltMask | KeyCode.CtrlMask, '\0')]
 	[InlineData ((KeyCode)'a', 97)] // 97 or Key.Space | Key.A
 	[InlineData ((KeyCode)'A', 97)] // 65 or equivalent to Key.A, but A-Z are mapped to lower case by drivers
-	//[InlineData (Key.A, 97)] // 65 equivalent to (Key)'A', but A-Z are mapped to lower case by drivers
+					//[InlineData (Key.A, 97)] // 65 equivalent to (Key)'A', but A-Z are mapped to lower case by drivers
 	[InlineData (KeyCode.ShiftMask | KeyCode.A, 65)]
 	[InlineData (KeyCode.CtrlMask | KeyCode.A, '\0')]
 	[InlineData (KeyCode.AltMask | KeyCode.A, '\0')]

--- a/UnitTests/Views/AppendAutocompleteTests.cs
+++ b/UnitTests/Views/AppendAutocompleteTests.cs
@@ -26,7 +26,7 @@ public class AppendAutocompleteTests {
 		tf.PositionCursor ();
 		TestHelpers.AssertDriverContentsAre ("", output);
 
-		tf.NewKeyDownEvent ('f');
+		tf.NewKeyDownEvent (new ('f'));
 
 		tf.Draw ();
 		tf.PositionCursor ();


### PR DESCRIPTION
Fixes #3071
Fixes #3079
Fixes #3081 

- [x] Adds `new Key (char)` constructor
- [x] Updates `(char)Key` cast to use char constructor
- [x] Adds unit tests
- [x] static standard key properties now always get new instance 
- [x] Adds Key constructor that takes a string
- [x] Changes KeyJsonSerializer to be far simpler (no object) and public. Removes it as an attribute on Key

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
