### PR TITLE
Fixes #3115. `TextView` should use `Command.ShowContextMenu` not `Command.Accept`

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1666,7 +1666,7 @@ namespace Terminal.Gui {
 			AddCommand (Command.Undo, () => { Undo (); return true; });
 			AddCommand (Command.Redo, () => { Redo (); return true; });
 			AddCommand (Command.DeleteAll, () => { DeleteAll (); return true; });
-			AddCommand (Command.Accept, () => {
+			AddCommand (Command.ShowContextMenu, () => {
 				ContextMenu!.Position = new Point (CursorPosition.X - _leftColumn + 2, CursorPosition.Y - _topRow + 2);
 				ShowContextMenu ();
 				return true;
@@ -1775,7 +1775,7 @@ namespace Terminal.Gui {
 			ContextMenu = new ContextMenu () { MenuItems = BuildContextMenuBarItem () };
 			ContextMenu.KeyChanged += ContextMenu_KeyChanged!;
 
-			KeyBindings.Add ((KeyCode)ContextMenu.Key, KeyBindingScope.HotKey, Command.Accept);
+			KeyBindings.Add ((KeyCode)ContextMenu.Key, KeyBindingScope.HotKey, Command.ShowContextMenu);
 		}
 
 		private MenuBarItem BuildContextMenuBarItem ()

--- a/UnitTests/Views/TextViewTests.cs
+++ b/UnitTests/Views/TextViewTests.cs
@@ -3047,6 +3047,11 @@ Line 2.", _output);
 		Assert.False (tv.NewKeyDownEvent (Application.AlternateForwardKey));
 		Assert.False (tv.NewKeyDownEvent (new (KeyCode.Tab | KeyCode.CtrlMask | KeyCode.ShiftMask)));
 		Assert.False (tv.NewKeyDownEvent (Application.AlternateBackwardKey));
+
+		Assert.Null (tv.ContextMenu.MenuBar);
+		Assert.True (tv.NewKeyDownEvent (ContextMenu.DefaultKey));
+		Assert.True (tv.ContextMenu.MenuBar.Visible);
+
 	}
 
 	[Fact]

--- a/UnitTests/Views/TextViewTests.cs
+++ b/UnitTests/Views/TextViewTests.cs
@@ -3047,10 +3047,9 @@ Line 2.", _output);
 		Assert.False (tv.NewKeyDownEvent (Application.AlternateForwardKey));
 		Assert.False (tv.NewKeyDownEvent (new (KeyCode.Tab | KeyCode.CtrlMask | KeyCode.ShiftMask)));
 		Assert.False (tv.NewKeyDownEvent (Application.AlternateBackwardKey));
-
-		Assert.Null (tv.ContextMenu.MenuBar);
+		
 		Assert.True (tv.NewKeyDownEvent (ContextMenu.DefaultKey));
-		Assert.True (tv.ContextMenu.MenuBar.Visible);
+		Assert.True (tv.ContextMenu != null && tv.ContextMenu.MenuBar.Visible);
 
 	}
 


### PR DESCRIPTION
Fixes #3115