### PR TITLE
Fixes #3122. Shift-Tab is broken on TextView.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1061,6 +1061,8 @@ internal class WindowsDriver : ConsoleDriver {
 
 			if (keyInfo.KeyChar == 0) {
 				return MapToKeyCodeModifiers (keyInfo.Modifiers, (KeyCode)(keyInfo.KeyChar));
+			} else if (keyInfo.Key != ConsoleKey.None) {
+				return MapToKeyCodeModifiers (keyInfo.Modifiers, (KeyCode)(keyInfo.KeyChar));
 			} else {
 				return MapToKeyCodeModifiers (keyInfo.Modifiers & ~ConsoleModifiers.Shift, (KeyCode)(keyInfo.KeyChar));
 			}

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -3373,6 +3373,9 @@ public class TextView : View {
 	///<inheritdoc/>
 	public override bool? OnInvokingKeyBindings (Key a)
 	{
+		if (!a.IsValid) {
+			return false;
+		}
 		// Give autocomplete first opportunity to respond to key presses
 		if (SelectedLength == 0 && Autocomplete.Suggestions.Count > 0 && Autocomplete.ProcessKey (a)) {
 			return true;
@@ -3752,6 +3755,8 @@ public class TextView : View {
 				_historyText.Add (new List<List<RuneCell>> () { new List<RuneCell> (GetCurrentLine ()) }, CursorPosition,
 					HistoryText.LineStatus.Replaced);
 			}
+
+			SetNeedsDisplay ();
 
 			UpdateWrapModel ();
 		}

--- a/UnitTests/Views/TextViewTests.cs
+++ b/UnitTests/Views/TextViewTests.cs
@@ -1541,6 +1541,9 @@ public class TextViewTests {
 	[TextViewTestsAutoInitShutdown]
 	public void TabWidth_Setting_To_Zero_Keeps_AllowsTab ()
 	{
+		Application.Top.Add (_textView);
+		Application.Begin (Application.Top);
+
 		Assert.Equal (4, _textView.TabWidth);
 		Assert.True (_textView.AllowsTab);
 		Assert.True (_textView.AllowsReturn);
@@ -1552,8 +1555,21 @@ public class TextViewTests {
 		Assert.True (_textView.Multiline);
 		_textView.NewKeyDownEvent (new (KeyCode.Tab));
 		Assert.Equal ("\tTAB to jump between text fields.", _textView.Text);
+		Application.Refresh ();
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
+TAB to jump between text field", _output);
+
+		_textView.TabWidth = 4;
+		Application.Refresh ();
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
+    TAB to jump between text f", _output);
+
 		_textView.NewKeyDownEvent (new (KeyCode.Tab | KeyCode.ShiftMask));
 		Assert.Equal ("TAB to jump between text fields.", _textView.Text);
+		Assert.True (_textView.NeedsDisplay);
+		Application.Refresh ();
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
+TAB to jump between text field", _output);
 	}
 
 	[Fact]


### PR DESCRIPTION
Fixes #3122 - `WindowsDriver` was stripping the shift key and `TextView` wasn't calling `SetNeedsDisplay`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
