### PR TITLE
Fixes #3132 #3138 ComboBox (v2) One key delay when keying down arrow. Up arrow does not move back to searchbox

### DIFF
--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -598,18 +598,15 @@ public class ComboBox : View {
 
 	bool? MoveUpList ()
 	{
-		if (_search.HasFocus) {
-			// stop odd behavior on KeyUp when search has focus
-			return true;
-		}
-
 		if (_listview.HasFocus && _listview.SelectedItem == 0 && _searchset?.Count > 0) // jump back to search
 		{
 			_search.CursorPosition = _search.Text.GetRuneCount ();
 			_search.SetFocus ();
-			return true;
+		} else {
+			MoveUp ();
 		}
-		return null;
+
+		return true;
 	}
 
 	bool? MoveDown ()

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -612,6 +612,8 @@ public class ComboBox : View {
 				_listview.SetFocus ();
 				if (_listview.SelectedItem > -1) {
 					SetValue (_searchset [_listview.SelectedItem]);
+				} else {
+					_listview.SelectedItem = 0;
 				}
 			} else {
 				_listview.TabStop = false;

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -10,7 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Terminal.Gui; 
+namespace Terminal.Gui;
 
 /// <summary>
 /// Provides a drop-down list of items the user can select from.
@@ -32,6 +32,7 @@ public class ComboBox : View {
 		{
 			_container = container ?? throw new ArgumentNullException (nameof (container), "ComboBox container cannot be null.");
 			HideDropdownListOnClick = hideDropdownListOnClick;
+			AddCommand (Command.LineUp, () => _container.MoveUpList ());
 		}
 
 		public bool HideDropdownListOnClick {
@@ -589,6 +590,14 @@ public class ComboBox : View {
 
 	bool? MoveUp ()
 	{
+		if (HasItems ()) {
+			_listview.MoveUp ();
+		}
+		return true;
+	}
+
+	bool? MoveUpList ()
+	{
 		if (_search.HasFocus) {
 			// stop odd behavior on KeyUp when search has focus
 			return true;
@@ -733,18 +742,18 @@ public class ComboBox : View {
 		_isShow = false;
 	}
 
-		private int GetSelectedItemFromSource (string searchText)
-		{
-			if (_source is null) {
-				return -1;
-			}
-			for (int i = 0; i < _searchset.Count; i++) {
-				if (_searchset [i].ToString () == searchText) {
-					return i;
-				}
-			}
+	private int GetSelectedItemFromSource (string searchText)
+	{
+		if (_source is null) {
 			return -1;
 		}
+		for (int i = 0; i < _searchset.Count; i++) {
+			if (_searchset [i].ToString () == searchText) {
+				return i;
+			}
+		}
+		return -1;
+	}
 
 	/// <summary>
 	/// Reset to full original list
@@ -786,20 +795,20 @@ public class ComboBox : View {
 		}
 	}
 
-		private void Search_Changed (object sender, TextChangedEventArgs e)
-		{
-			if (_source is null) { // Object initialization		
-				return;
-			}
+	private void Search_Changed (object sender, TextChangedEventArgs e)
+	{
+		if (_source is null) { // Object initialization		
+			return;
+		}
 
-			if (string.IsNullOrEmpty (_search.Text) && string.IsNullOrEmpty (e.OldValue)) {
-				ResetSearchSet ();
-			} else if (_search.Text != e.OldValue) {
-				if (_search.Text.Length < e.OldValue.Length) {
-					_selectedItem = -1;
-				}
-				_isShow = true;
-				ResetSearchSet (noCopy: true);
+		if (string.IsNullOrEmpty (_search.Text) && string.IsNullOrEmpty (e.OldValue)) {
+			ResetSearchSet ();
+		} else if (_search.Text != e.OldValue) {
+			if (_search.Text.Length < e.OldValue.Length) {
+				_selectedItem = -1;
+			}
+			_isShow = true;
+			ResetSearchSet (noCopy: true);
 
 			foreach (object item in _source.ToList ()) {
 				// Iterate to preserver object type and force deep copy

--- a/UICatalog/Properties/launchSettings.json
+++ b/UICatalog/Properties/launchSettings.json
@@ -65,6 +65,10 @@
     "MenuBarScenario": {
       "commandName": "Project",
       "commandLineArgs": "MenuBar"
+    },
+    "ListView & ComboBox": {
+      "commandName": "Project",
+      "commandLineArgs": "\"ListView & ComboBox\""
     }
   }
 }


### PR DESCRIPTION
Fixes #3132 #3138 - ComboBox one key delay when keying down arrow. Up arrow does not move back to searchbox

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
