### PR TITLE
Add ToString implementation for SliderOption<T>

### DIFF
--- a/Terminal.Gui/Views/Slider.cs
+++ b/Terminal.Gui/Views/Slider.cs
@@ -86,6 +86,12 @@ public class SliderOption<T> {
 	/// Event fired when the an option has changed.
 	/// </summary>
 	public event EventHandler<SliderOptionEventArgs> Changed;
+
+	/// <summary>
+	/// Creates a human-readable string that represents this <see cref="SliderOption{T}"/>.
+	/// </summary>
+	public override string ToString () => "{Legend=" + Legend + ", LegendAbbr=" + LegendAbbr.ToString () + ", Data=" + Data?.ToString () + "}";
+
 }
 
 /// <summary>

--- a/UnitTests/Views/SliderTests.cs
+++ b/UnitTests/Views/SliderTests.cs
@@ -62,7 +62,7 @@ public class SliderOptionTests {
 	}
 
 	[Fact]
-	public void SliderOption_ToString_WhenPopulated ()
+	public void SliderOption_ToString_WhenPopulated_WithInt ()
 	{
 		var sliderOption = new SliderOption<int> {
 			Legend = "Lord flibble",
@@ -71,6 +71,19 @@ public class SliderOptionTests {
 		};
 
 		Assert.Equal ("{Legend=Lord flibble, LegendAbbr=l, Data=1}", sliderOption.ToString ());
+	}
+
+
+	[Fact]
+	public void SliderOption_ToString_WhenPopulated_WithSizeF ()
+	{
+		var sliderOption = new SliderOption<SizeF> {
+			Legend = "Lord flibble",
+			LegendAbbr = new Rune ('l'),
+			Data = new SizeF(32,11),
+		};
+
+		Assert.Equal ("{Legend=Lord flibble, LegendAbbr=l, Data={Width=32, Height=11}}", sliderOption.ToString ());
 	}
 }
 

--- a/UnitTests/Views/SliderTests.cs
+++ b/UnitTests/Views/SliderTests.cs
@@ -53,6 +53,25 @@ public class SliderOptionTests {
 		// Assert
 		Assert.True (eventRaised);
 	}
+
+	[Fact]
+	public void SliderOption_ToString_WhenEmpty ()
+	{
+		var sliderOption = new SliderOption<object> ();
+		Assert.Equal ("{Legend=, LegendAbbr=\0, Data=}", sliderOption.ToString ());
+	}
+
+	[Fact]
+	public void SliderOption_ToString_WhenPopulated ()
+	{
+		var sliderOption = new SliderOption<int> {
+			Legend = "Lord flibble",
+			LegendAbbr = new Rune ('l'),
+			Data = 1,
+		};
+
+		Assert.Equal ("{Legend=Lord flibble, LegendAbbr=l, Data=1}", sliderOption.ToString ());
+	}
 }
 
 public class SliderEventArgsTests {
@@ -411,7 +430,7 @@ public class SliderTests {
 
 		// Assert
 		Assert.False (result);
-		Assert.NotEmpty (slider.GetSetOptions());
+		Assert.NotEmpty (slider.GetSetOptions ());
 	}
 
 	// Add more tests for different scenarios and edge cases.


### PR DESCRIPTION
Fixes #3102 - Adds ToString implementation for `SliderOption<T>`

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
