### PR TITLE
Fixes #3144. TextView Autocomplete does not insert capital letters

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -3026,14 +3026,14 @@ public class TextView : View {
 	public void InsertText (string toAdd)
 	{
 		foreach (char ch in toAdd) {
-			KeyCode key;
+			Key key;
 			try {
-				key = (KeyCode)ch;
+				key = new Key(ch);
 			} catch (Exception) {
 				throw new ArgumentException ($"Cannot insert character '{ch}' because it does not map to a Key");
 			}
 
-			InsertText (new Key (key));
+			InsertText (key);
 
 			if (NeedsDisplay) {
 				Adjust ();

--- a/UnitTests/Text/AutocompleteTests.cs
+++ b/UnitTests/Text/AutocompleteTests.cs
@@ -153,7 +153,7 @@ namespace Terminal.Gui.TextTests {
 			Assert.Equal (3, g.AllSuggestions.Count);
 			Assert.True (tv.NewKeyDownEvent (new (tv.Autocomplete.SelectionKey)));
 			tv.PositionCursor ();
-			Assert.Equal ($"fortunately Fortunately super feature.", tv.Text);
+			Assert.Equal ($"Fortunately Fortunately super feature.", tv.Text);
 			Assert.Equal (new Point (11, 0), tv.CursorPosition);
 			Assert.Empty (tv.Autocomplete.Suggestions);
 			Assert.Equal (3, g.AllSuggestions.Count);


### PR DESCRIPTION
Fixes #3144. TextView Autocomplete does not insert capital letters

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- Have 2 failing tests I believe to be unrelated to the changes in this PR
- I believe this issue is captured in #3141 
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
