### PR TITLE
Add constructor overload to SliderOption<T>

### DIFF
--- a/Terminal.Gui/Views/Slider.cs
+++ b/Terminal.Gui/Views/Slider.cs
@@ -49,6 +49,25 @@ public class SliderOption<T> {
 	public T Data { get; set; }
 
 	/// <summary>
+	/// Creates a new empty instance of the <see cref="SliderOption{T}"/> class.
+	/// </summary>
+	public SliderOption ()
+	{
+
+	}
+
+	/// <summary>
+	/// Creates a new instance of the <see cref="SliderOption{T}"/> class with values for
+	/// each property.
+	/// </summary>
+	public SliderOption (string legend, Rune legendAbbr, T data)
+	{
+		Legend = legend;
+		LegendAbbr = legendAbbr;
+		Data = data;
+	}
+
+	/// <summary>
 	/// To Raise the <see cref="Set"/> event from the Slider.
 	/// </summary>
 	internal void OnSet ()

--- a/UnitTests/Views/SliderTests.cs
+++ b/UnitTests/Views/SliderTests.cs
@@ -136,6 +136,24 @@ public class SliderTests {
 	}
 
 	[Fact]
+	public void Slider_Option_Default_Constructor ()
+	{
+		var o = new SliderOption<int> ();
+		Assert.Null (o.Legend);
+		Assert.Equal (default,o.LegendAbbr);
+		Assert.Equal (default, o.Data);
+	}
+
+	[Fact]
+	public void Slider_Option_Values_Constructor()
+	{
+		var o = new SliderOption<int> ("1 thousand",new Rune('y'),1000);
+		Assert.Equal ("1 thousand", o.Legend);
+		Assert.Equal (new Rune('y'), o.LegendAbbr);
+		Assert.Equal (1000, o.Data);
+	}
+
+	[Fact]
 	public void OnOptionsChanged_Event_Raised ()
 	{
 		// Arrange

--- a/UnitTests/Views/SliderTests.cs
+++ b/UnitTests/Views/SliderTests.cs
@@ -9,6 +9,26 @@ using System.Threading.Tasks;
 namespace Terminal.Gui.ViewsTests;
 
 public class SliderOptionTests {
+
+
+	[Fact]
+	public void Slider_Option_Default_Constructor ()
+	{
+		var o = new SliderOption<int> ();
+		Assert.Null (o.Legend);
+		Assert.Equal (default, o.LegendAbbr);
+		Assert.Equal (default, o.Data);
+	}
+
+	[Fact]
+	public void Slider_Option_Values_Constructor ()
+	{
+		var o = new SliderOption<int> ("1 thousand", new Rune ('y'), 1000);
+		Assert.Equal ("1 thousand", o.Legend);
+		Assert.Equal (new Rune ('y'), o.LegendAbbr);
+		Assert.Equal (1000, o.Data);
+	}
+
 	[Fact]
 	public void OnSet_Should_Raise_SetEvent ()
 	{
@@ -133,24 +153,6 @@ public class SliderTests {
 		Assert.NotNull (slider);
 		Assert.NotNull (slider.Options);
 		Assert.Equal (options.Count, slider.Options.Count);
-	}
-
-	[Fact]
-	public void Slider_Option_Default_Constructor ()
-	{
-		var o = new SliderOption<int> ();
-		Assert.Null (o.Legend);
-		Assert.Equal (default, o.LegendAbbr);
-		Assert.Equal (default, o.Data);
-	}
-
-	[Fact]
-	public void Slider_Option_Values_Constructor ()
-	{
-		var o = new SliderOption<int> ("1 thousand", new Rune ('y'), 1000);
-		Assert.Equal ("1 thousand", o.Legend);
-		Assert.Equal (new Rune ('y'), o.LegendAbbr);
-		Assert.Equal (1000, o.Data);
 	}
 
 	[Fact]

--- a/UnitTests/Views/SliderTests.cs
+++ b/UnitTests/Views/SliderTests.cs
@@ -140,16 +140,16 @@ public class SliderTests {
 	{
 		var o = new SliderOption<int> ();
 		Assert.Null (o.Legend);
-		Assert.Equal (default,o.LegendAbbr);
+		Assert.Equal (default, o.LegendAbbr);
 		Assert.Equal (default, o.Data);
 	}
 
 	[Fact]
-	public void Slider_Option_Values_Constructor()
+	public void Slider_Option_Values_Constructor ()
 	{
-		var o = new SliderOption<int> ("1 thousand",new Rune('y'),1000);
+		var o = new SliderOption<int> ("1 thousand", new Rune ('y'), 1000);
 		Assert.Equal ("1 thousand", o.Legend);
-		Assert.Equal (new Rune('y'), o.LegendAbbr);
+		Assert.Equal (new Rune ('y'), o.LegendAbbr);
 		Assert.Equal (1000, o.Data);
 	}
 
@@ -429,7 +429,7 @@ public class SliderTests {
 
 		// Assert
 		Assert.False (result);
-		Assert.NotEmpty (slider.GetSetOptions());
+		Assert.NotEmpty (slider.GetSetOptions ());
 	}
 
 	// Add more tests for different scenarios and edge cases.


### PR DESCRIPTION
Fixes #3100- Adds new constructor to `SliderOption<T>` for populating values (Legend etc).

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
