### PR TITLE
Fixes #3141. Some ResponderTests are failing sometimes.

### DIFF
--- a/UnitTests/Input/ResponderTests.cs
+++ b/UnitTests/Input/ResponderTests.cs
@@ -139,6 +139,9 @@ public class ResponderTests {
 	[Fact]
 	public void Responder_Not_Notifying_Dispose ()
 	{
+		// Only clear before because need to test after assert
+		Responder.Instances.Clear ();
+
 		var container1 = new View () { Id = "Container1" };
 
 		var view = new View () { Id = "View" };
@@ -175,6 +178,9 @@ public class ResponderTests {
 	[Fact]
 	public void Disposing_Event_Notify_All_Subscribers_On_The_Second_Container ()
 	{
+		// Only clear before because need to test after assert
+		Responder.Instances.Clear ();
+
 		var container1 = new View () { Id = "Container1" };
 
 		var view = new View () { Id = "View" };
@@ -212,6 +218,9 @@ public class ResponderTests {
 	[Fact]
 	public void Disposing_Event_Notify_All_Subscribers_On_The_First_Container ()
 	{
+		// Only clear before because need to test after assert
+		Responder.Instances.Clear ();
+
 		var container1 = new View () { Id = "Container1" };
 		var count = 0;
 


### PR DESCRIPTION
Fixes #3141 - Fix Disposing unit tests that sometimes throws because some instances aren't cleared on others unit tests classes.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [xx] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
