### PR TITLE
Fixes #3106: Combo Box selection fixes

### DIFF
--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -759,13 +759,13 @@ namespace Terminal.Gui {
 			isShow = false;
 		}
 
-		private int GetSelectedItemFromSource (string value)
+		private int GetSelectedItemFromSource (string searchText)
 		{
-			if (source == null) {
+			if (source is null) {
 				return -1;
 			}
 			for (int i = 0; i < searchset.Count; i++) {
-				if (searchset [i].ToString () == value) {
+				if (searchset [i].ToString () == searchText) {
 					return i;
 				}
 			}

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -815,13 +815,16 @@ namespace Terminal.Gui {
 
 		private void Search_Changed (object sender, TextChangedEventArgs e)
 		{
-			if (source == null) { // Object initialization		
+			if (source is null) { // Object initialization		
 				return;
 			}
 
 			if (string.IsNullOrEmpty (search.Text) && string.IsNullOrEmpty (e.OldValue)) {
 				ResetSearchSet ();
 			} else if (search.Text != e.OldValue) {
+				if (search.Text.Length < e.OldValue.Length) {
+					selectedItem = -1;
+				}
 				isShow = true;
 				ResetSearchSet (noCopy: true);
 

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -764,8 +764,8 @@ namespace Terminal.Gui {
 			if (source == null) {
 				return -1;
 			}
-			for (int i = 0; i < source.Count; i++) {
-				if (source.ToList () [i].ToString () == value) {
+			for (int i = 0; i < searchset.Count; i++) {
+				if (searchset [i].ToString () == value) {
 					return i;
 				}
 			}

--- a/UnitTests/Views/ComboBoxTests.cs
+++ b/UnitTests/Views/ComboBoxTests.cs
@@ -256,7 +256,7 @@ Three
 			Assert.Equal ("One", cb.Text);
 			cb.Text = "T";
 			Assert.True (cb.IsShow);
-			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal (-1, cb.SelectedItem);
 			Assert.Equal ("T", cb.Text);
 			Assert.True (cb.NewKeyDownEvent (new (KeyCode.Enter)));
 			Assert.False (cb.IsShow);

--- a/UnitTests/Views/ComboBoxTests.cs
+++ b/UnitTests/Views/ComboBoxTests.cs
@@ -215,17 +215,17 @@ Three
 			Assert.True (cb.NewKeyDownEvent (new (KeyCode.CursorDown))); // losing focus
 			Assert.False (cb.HasFocus);
 			Assert.False (cb.IsShow);
-			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal (-1, cb.SelectedItem);
 			Assert.Equal ("One", cb.Text);
 			Application.Top.FocusFirst (); // Gets focus again
 			Assert.True (cb.HasFocus);
 			Assert.False (cb.IsShow);
-			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal (-1, cb.SelectedItem);
 			Assert.Equal ("One", cb.Text);
 			Assert.True (cb.NewKeyDownEvent (new (KeyCode.U | KeyCode.CtrlMask)));
 			Assert.True (cb.HasFocus);
 			Assert.True (cb.IsShow);
-			Assert.Equal (0, cb.SelectedItem);
+			Assert.Equal (-1, cb.SelectedItem);
 			Assert.Equal ("", cb.Text);
 			Assert.Equal (3, cb.Source.Count);
 		}


### PR DESCRIPTION
Fixes #3106 - The bug occurred because we were searching for an item in the entire collection instead of the filtered set. Additionally, I introduced a feature that deselects the previously selected item when the search text is shorter than the previous one. This ensures proper cleanup after the previous search. 

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
