### PR TITLE
Fixes #3097. Now that View is IDisposable, it should expose a Disposing event.

### DIFF
--- a/Terminal.Gui/Input/Responder.cs
+++ b/Terminal.Gui/Input/Responder.cs
@@ -192,10 +192,10 @@ public class Responder : IDisposable {
 	{
 		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
 		Dispose (disposing: true);
+		Disposed?.Invoke (this, EventArgs.Empty);
 		GC.SuppressFinalize (this);
 #if DEBUG_IDISPOSABLE
 		WasDisposed = true;
-		Disposed?.Invoke (this, EventArgs.Empty);
 
 		foreach (var instance in Instances.Where (x => x.WasDisposed).ToList ()) {
 			Instances.Remove (instance);

--- a/Terminal.Gui/Input/Responder.cs
+++ b/Terminal.Gui/Input/Responder.cs
@@ -48,7 +48,7 @@ public class Responder : IDisposable {
 #endif
 
 	/// <summary>
-	/// Invokes subscribers that this is disposed.
+	/// Event raised when <see cref="Dispose()"/> is called to signal that this object has been disposed.
 	/// </summary>
 	public event EventHandler Disposing;
 

--- a/Terminal.Gui/Input/Responder.cs
+++ b/Terminal.Gui/Input/Responder.cs
@@ -48,6 +48,11 @@ public class Responder : IDisposable {
 #endif
 
 	/// <summary>
+	/// Invokes subscribers that this is disposed.
+	/// </summary>
+	public event EventHandler Disposing;
+
+	/// <summary>
 	/// Gets or sets a value indicating whether this <see cref="Responder"/> can focus.
 	/// </summary>
 	/// <value><c>true</c> if can focus; otherwise, <c>false</c>.</value>
@@ -187,6 +192,7 @@ public class Responder : IDisposable {
 	{
 		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
 		Dispose (disposing: true);
+		Disposing?.Invoke (this, EventArgs.Empty);
 		GC.SuppressFinalize (this);
 #if DEBUG_IDISPOSABLE
 		WasDisposed = true;

--- a/Terminal.Gui/Input/Responder.cs
+++ b/Terminal.Gui/Input/Responder.cs
@@ -48,9 +48,9 @@ public class Responder : IDisposable {
 #endif
 
 	/// <summary>
-	/// Event raised when <see cref="Dispose()"/> is called to signal that this object has been disposed.
+	/// Event raised when <see cref="Dispose()"/> has been called to signal that this object is being disposed.
 	/// </summary>
-	public event EventHandler Disposed;
+	public event EventHandler Disposing;
 
 	/// <summary>
 	/// Gets or sets a value indicating whether this <see cref="Responder"/> can focus.
@@ -191,8 +191,8 @@ public class Responder : IDisposable {
 	public void Dispose ()
 	{
 		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Disposing?.Invoke (this, EventArgs.Empty);
 		Dispose (disposing: true);
-		Disposed?.Invoke (this, EventArgs.Empty);
 		GC.SuppressFinalize (this);
 #if DEBUG_IDISPOSABLE
 		WasDisposed = true;

--- a/Terminal.Gui/Input/Responder.cs
+++ b/Terminal.Gui/Input/Responder.cs
@@ -50,7 +50,7 @@ public class Responder : IDisposable {
 	/// <summary>
 	/// Event raised when <see cref="Dispose()"/> is called to signal that this object has been disposed.
 	/// </summary>
-	public event EventHandler Disposing;
+	public event EventHandler Disposed;
 
 	/// <summary>
 	/// Gets or sets a value indicating whether this <see cref="Responder"/> can focus.
@@ -192,10 +192,10 @@ public class Responder : IDisposable {
 	{
 		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
 		Dispose (disposing: true);
-		Disposing?.Invoke (this, EventArgs.Empty);
 		GC.SuppressFinalize (this);
 #if DEBUG_IDISPOSABLE
 		WasDisposed = true;
+		Disposed?.Invoke (this, EventArgs.Empty);
 
 		foreach (var instance in Instances.Where (x => x.WasDisposed).ToList ()) {
 			Instances.Remove (instance);

--- a/UnitTests/Input/ResponderTests.cs
+++ b/UnitTests/Input/ResponderTests.cs
@@ -143,18 +143,21 @@ public class ResponderTests {
 
 		var view = new View () { Id = "View" };
 		container1.Add (view);
+		Assert.Equal (container1, view.SuperView);
 
 		Assert.Single (container1.Subviews);
 
 		var container2 = new View () { Id = "Container2" };
 
 		container2.Add (view);
+		Assert.Equal (container2, view.SuperView);
 		Assert.Equal (container1.Subviews.Count, container2.Subviews.Count);
 		container1.Dispose ();
 
 		Assert.Empty (container1.Subviews);
 		Assert.NotEmpty (container2.Subviews);
 		Assert.Single (container2.Subviews);
+		Assert.Null (view.SuperView);
 
 		// Trying access disposed properties
 		Assert.True (container2.Subviews [0].WasDisposed);
@@ -162,6 +165,7 @@ public class ResponderTests {
 		Assert.Null (container2.Subviews [0].Margin);
 		Assert.Null (container2.Subviews [0].Border);
 		Assert.Null (container2.Subviews [0].Padding);
+		Assert.Null (view.SuperView);
 
 		container2.Dispose ();
 
@@ -169,22 +173,23 @@ public class ResponderTests {
 	}
 
 	[Fact]
-	public void Disposed_Event_Notify_All_Subscribers_On_The_Second_Container ()
+	public void Disposing_Event_Notify_All_Subscribers_On_The_Second_Container ()
 	{
 		var container1 = new View () { Id = "Container1" };
 
 		var view = new View () { Id = "View" };
 		container1.Add (view);
-
+		Assert.Equal (container1, view.SuperView);
 		Assert.Single (container1.Subviews);
 
 		var container2 = new View () { Id = "Container2" };
 		var count = 0;
 
-		view.Disposed += View_Disposed;
+		view.Disposing += View_Disposing;
 		container2.Add (view);
+		Assert.Equal (container2, view.SuperView);
 
-		void View_Disposed (object sender, System.EventArgs e)
+		void View_Disposing (object sender, System.EventArgs e)
 		{
 			count++;
 			Assert.Equal (view, sender);
@@ -197,6 +202,7 @@ public class ResponderTests {
 		Assert.Empty (container1.Subviews);
 		Assert.Empty (container2.Subviews);
 		Assert.Equal (1, count);
+		Assert.Null (view.SuperView);
 
 		container2.Dispose ();
 
@@ -204,16 +210,17 @@ public class ResponderTests {
 	}
 
 	[Fact]
-	public void Disposed_Event_Notify_All_Subscribers_On_The_First_Container ()
+	public void Disposing_Event_Notify_All_Subscribers_On_The_First_Container ()
 	{
 		var container1 = new View () { Id = "Container1" };
 		var count = 0;
 
 		var view = new View () { Id = "View" };
-		view.Disposed += View_Disposed;
+		view.Disposing += View_Disposing;
 		container1.Add (view);
+		Assert.Equal (container1, view.SuperView);
 
-		void View_Disposed (object sender, System.EventArgs e)
+		void View_Disposing (object sender, System.EventArgs e)
 		{
 			count++;
 			Assert.Equal (view, sender);
@@ -225,13 +232,14 @@ public class ResponderTests {
 		var container2 = new View () { Id = "Container2" };
 
 		container2.Add (view);
-
+		Assert.Equal (container2, view.SuperView);
 		Assert.Equal (container1.Subviews.Count, container2.Subviews.Count);
 		container2.Dispose ();
 
 		Assert.Empty (container1.Subviews);
 		Assert.Empty (container2.Subviews);
 		Assert.Equal (1, count);
+		Assert.Null (view.SuperView);
 
 		container1.Dispose ();
 

--- a/UnitTests/Input/ResponderTests.cs
+++ b/UnitTests/Input/ResponderTests.cs
@@ -7,7 +7,8 @@ using Console = Terminal.Gui.FakeConsole;
 namespace Terminal.Gui.InputTests;
 
 public class ResponderTests {
-	[Fact] [TestRespondersDisposed]
+	[Fact]
+	[TestRespondersDisposed]
 	public void New_Initializes ()
 	{
 		var r = new Responder ();
@@ -20,7 +21,8 @@ public class ResponderTests {
 		r.Dispose ();
 	}
 
-	[Fact] [TestRespondersDisposed]
+	[Fact]
+	[TestRespondersDisposed]
 	public void New_Methods_Return_False ()
 	{
 		var r = new View ();
@@ -60,7 +62,8 @@ public class ResponderTests {
 	}
 
 	// Generic lifetime (IDisposable) tests
-	[Fact] [TestRespondersDisposed]
+	[Fact]
+	[TestRespondersDisposed]
 	public void Dispose_Works ()
 	{
 
@@ -84,7 +87,8 @@ public class ResponderTests {
 		}
 	}
 
-	[Fact] [TestRespondersDisposed]
+	[Fact]
+	[TestRespondersDisposed]
 	public void IsOverridden_False_IfNotOverridden ()
 	{
 		// MouseEvent IS defined on Responder but NOT overridden
@@ -107,7 +111,8 @@ public class ResponderTests {
 #endif
 	}
 
-	[Fact] [TestRespondersDisposed]
+	[Fact]
+	[TestRespondersDisposed]
 	public void IsOverridden_True_IfOverridden ()
 	{
 		// MouseEvent is defined on Responder IS overriden on ScrollBarView (but not View)
@@ -134,28 +139,22 @@ public class ResponderTests {
 	[Fact]
 	public void Responder_Not_Notifying_Dispose ()
 	{
-		List<View> views = new List<View> ();
 		var container1 = new View () { Id = "Container1" };
 
-		for (int i = 0; i < 20; i++) {
-			var view = new View () { Id = $"View{i}" };
-			views.Add (view);
-			container1.Add (view);
-		}
+		var view = new View () { Id = "View" };
+		container1.Add (view);
 
-		Assert.Equal (views.Count, container1.Subviews.Count);
+		Assert.Single (container1.Subviews);
 
 		var container2 = new View () { Id = "Container2" };
 
-		foreach (View view in views) {
-			container2.Add (view);
-		}
+		container2.Add (view);
 		Assert.Equal (container1.Subviews.Count, container2.Subviews.Count);
 		container1.Dispose ();
 
 		Assert.Empty (container1.Subviews);
 		Assert.NotEmpty (container2.Subviews);
-		Assert.Equal (views.Count, container2.Subviews.Count);
+		Assert.Single (container2.Subviews);
 
 		// Trying access disposed properties
 		Assert.True (container2.Subviews [0].WasDisposed);
@@ -170,31 +169,25 @@ public class ResponderTests {
 	}
 
 	[Fact]
-	public void Disposing_Event_Notify_All_Subscribers_On_The_Second_Container ()
+	public void Disposed_Event_Notify_All_Subscribers_On_The_Second_Container ()
 	{
-		List<View> views = new List<View> ();
 		var container1 = new View () { Id = "Container1" };
 
-		for (int i = 0; i < 20; i++) {
-			var view = new View () { Id = $"View{i}" };
-			views.Add (view);
-			container1.Add(view);
-		}
+		var view = new View () { Id = "View" };
+		container1.Add (view);
 
-		Assert.Equal (views.Count, container1.Subviews.Count);
+		Assert.Single (container1.Subviews);
 
 		var container2 = new View () { Id = "Container2" };
 		var count = 0;
 
-		foreach (View view in views) {
-			view.Disposing += View_Disposing;
-			container2.Add (view);
-		}
+		view.Disposed += View_Disposed;
+		container2.Add (view);
 
-		void View_Disposing (object sender, System.EventArgs e)
+		void View_Disposed (object sender, System.EventArgs e)
 		{
 			count++;
-			Assert.Equal (views [views.Count - count], sender);
+			Assert.Equal (view, sender);
 			container2.Remove ((View)sender);
 		}
 
@@ -203,7 +196,7 @@ public class ResponderTests {
 
 		Assert.Empty (container1.Subviews);
 		Assert.Empty (container2.Subviews);
-		Assert.Equal (count, views.Count);
+		Assert.Equal (1, count);
 
 		container2.Dispose ();
 
@@ -211,40 +204,34 @@ public class ResponderTests {
 	}
 
 	[Fact]
-	public void Disposing_Event_Notify_All_Subscribers_On_The_First_Container ()
+	public void Disposed_Event_Notify_All_Subscribers_On_The_First_Container ()
 	{
-		List<View> views = new List<View> ();
 		var container1 = new View () { Id = "Container1" };
 		var count = 0;
 
-		for (int i = 0; i < 20; i++) {
-			var view = new View () { Id = $"View{i}" };
-			view.Disposing += View_Disposing;
-			views.Add (view);
-			container1.Add (view);
-		}
+		var view = new View () { Id = "View" };
+		view.Disposed += View_Disposed;
+		container1.Add (view);
 
-		void View_Disposing (object sender, System.EventArgs e)
+		void View_Disposed (object sender, System.EventArgs e)
 		{
 			count++;
-			Assert.Equal (views [views.Count - count], sender);
+			Assert.Equal (view, sender);
 			container1.Remove ((View)sender);
 		}
 
-		Assert.Equal (views.Count, container1.Subviews.Count);
+		Assert.Single (container1.Subviews);
 
 		var container2 = new View () { Id = "Container2" };
 
-		foreach (View view in views) {
-			container2.Add (view);
-		}
+		container2.Add (view);
 
 		Assert.Equal (container1.Subviews.Count, container2.Subviews.Count);
 		container2.Dispose ();
 
 		Assert.Empty (container1.Subviews);
 		Assert.Empty (container2.Subviews);
-		Assert.Equal (count, views.Count);
+		Assert.Equal (1, count);
 
 		container1.Dispose ();
 

--- a/UnitTests/Input/ResponderTests.cs
+++ b/UnitTests/Input/ResponderTests.cs
@@ -157,6 +157,13 @@ public class ResponderTests {
 		Assert.NotEmpty (container2.Subviews);
 		Assert.Equal (views.Count, container2.Subviews.Count);
 
+		// Trying access disposed properties
+		Assert.True (container2.Subviews [0].WasDisposed);
+		Assert.False (container2.Subviews [0].CanFocus);
+		Assert.Null (container2.Subviews [0].Margin);
+		Assert.Null (container2.Subviews [0].Border);
+		Assert.Null (container2.Subviews [0].Padding);
+
 		container2.Dispose ();
 
 		Assert.Empty (Responder.Instances);


### PR DESCRIPTION
Fixes #3097 - Added `Disposing` event which will help to take the necessary measure when needed.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
