### PR TITLE
Fixes #3072, #3148. `Dialog` and `MessageBox` key binding do not handle Enter correctly

### DIFF
--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -122,8 +122,15 @@ public class Button : View {
 
 		// Override default behavior of View
 		// Command.Default sets focus
-		AddCommand (Command.Accept, () => { OnClicked (); return true; });
+		AddCommand (Command.Accept, () => AcceptKey ());
 		KeyBindings.Add (Key.Space, Command.Default, Command.Accept);
+		KeyBindings.Add (Key.Enter, Command.Default, Command.Accept);
+	}
+
+	bool AcceptKey ()
+	{
+		OnClicked ();
+		return true;
 	}
 
 	/// <summary>
@@ -166,14 +173,6 @@ public class Button : View {
 		}
 	}
 
-	bool AcceptKey ()
-	{
-		//if (!HasFocus) {
-		//	SetFocus ();
-		//}
-		OnClicked ();
-		return true;
-	}
 
 	/// <summary>
 	/// Virtual method to invoke the <see cref="Clicked"/> event.

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -120,19 +120,12 @@ public class Button : View {
 
 		OnResizeNeeded ();
 
-		// Override default behavior of View
-		// Command.Default sets focus
-		AddCommand (Command.Accept, () => AcceptKey ());
+		// Override default behavior of View - Command.Default sets focus
+		AddCommand (Command.Accept, () => { OnClicked (); return true; });
 		KeyBindings.Add (Key.Space, Command.Default, Command.Accept);
 		KeyBindings.Add (Key.Enter, Command.Default, Command.Accept);
 	}
-
-	bool AcceptKey ()
-	{
-		OnClicked ();
-		return true;
-	}
-
+	
 	/// <summary>
 	/// Gets or sets whether the <see cref="Button"/> is the default action to activate in a dialog.
 	/// </summary>

--- a/Terminal.Gui/Views/Dialog.cs
+++ b/Terminal.Gui/Views/Dialog.cs
@@ -79,6 +79,8 @@ public class Dialog : Window {
 			return false;
 		});
 
+
+		KeyBindings.Add (KeyCode.Esc, Command.QuitToplevel);
 		// This enables the default button to be activated by the Enter key.
 		KeyBindings.Add (KeyCode.Enter, Command.Accept);
 
@@ -240,17 +242,5 @@ public class Dialog : Window {
 			}
 			break;
 		}
-	}
-
-	// BUGBUG: Why is this not handled by a key binding???
-	///<inheritdoc/>
-	public override bool OnProcessKeyDown (Key a)
-	{
-		switch (a.KeyCode) {
-		case KeyCode.Esc:
-			Application.RequestStop (this);
-			return true;
-		}
-		return false;
 	}
 }

--- a/Terminal.Gui/Views/Dialog.cs
+++ b/Terminal.Gui/Views/Dialog.cs
@@ -70,18 +70,7 @@ public class Dialog : Window {
 		Modal = true;
 		ButtonAlignment = DefaultButtonAlignment;
 
-		// This enables the default button to be activated by the Enter key.
-		AddCommand (Command.Accept, () => {
-			// TODO: Perhaps all views should support the concept of being default?
-			if (Subviews.FirstOrDefault (v => v is Button && ((Button)v).IsDefault && ((Button)v).Enabled) is Button defaultBtn) {
-				defaultBtn.InvokeCommand (Command.Accept);
-				return true;
-			}
-			return false;
-		});
-
-		KeyBindings.Add (KeyCode.Esc, Command.QuitToplevel);
-		KeyBindings.Add (KeyCode.Enter, Command.Accept);
+		KeyBindings.Add (Key.Esc, Command.QuitToplevel);
 
 		if (buttons != null) {
 			foreach (var b in buttons) {

--- a/Terminal.Gui/Views/Dialog.cs
+++ b/Terminal.Gui/Views/Dialog.cs
@@ -70,6 +70,7 @@ public class Dialog : Window {
 		Modal = true;
 		ButtonAlignment = DefaultButtonAlignment;
 
+		// This enables the default button to be activated by the Enter key.
 		AddCommand (Command.Accept, () => {
 			// TODO: Perhaps all views should support the concept of being default?
 			if (Subviews.FirstOrDefault (v => v is Button && ((Button)v).IsDefault && ((Button)v).Enabled) is Button defaultBtn) {
@@ -79,9 +80,7 @@ public class Dialog : Window {
 			return false;
 		});
 
-
 		KeyBindings.Add (KeyCode.Esc, Command.QuitToplevel);
-		// This enables the default button to be activated by the Enter key.
 		KeyBindings.Add (KeyCode.Enter, Command.Accept);
 
 		if (buttons != null) {

--- a/Terminal.Gui/Views/Dialog.cs
+++ b/Terminal.Gui/Views/Dialog.cs
@@ -70,6 +70,18 @@ public class Dialog : Window {
 		Modal = true;
 		ButtonAlignment = DefaultButtonAlignment;
 
+		AddCommand (Command.Accept, () => {
+			// TODO: Perhaps all views should support the concept of being default?
+			if (Subviews.FirstOrDefault (v => v is Button && ((Button)v).IsDefault && ((Button)v).Enabled) is Button defaultBtn) {
+				defaultBtn.InvokeCommand (Command.Accept);
+				return true;
+			}
+			return false;
+		});
+
+		// This enables the default button to be activated by the Enter key.
+		KeyBindings.Add (KeyCode.Enter, Command.Accept);
+
 		if (buttons != null) {
 			foreach (var b in buttons) {
 				AddButton (b);
@@ -104,6 +116,7 @@ public class Dialog : Window {
 		//button.AutoSize = false; // BUGBUG: v2 - Hack to get around autosize not accounting for Margin?
 		buttons.Add (button);
 		Add (button);
+
 		SetNeedsDisplay ();
 		if (IsInitialized) {
 			LayoutSubviews ();

--- a/Terminal.Gui/Views/Toplevel.cs
+++ b/Terminal.Gui/Views/Toplevel.cs
@@ -226,7 +226,7 @@ public partial class Toplevel : View {
 
 
 		// Default keybindings for this view
-		KeyBindings.Add ((KeyCode)Application.QuitKey, Command.QuitToplevel);
+		KeyBindings.Add (Application.QuitKey, Command.QuitToplevel);
 
 		KeyBindings.Add (KeyCode.CursorRight, Command.NextView);
 		KeyBindings.Add (KeyCode.CursorDown, Command.NextView);
@@ -239,8 +239,8 @@ public partial class Toplevel : View {
 		KeyBindings.Add (KeyCode.Tab | KeyCode.ShiftMask | KeyCode.CtrlMask, Command.PreviousViewOrTop);
 
 		KeyBindings.Add (KeyCode.F5, Command.Refresh);
-		KeyBindings.Add ((KeyCode)Application.AlternateForwardKey, Command.NextViewOrTop); // Needed on Unix
-		KeyBindings.Add ((KeyCode)Application.AlternateBackwardKey, Command.PreviousViewOrTop); // Needed on Unix
+		KeyBindings.Add (Application.AlternateForwardKey, Command.NextViewOrTop); // Needed on Unix
+		KeyBindings.Add (Application.AlternateBackwardKey, Command.PreviousViewOrTop); // Needed on Unix
 
 #if UNIX_KEY_BINDINGS
 			KeyBindings.Add (Key.Z | Key.CtrlMask, Command.Suspend);

--- a/Terminal.Gui/Views/Toplevel.cs
+++ b/Terminal.Gui/Views/Toplevel.cs
@@ -223,15 +223,7 @@ public partial class Toplevel : View {
 			Application.Refresh ();
 			return true;
 		});
-		AddCommand (Command.Accept, () => {
-			// TODO: Perhaps all views should support the concept of being default?
-			// TODO: It's bad that Toplevel is tightly coupled with Button
-			if (Subviews.FirstOrDefault (v => v is Button && ((Button)v).IsDefault && ((Button)v).Enabled) is Button defaultBtn) {
-				defaultBtn.InvokeCommand (Command.Accept);
-				return true;
-			}
-			return false;
-		});
+
 
 		// Default keybindings for this view
 		KeyBindings.Add ((KeyCode)Application.QuitKey, Command.QuitToplevel);
@@ -257,8 +249,6 @@ public partial class Toplevel : View {
 			KeyBindings.Add (Key.I | Key.CtrlMask, Command.NextView); // Unix
 			KeyBindings.Add (Key.B | Key.CtrlMask, Command.PreviousView);// Unix
 #endif
-		// This enables the default button to be activated by the Enter key.
-		KeyBindings.Add (KeyCode.Enter, Command.Accept);
 	}
 
 	void Application_UnGrabbingMouse (object sender, GrabMouseEventArgs e)

--- a/Terminal.Gui/Views/Toplevel.cs
+++ b/Terminal.Gui/Views/Toplevel.cs
@@ -228,26 +228,26 @@ public partial class Toplevel : View {
 		// Default keybindings for this view
 		KeyBindings.Add (Application.QuitKey, Command.QuitToplevel);
 
-		KeyBindings.Add (KeyCode.CursorRight, Command.NextView);
-		KeyBindings.Add (KeyCode.CursorDown, Command.NextView);
-		KeyBindings.Add (KeyCode.CursorLeft, Command.PreviousView);
-		KeyBindings.Add (KeyCode.CursorUp, Command.PreviousView);
+		KeyBindings.Add (Key.CursorRight, Command.NextView);
+		KeyBindings.Add (Key.CursorDown, Command.NextView);
+		KeyBindings.Add (Key.CursorLeft, Command.PreviousView);
+		KeyBindings.Add (Key.CursorUp, Command.PreviousView);
 
-		KeyBindings.Add (KeyCode.Tab, Command.NextView);
-		KeyBindings.Add (KeyCode.Tab | KeyCode.ShiftMask, Command.PreviousView);
-		KeyBindings.Add (KeyCode.Tab | KeyCode.CtrlMask, Command.NextViewOrTop);
-		KeyBindings.Add (KeyCode.Tab | KeyCode.ShiftMask | KeyCode.CtrlMask, Command.PreviousViewOrTop);
+		KeyBindings.Add (Key.Tab, Command.NextView);
+		KeyBindings.Add (Key.Tab.WithShift, Command.PreviousView);
+		KeyBindings.Add (Key.Tab.WithCtrl, Command.NextViewOrTop);
+		KeyBindings.Add (Key.Tab.WithShift.WithCtrl, Command.PreviousViewOrTop);
 
-		KeyBindings.Add (KeyCode.F5, Command.Refresh);
+		KeyBindings.Add (Key.F5, Command.Refresh);
 		KeyBindings.Add (Application.AlternateForwardKey, Command.NextViewOrTop); // Needed on Unix
 		KeyBindings.Add (Application.AlternateBackwardKey, Command.PreviousViewOrTop); // Needed on Unix
 
 #if UNIX_KEY_BINDINGS
-			KeyBindings.Add (Key.Z | Key.CtrlMask, Command.Suspend);
-			KeyBindings.Add (Key.L | Key.CtrlMask, Command.Refresh);// Unix
-			KeyBindings.Add (Key.F | Key.CtrlMask, Command.NextView);// Unix
-			KeyBindings.Add (Key.I | Key.CtrlMask, Command.NextView); // Unix
-			KeyBindings.Add (Key.B | Key.CtrlMask, Command.PreviousView);// Unix
+			KeyBindings.Add (Key.Z.WithCtrl, Command.Suspend);
+			KeyBindings.Add (Key.L.WithCtrl, Command.Refresh);// Unix
+			KeyBindings.Add (Key.F.WithCtrl, Command.NextView);// Unix
+			KeyBindings.Add (Key.I.WithCtrl, Command.NextView); // Unix
+			KeyBindings.Add (Key.B.WithCtrl, Command.PreviousView);// Unix
 #endif
 	}
 
@@ -276,7 +276,7 @@ public partial class Toplevel : View {
 	/// <param name="e"></param>
 	public virtual void OnAlternateForwardKeyChanged (KeyChangedEventArgs e)
 	{
-		KeyBindings.Replace ((KeyCode)e.OldKey, (KeyCode)e.NewKey);
+		KeyBindings.Replace (e.OldKey, e.NewKey);
 		AlternateForwardKeyChanged?.Invoke (this, e);
 	}
 
@@ -291,7 +291,7 @@ public partial class Toplevel : View {
 	/// <param name="e"></param>
 	public virtual void OnAlternateBackwardKeyChanged (KeyChangedEventArgs e)
 	{
-		KeyBindings.Replace ((KeyCode)e.OldKey, (KeyCode)e.NewKey);
+		KeyBindings.Replace (e.OldKey, e.NewKey);
 		AlternateBackwardKeyChanged?.Invoke (this, e);
 	}
 
@@ -306,7 +306,7 @@ public partial class Toplevel : View {
 	/// <param name="e"></param>
 	public virtual void OnQuitKeyChanged (KeyChangedEventArgs e)
 	{
-		KeyBindings.Replace ((KeyCode)e.OldKey, (KeyCode)e.NewKey);
+		KeyBindings.Replace (e.OldKey, e.NewKey);
 		QuitKeyChanged?.Invoke (this, e);
 	}
 

--- a/Terminal.Gui/Views/Window.cs
+++ b/Terminal.Gui/Views/Window.cs
@@ -1,60 +1,68 @@
-﻿using System;
-using System.Collections;
+﻿using System.Linq;
 using System.Text.Json.Serialization;
-using System.Text;
-using Terminal.Gui;
-using static Terminal.Gui.ConfigurationManager;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui;
+
+/// <summary>
+/// A <see cref="Toplevel"/> <see cref="View"/> with <see cref="View.BorderStyle"/> set to
+/// <see cref="LineStyle.Single"/>. Provides a container for other views. 
+/// </summary>
+/// <remarks>
+/// <para>
+/// If any subview is a button and the <see cref="Button.IsDefault"/> property is set to true, the Enter key
+/// will invoke the <see cref="Command.Accept"/> command on that subview.
+/// </para>
+/// </remarks>
+public class Window : Toplevel {
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Window"/> class using
+	/// <see cref="LayoutStyle.Computed"/> positioning.
+	/// </summary>
+	public Window () => SetInitialProperties ();
 
 	/// <summary>
-	/// A <see cref="Toplevel"/> <see cref="View"/> with <see cref="View.BorderStyle"/> set to <see cref="LineStyle.Single"/>. 
+	/// Initializes a new instance of the <see cref="Window"/> class using
+	/// <see cref="LayoutStyle.Computed"/> positioning.
+	/// </summary>
+	public Window (Rect frame) : base (frame) => SetInitialProperties ();
+
+	// TODO: enable this
+	///// <summary>
+	///// The default <see cref="LineStyle"/> for <see cref="Window"/>'s border. The default is <see cref="LineStyle.Single"/>.
+	///// </summary>
+	///// <remarks>
+	///// This property can be set in a Theme to change the default <see cref="LineStyle"/> for all <see cref="Window"/>s. 
+	///// </remarks>
+	/////[SerializableConfigurationProperty (Scope = typeof (ThemeScope)), JsonConverter (typeof (JsonStringEnumConverter))]
+	////public static ColorScheme DefaultColorScheme { get; set; } = Colors.Base;
+
+	/// <summary>
+	/// The default <see cref="LineStyle"/> for <see cref="Window"/>'s border. The default is
+	/// <see cref="LineStyle.Single"/>.
 	/// </summary>
 	/// <remarks>
-	/// <para>
-	/// This is a helper class to simplify creating a <see cref="Toplevel"/> with a border.
-	/// </para>
+	/// This property can be set in a Theme to change the default <see cref="LineStyle"/> for all
+	/// <see cref="Window"/>s.
 	/// </remarks>
-	public class Window : Toplevel {
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Window"/> class using <see cref="LayoutStyle.Computed"/> positioning.
-		/// </summary>
-		public Window () : base () {
-			SetInitialProperties ();
-		}
+	[SerializableConfigurationProperty (Scope = typeof (ThemeScope))] [JsonConverter (typeof (JsonStringEnumConverter))]
+	public static LineStyle DefaultBorderStyle { get; set; } = LineStyle.Single;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Window"/> class using <see cref="LayoutStyle.Computed"/> positioning.
-		/// </summary>
-		public Window (Rect frame) : base (frame)
-		{
-			SetInitialProperties ();
-		}
+	void SetInitialProperties ()
+	{
+		CanFocus = true;
+		ColorScheme = Colors.Base; // TODO: make this a theme property
+		BorderStyle = DefaultBorderStyle;
 
-		// TODO: enable this
-		///// <summary>
-		///// The default <see cref="LineStyle"/> for <see cref="Window"/>'s border. The default is <see cref="LineStyle.Single"/>.
-		///// </summary>
-		///// <remarks>
-		///// This property can be set in a Theme to change the default <see cref="LineStyle"/> for all <see cref="Window"/>s. 
-		///// </remarks>
-		/////[SerializableConfigurationProperty (Scope = typeof (ThemeScope)), JsonConverter (typeof (JsonStringEnumConverter))]
-		////public static ColorScheme DefaultColorScheme { get; set; } = Colors.Base;
+		// This enables the default button to be activated by the Enter key.
+		AddCommand (Command.Accept, () => {
+			// TODO: Perhaps all views should support the concept of being default?
+			if (Subviews.FirstOrDefault (v => v is Button { IsDefault: true, Enabled: true }) is Button defaultBtn) {
+				defaultBtn.InvokeCommand (Command.Accept);
+				return true;
+			}
+			return false;
+		});
 
-		/// <summary>
-		/// The default <see cref="LineStyle"/> for <see cref="Window"/>'s border. The default is <see cref="LineStyle.Single"/>.
-		/// </summary>
-		/// <remarks>
-		/// This property can be set in a Theme to change the default <see cref="LineStyle"/> for all <see cref="Window"/>s. 
-		/// </remarks>
-		[SerializableConfigurationProperty (Scope = typeof (ThemeScope)), JsonConverter (typeof (JsonStringEnumConverter))]
-		public static LineStyle DefaultBorderStyle { get; set; } = LineStyle.Single;
-
-		void SetInitialProperties ()
-		{
-			CanFocus = true;
-			ColorScheme = Colors.Base; // TODO: make this a theme property
-			BorderStyle = DefaultBorderStyle;
-		}
+		KeyBindings.Add (Key.Enter, Command.Accept);
 	}
 }

--- a/UnitTests/Dialogs/DialogTests.cs
+++ b/UnitTests/Dialogs/DialogTests.cs
@@ -1,167 +1,154 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using Terminal.Gui;
-using Xunit;
-using System.Globalization;
+﻿using Xunit;
 using Xunit.Abstractions;
-using System.Text;
 using static Terminal.Gui.Application;
 
-namespace Terminal.Gui.DialogTests {
+namespace Terminal.Gui.DialogTests; 
 
-	public class DialogTests {
-		readonly ITestOutputHelper output;
+public class DialogTests {
+	readonly ITestOutputHelper output;
 
-		public DialogTests (ITestOutputHelper output)
-		{
-			this.output = output;
-		}
+	public DialogTests (ITestOutputHelper output) => this.output = output;
 
-		//[Fact]
-		//[AutoInitShutdown]
-		//public void Default_Has_Border ()
-		//{
-		//	var d = (FakeDriver)Application.Driver;
-		//	d.SetBufferSize (20, 5);
-		//	Application.RunState runstate = null;
+	//[Fact]
+	//[AutoInitShutdown]
+	//public void Default_Has_Border ()
+	//{
+	//	var d = (FakeDriver)Application.Driver;
+	//	d.SetBufferSize (20, 5);
+	//	Application.RunState runstate = null;
 
-		//	var title = "Title";
-		//	var btnText = "ok";
-		//	var buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
-		//	var width = buttonRow.Length;
-		//	var topRow = $"┌┤{title} {new string (d.HLine.ToString () [0], width - title.Length - 2)}├┐";
-		//	var bottomRow = $"└{new string (d.HLine.ToString () [0], width - 2)}┘";
+	//	var title = "Title";
+	//	var btnText = "ok";
+	//	var buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
+	//	var width = buttonRow.Length;
+	//	var topRow = $"┌┤{title} {new string (d.HLine.ToString () [0], width - title.Length - 2)}├┐";
+	//	var bottomRow = $"└{new string (d.HLine.ToString () [0], width - 2)}┘";
 
-		//	var dlg = new Dialog (title, new Button (btnText));
-		//	Application.Begin (dlg);
+	//	var dlg = new Dialog (title, new Button (btnText));
+	//	Application.Begin (dlg);
 
-		//	TestHelpers.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
-		//	Application.End (runstate);
-		//}
+	//	TestHelpers.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+	//	Application.End (runstate);
+	//}
 
-		private (RunState, Dialog) RunButtonTestDialog (string title, int width, Dialog.ButtonAlignments align, params Button [] btns)
-		{
-			var dlg = new Dialog (btns) {
-				Title = title,
-				X = 0,
-				Y = 0,
-				Width = width,
-				Height = 1,
-				ButtonAlignment = align,
-			};
-			// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
-			dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
-			return (Application.Begin (dlg), dlg);
-		}
+	(RunState, Dialog) RunButtonTestDialog (string title, int width, Dialog.ButtonAlignments align, params Button [] btns)
+	{
+		var dlg = new Dialog (btns) {
+			Title = title,
+			X = 0,
+			Y = 0,
+			Width = width,
+			Height = 1,
+			ButtonAlignment = align
+		};
+		// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
+		dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
+		return (Begin (dlg), dlg);
+	}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Size_Default ()
-		{
-			var d = new Dialog () {
-			};
-			Application.Begin (d);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+	[Fact]
+	[AutoInitShutdown]
+	public void Size_Default ()
+	{
+		var d = new Dialog ();
+		Begin (d);
+		((FakeDriver)Driver).SetBufferSize (100, 100);
 
-			// Default size is Percent(85) 
-			Assert.Equal (new Size ((int)(100 * .85), (int)(100 * .85)), d.Frame.Size);
-		}
+		// Default size is Percent(85) 
+		Assert.Equal (new Size ((int)(100 * .85), (int)(100 * .85)), d.Frame.Size);
+	}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Location_Default ()
-		{
-			var d = new Dialog () {
-			};
-			Application.Begin (d);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+	[Fact]
+	[AutoInitShutdown]
+	public void Location_Default ()
+	{
+		var d = new Dialog ();
+		Begin (d);
+		((FakeDriver)Driver).SetBufferSize (100, 100);
 
-			// Default location is centered, so 100 / 2 - 85 / 2 = 7
-			var expected = 7;
-			Assert.Equal (new Point (expected, expected), d.Frame.Location);
-		}
+		// Default location is centered, so 100 / 2 - 85 / 2 = 7
+		var expected = 7;
+		Assert.Equal (new Point (expected, expected), d.Frame.Location);
+	}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Size_Not_Default ()
-		{
-			var d = new Dialog () {
-				Width = 50,
-				Height = 50,
-			};
+	[Fact]
+	[AutoInitShutdown]
+	public void Size_Not_Default ()
+	{
+		var d = new Dialog {
+			Width = 50,
+			Height = 50
+		};
 
-			Application.Begin (d);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+		Begin (d);
+		((FakeDriver)Driver).SetBufferSize (100, 100);
 
-			// Default size is Percent(85) 
-			Assert.Equal (new Size (50, 50), d.Frame.Size);
-		}
+		// Default size is Percent(85) 
+		Assert.Equal (new Size (50, 50), d.Frame.Size);
+	}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Location_Not_Default ()
-		{
-			var d = new Dialog () {
-				X = 1,
-				Y = 1,
-			};
-			Application.Begin (d);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+	[Fact]
+	[AutoInitShutdown]
+	public void Location_Not_Default ()
+	{
+		var d = new Dialog {
+			X = 1,
+			Y = 1
+		};
+		Begin (d);
+		((FakeDriver)Driver).SetBufferSize (100, 100);
 
-			// Default location is centered, so 100 / 2 - 85 / 2 = 7
-			var expected = 1;
-			Assert.Equal (new Point (expected, expected), d.Frame.Location);
-		}
+		// Default location is centered, so 100 / 2 - 85 / 2 = 7
+		var expected = 1;
+		Assert.Equal (new Point (expected, expected), d.Frame.Location);
+	}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Location_When_Application_Top_Not_Default ()
-		{
-			var expected = 5;
-			var d = new Dialog () {
-				X = expected,
-				Y = expected,
-				Height = 5,
-				Width = 5
-			};
-			Application.Begin (d);
-			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+	[Fact]
+	[AutoInitShutdown]
+	public void Location_When_Application_Top_Not_Default ()
+	{
+		var expected = 5;
+		var d = new Dialog {
+			X = expected,
+			Y = expected,
+			Height = 5,
+			Width = 5
+		};
+		Begin (d);
+		((FakeDriver)Driver).SetBufferSize (20, 10);
 
-			// Default location is centered, so 100 / 2 - 85 / 2 = 7
-			Assert.Equal (new Point (expected, expected), d.Frame.Location);
+		// Default location is centered, so 100 / 2 - 85 / 2 = 7
+		Assert.Equal (new Point (expected, expected), d.Frame.Location);
 
-			TestHelpers.AssertDriverContentsWithFrameAre (@"
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
      ┌───┐
      │   │
      │   │
      │   │
      └───┘", output);
-		}
+	}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Location_When_Not_Application_Top_Not_Default ()
-		{
-			Application.Top.BorderStyle = LineStyle.Double;
+	[Fact]
+	[AutoInitShutdown]
+	public void Location_When_Not_Application_Top_Not_Default ()
+	{
+		Top.BorderStyle = LineStyle.Double;
 
-			var iterations = -1;
-			Application.Iteration += (s, a) => {
-				iterations++;
+		var iterations = -1;
+		Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					var d = new Dialog () {
-						X = 5,
-						Y = 5,
-						Height = 3,
-						Width = 5
-					};
-					Application.Begin (d);
+			if (iterations == 0) {
+				var d = new Dialog {
+					X = 5,
+					Y = 5,
+					Height = 3,
+					Width = 5
+				};
+				Begin (d);
 
-					Assert.Equal (new Point (5, 5), d.Frame.Location);
-					TestHelpers.AssertDriverContentsWithFrameAre (@"
+				Assert.Equal (new Point (5, 5), d.Frame.Location);
+				TestHelpers.AssertDriverContentsWithFrameAre (@"
 ╔══════════════════╗
 ║                  ║
 ║                  ║
@@ -173,16 +160,16 @@ namespace Terminal.Gui.DialogTests {
 ║                  ║
 ╚══════════════════╝", output);
 
-					d = new Dialog () {
-						X = 5,
-						Y = 5,
-					};
-					Application.Begin (d);
+				d = new Dialog {
+					X = 5,
+					Y = 5
+				};
+				Begin (d);
 
-					// This is because of PostionTopLevels and EnsureVisibleBounds
-					Assert.Equal (new Point (3, 2), d.Frame.Location);
-					Assert.Equal (new Size (17, 8), d.Frame.Size);
-					TestHelpers.AssertDriverContentsWithFrameAre (@"
+				// This is because of PostionTopLevels and EnsureVisibleBounds
+				Assert.Equal (new Point (3, 2), d.Frame.Location);
+				Assert.Equal (new Size (17, 8), d.Frame.Size);
+				TestHelpers.AssertDriverContentsWithFrameAre (@"
 ╔══════════════════╗
 ║                  ║
 ║  ┌───────────────┐
@@ -194,622 +181,626 @@ namespace Terminal.Gui.DialogTests {
 ║  │               │
 ╚══└───────────────┘", output);
 
-				} else if (iterations > 0) {
-					Application.RequestStop ();
-				}
-			};
-
-			Application.Begin (Application.Top);
-			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
-			Application.Run ();
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void ButtonAlignment_One ()
-		{
-			var d = (FakeDriver)Application.Driver;
-			RunState runstate = null;
-
-			var title = "1234";
-			// E.g "|[ ok ]|"
-			var btnText = "ok";
-			var buttonRow = $"{CM.Glyphs.VLine}  {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}  {CM.Glyphs.VLine}";
-			var width = buttonRow.Length;
-
-			d.SetBufferSize (width, 1);
-
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
-			// Center
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify 
-			buttonRow = $"{CM.Glyphs.VLine}    {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btnText));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			buttonRow = $"{CM.Glyphs.VLine}    {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btnText));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}    {CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btnText));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Wider
-			buttonRow = $"{CM.Glyphs.VLine}   {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}   {CM.Glyphs.VLine}";
-			width = buttonRow.Length;
-
-			d.SetBufferSize (width, 1);
-
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			buttonRow = $"{CM.Glyphs.VLine}      {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btnText));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			buttonRow = $"{CM.Glyphs.VLine}      {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btnText));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}      {CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btnText));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void ButtonAlignment_Two ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-			// E.g "|[ yes ][ no ]|"
-			var btn1Text = "yes";
-			var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
-			var btn2Text = "no";
-			var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
-
-			var buttonRow = $@"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}";
-			var width = buttonRow.Length;
-
-			d.SetBufferSize (buttonRow.Length, 3);
-
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			buttonRow = $@"{CM.Glyphs.VLine}{btn1}   {btn2}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			buttonRow = $@"{CM.Glyphs.VLine}  {btn1} {btn2}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			buttonRow = $@"{CM.Glyphs.VLine}{btn1} {btn2}  {CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void ButtonAlignment_Two_Hidden ()
-		{
-			RunState runstate = null;
-			bool firstIteration = false;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-			// E.g "|[ yes ][ no ]|"
-			var btn1Text = "yes";
-			var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
-			var btn2Text = "no";
-			var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
-
-			var buttonRow = $@"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}";
-			var width = buttonRow.Length;
-
-			d.SetBufferSize (buttonRow.Length, 3);
-
-			Dialog dlg = null;
-			Button button1, button2;
-
-			// Default (Center)
-			button1 = new Button (btn1Text);
-			button2 = new Button (btn2Text);
-			(runstate, dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, button1, button2);
-			button1.Visible = false;
-			Application.RunIteration (ref runstate, ref firstIteration);
-			buttonRow = $@"{CM.Glyphs.VLine}         {btn2} {CM.Glyphs.VLine}";
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			Assert.Equal (width, buttonRow.Length);
-			button1 = new Button (btn1Text);
-			button2 = new Button (btn2Text);
-			(runstate, dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, button1, button2);
-			button1.Visible = false;
-			Application.RunIteration (ref runstate, ref firstIteration);
-			buttonRow = $@"{CM.Glyphs.VLine}          {btn2}{CM.Glyphs.VLine}";
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			Assert.Equal (width, buttonRow.Length);
-			button1 = new Button (btn1Text);
-			button2 = new Button (btn2Text);
-			(runstate, dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, button1, button2);
-			button1.Visible = false;
-			Application.RunIteration (ref runstate, ref firstIteration);
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			Assert.Equal (width, buttonRow.Length);
-			button1 = new Button (btn1Text);
-			button2 = new Button (btn2Text);
-			(runstate, dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, button1, button2);
-			button1.Visible = false;
-			Application.RunIteration (ref runstate, ref firstIteration);
-			buttonRow = $@"{CM.Glyphs.VLine}        {btn2}  {CM.Glyphs.VLine}";
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void ButtonAlignment_Three ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-			// E.g "|[ yes ][ no ][ maybe ]|"
-			var btn1Text = "yes";
-			var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
-			var btn2Text = "no";
-			var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
-			var btn3Text = "maybe";
-			var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
-
-			var buttonRow = $@"{CM.Glyphs.VLine} {btn1} {btn2} {btn3} {CM.Glyphs.VLine}";
-			var width = buttonRow.Length;
-
-			d.SetBufferSize (buttonRow.Length, 3);
-
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			buttonRow = $@"{CM.Glyphs.VLine}{btn1}  {btn2}  {btn3}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			buttonRow = $@"{CM.Glyphs.VLine}  {btn1} {btn2} {btn3}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			buttonRow = $@"{CM.Glyphs.VLine}{btn1} {btn2} {btn3}  {CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void ButtonAlignment_Four ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-
-			// E.g "|[ yes ][ no ][ maybe ]|"
-			var btn1Text = "yes";
-			var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
-			var btn2Text = "no";
-			var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
-			var btn3Text = "maybe";
-			var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
-			var btn4Text = "never";
-			var btn4 = $"{CM.Glyphs.LeftBracket} {btn4Text} {CM.Glyphs.RightBracket}";
-
-			var buttonRow = $"{CM.Glyphs.VLine} {btn1} {btn2} {btn3} {btn4} {CM.Glyphs.VLine}";
-			var width = buttonRow.Length;
-			d.SetBufferSize (buttonRow.Length, 3);
-
-			// Default - Center
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2}  {btn3}  {btn4}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			buttonRow = $"{CM.Glyphs.VLine}  {btn1} {btn2} {btn3} {btn4}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2} {btn3} {btn4}  {CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void ButtonAlignment_Four_On_Too_Small_Width ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-
-			// E.g "|[ yes ][ no ][ maybe ][ never ]|"
-			var btn1Text = "yes";
-			var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
-			var btn2Text = "no";
-			var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
-			var btn3Text = "maybe";
-			var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
-			var btn4Text = "never";
-			var btn4 = $"{CM.Glyphs.LeftBracket} {btn4Text} {CM.Glyphs.RightBracket}";
-			var buttonRow = string.Empty;
-
-			var width = 30;
-			d.SetBufferSize (width, 1);
-
-			// Default - Center
-			buttonRow = $"{CM.Glyphs.VLine}es {CM.Glyphs.RightBracket} {btn2} {btn3} {CM.Glyphs.LeftBracket} neve{CM.Glyphs.VLine}";
-			(runstate, var dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			Assert.Equal (new Size (width, 1), dlg.Frame.Size);
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.LeftBracket} yes {CM.Glyphs.LeftBracket} no {CM.Glyphs.LeftBracket} maybe {CM.Glyphs.LeftBracket} never {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output); Application.End (runstate);
-
-			// Right
-			buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.RightBracket} {btn2} {btn3} {btn4}{CM.Glyphs.VLine}";
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output); Application.End (runstate);
-
-			// Left
-			buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2} {btn3} {CM.Glyphs.LeftBracket} n{CM.Glyphs.VLine}";
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output); Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void ButtonAlignment_Four_Wider ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-
-			// E.g "|[ yes ][ no ][ maybe ]|"
-			var btn1Text = "yes";
-			var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
-			var btn2Text = "no";
-			var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
-			var btn3Text = "你你你你你"; // This is a wide char
-			var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
-			// Requires a Nerd Font
-			var btn4Text = "\uE36E\uE36F\uE370\uE371\uE372\uE373";
-			var btn4 = $"{CM.Glyphs.LeftBracket} {btn4Text} {CM.Glyphs.RightBracket}";
-
-			// Note extra spaces to make dialog even wider
-			//                         123456                           123456
-			var buttonRow = $"{CM.Glyphs.VLine}      {btn1} {btn2} {btn3} {btn4}      {CM.Glyphs.VLine}";
-			var width = buttonRow.GetColumns ();
-			d.SetBufferSize (width, 3);
-
-			// Default - Center
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			buttonRow = $"{CM.Glyphs.VLine}{btn1}     {btn2}     {btn3}     {btn4}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.GetColumns ());
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			buttonRow = $"{CM.Glyphs.VLine}            {btn1} {btn2} {btn3} {btn4}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.GetColumns ());
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2} {btn3} {btn4}            {CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.GetColumns ());
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void ButtonAlignment_Four_WideOdd ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-
-			// E.g "|[ yes ][ no ][ maybe ]|"
-			var btn1Text = "really long button 1";
-			var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
-			var btn2Text = "really long button 2";
-			var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
-			var btn3Text = "really long button 3";
-			var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
-			var btn4Text = "really long button 44"; // 44 is intentional to make length different than rest
-			var btn4 = $"{CM.Glyphs.LeftBracket} {btn4Text} {CM.Glyphs.RightBracket}";
-
-			// Note extra spaces to make dialog even wider
-			//                         123456                          1234567
-			var buttonRow = $"{CM.Glyphs.VLine}      {btn1} {btn2} {btn3} {btn4}      {CM.Glyphs.VLine}";
-			var width = buttonRow.Length;
-			d.SetBufferSize (buttonRow.Length, 1);
-
-			// Default - Center
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			buttonRow = $"{CM.Glyphs.VLine}{btn1}     {btn2}     {btn3}     {btn4}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			buttonRow = $"{CM.Glyphs.VLine}            {btn1} {btn2} {btn3} {btn4}{CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2} {btn3} {btn4}            {CM.Glyphs.VLine}";
-			Assert.Equal (width, buttonRow.Length);
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Zero_Buttons_Works ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-
-			var buttonRow = $"{CM.Glyphs.VLine}        {CM.Glyphs.VLine}";
-			var width = buttonRow.Length;
-			d.SetBufferSize (buttonRow.Length, 3);
-
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, null);
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void One_Button_Works ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "";
-			var btnText = "ok";
-			var buttonRow = $"{CM.Glyphs.VLine}   {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}   {CM.Glyphs.VLine}";
-
-			var width = buttonRow.Length;
-			d.SetBufferSize (buttonRow.Length, 10);
-
-			(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Add_Button_Works ()
-		{
-			RunState runstate = null;
-
-			var d = (FakeDriver)Application.Driver;
-
-			var title = "1234";
-			var btn1Text = "yes";
-			var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
-			var btn2Text = "no";
-			var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
-
-			// We test with one button first, but do this to get the width right for 2
-			var width = $@"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}".Length;
-			d.SetBufferSize (width, 1);
-
-			// Default (center)
-			var dlg = new Dialog (new Button (btn1Text)) { Title = title, Width = width, Height = 1, ButtonAlignment = Dialog.ButtonAlignments.Center };
-			// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
-			dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
-			runstate = Application.Begin (dlg);
-			var buttonRow = $"{CM.Glyphs.VLine}     {btn1}    {CM.Glyphs.VLine}";
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-
-			// Now add a second button
-			buttonRow = $"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}";
-			dlg.AddButton (new Button (btn2Text));
-			bool first = false;
-			Application.RunIteration (ref runstate, ref first);
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Justify
-			dlg = new Dialog (new Button (btn1Text)) { Title = title, Width = width, Height = 1, ButtonAlignment = Dialog.ButtonAlignments.Justify };
-			// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
-			dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
-			runstate = Application.Begin (dlg);
-			buttonRow = $"{CM.Glyphs.VLine}         {btn1}{CM.Glyphs.VLine}";
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-
-			// Now add a second button
-			buttonRow = $"{CM.Glyphs.VLine}{btn1}   {btn2}{CM.Glyphs.VLine}";
-			dlg.AddButton (new Button (btn2Text));
-			first = false;
-			Application.RunIteration (ref runstate, ref first);
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Right
-			dlg = new Dialog (new Button (btn1Text)) { Title = title, Width = width, Height = 1, ButtonAlignment = Dialog.ButtonAlignments.Right };
-			// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
-			dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
-			runstate = Application.Begin (dlg);
-			buttonRow = $"{CM.Glyphs.VLine}{new string (' ', width - btn1.Length - 2)}{btn1}{CM.Glyphs.VLine}";
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-
-			// Now add a second button
-			buttonRow = $"{CM.Glyphs.VLine}  {btn1} {btn2}{CM.Glyphs.VLine}";
-			dlg.AddButton (new Button (btn2Text));
-			first = false;
-			Application.RunIteration (ref runstate, ref first);
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-
-			// Left
-			dlg = new Dialog (new Button (btn1Text)) { Title = title, Width = width, Height = 1, ButtonAlignment = Dialog.ButtonAlignments.Left };
-			// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
-			dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
-			runstate = Application.Begin (dlg);
-			buttonRow = $"{CM.Glyphs.VLine}{btn1}{new string (' ', width - btn1.Length - 2)}{CM.Glyphs.VLine}";
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-
-			// Now add a second button
-			buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2}  {CM.Glyphs.VLine}";
-			dlg.AddButton (new Button (btn2Text));
-			first = false;
-			Application.RunIteration (ref runstate, ref first);
-			TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
-			Application.End (runstate);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void FileDialog_FileSystemWatcher ()
-		{
-			for (int i = 0; i < 8; i++) {
-				var fd = new FileDialog ();
-				fd.Ready += (s, e) => Application.RequestStop ();
-				Application.Run (fd);
+			} else if (iterations > 0) {
+				RequestStop ();
 			}
+		};
+
+		Begin (Top);
+		((FakeDriver)Driver).SetBufferSize (20, 10);
+		Run ();
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void ButtonAlignment_One ()
+	{
+		var d = (FakeDriver)Driver;
+		RunState runstate = null;
+
+		var title = "1234";
+		// E.g "|[ ok ]|"
+		var btnText = "ok";
+		var buttonRow = $"{CM.Glyphs.VLine}  {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}  {CM.Glyphs.VLine}";
+		var width = buttonRow.Length;
+
+		d.SetBufferSize (width, 1);
+
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
+		// Center
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify 
+		buttonRow = $"{CM.Glyphs.VLine}    {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btnText));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		buttonRow = $"{CM.Glyphs.VLine}    {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btnText));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}    {CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btnText));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Wider
+		buttonRow = $"{CM.Glyphs.VLine}   {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}   {CM.Glyphs.VLine}";
+		width = buttonRow.Length;
+
+		d.SetBufferSize (width, 1);
+
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		buttonRow = $"{CM.Glyphs.VLine}      {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btnText));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		buttonRow = $"{CM.Glyphs.VLine}      {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btnText));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}      {CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btnText));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void ButtonAlignment_Two ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+		// E.g "|[ yes ][ no ]|"
+		var btn1Text = "yes";
+		var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
+		var btn2Text = "no";
+		var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
+
+		var buttonRow = $@"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}";
+		var width = buttonRow.Length;
+
+		d.SetBufferSize (buttonRow.Length, 3);
+
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		buttonRow = $@"{CM.Glyphs.VLine}{btn1}   {btn2}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		buttonRow = $@"{CM.Glyphs.VLine}  {btn1} {btn2}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		buttonRow = $@"{CM.Glyphs.VLine}{btn1} {btn2}  {CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void ButtonAlignment_Two_Hidden ()
+	{
+		RunState runstate = null;
+		var firstIteration = false;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+		// E.g "|[ yes ][ no ]|"
+		var btn1Text = "yes";
+		var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
+		var btn2Text = "no";
+		var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
+
+		var buttonRow = $@"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}";
+		var width = buttonRow.Length;
+
+		d.SetBufferSize (buttonRow.Length, 3);
+
+		Dialog dlg = null;
+		Button button1, button2;
+
+		// Default (Center)
+		button1 = new Button (btn1Text);
+		button2 = new Button (btn2Text);
+		(runstate, dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, button1, button2);
+		button1.Visible = false;
+		RunIteration (ref runstate, ref firstIteration);
+		buttonRow = $@"{CM.Glyphs.VLine}         {btn2} {CM.Glyphs.VLine}";
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		Assert.Equal (width, buttonRow.Length);
+		button1 = new Button (btn1Text);
+		button2 = new Button (btn2Text);
+		(runstate, dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, button1, button2);
+		button1.Visible = false;
+		RunIteration (ref runstate, ref firstIteration);
+		buttonRow = $@"{CM.Glyphs.VLine}          {btn2}{CM.Glyphs.VLine}";
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		Assert.Equal (width, buttonRow.Length);
+		button1 = new Button (btn1Text);
+		button2 = new Button (btn2Text);
+		(runstate, dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, button1, button2);
+		button1.Visible = false;
+		RunIteration (ref runstate, ref firstIteration);
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		Assert.Equal (width, buttonRow.Length);
+		button1 = new Button (btn1Text);
+		button2 = new Button (btn2Text);
+		(runstate, dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, button1, button2);
+		button1.Visible = false;
+		RunIteration (ref runstate, ref firstIteration);
+		buttonRow = $@"{CM.Glyphs.VLine}        {btn2}  {CM.Glyphs.VLine}";
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void ButtonAlignment_Three ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+		// E.g "|[ yes ][ no ][ maybe ]|"
+		var btn1Text = "yes";
+		var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
+		var btn2Text = "no";
+		var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
+		var btn3Text = "maybe";
+		var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
+
+		var buttonRow = $@"{CM.Glyphs.VLine} {btn1} {btn2} {btn3} {CM.Glyphs.VLine}";
+		var width = buttonRow.Length;
+
+		d.SetBufferSize (buttonRow.Length, 3);
+
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		buttonRow = $@"{CM.Glyphs.VLine}{btn1}  {btn2}  {btn3}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		buttonRow = $@"{CM.Glyphs.VLine}  {btn1} {btn2} {btn3}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		buttonRow = $@"{CM.Glyphs.VLine}{btn1} {btn2} {btn3}  {CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void ButtonAlignment_Four ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+
+		// E.g "|[ yes ][ no ][ maybe ]|"
+		var btn1Text = "yes";
+		var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
+		var btn2Text = "no";
+		var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
+		var btn3Text = "maybe";
+		var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
+		var btn4Text = "never";
+		var btn4 = $"{CM.Glyphs.LeftBracket} {btn4Text} {CM.Glyphs.RightBracket}";
+
+		var buttonRow = $"{CM.Glyphs.VLine} {btn1} {btn2} {btn3} {btn4} {CM.Glyphs.VLine}";
+		var width = buttonRow.Length;
+		d.SetBufferSize (buttonRow.Length, 3);
+
+		// Default - Center
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2}  {btn3}  {btn4}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		buttonRow = $"{CM.Glyphs.VLine}  {btn1} {btn2} {btn3} {btn4}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2} {btn3} {btn4}  {CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void ButtonAlignment_Four_On_Too_Small_Width ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+
+		// E.g "|[ yes ][ no ][ maybe ][ never ]|"
+		var btn1Text = "yes";
+		var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
+		var btn2Text = "no";
+		var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
+		var btn3Text = "maybe";
+		var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
+		var btn4Text = "never";
+		var btn4 = $"{CM.Glyphs.LeftBracket} {btn4Text} {CM.Glyphs.RightBracket}";
+		var buttonRow = string.Empty;
+
+		var width = 30;
+		d.SetBufferSize (width, 1);
+
+		// Default - Center
+		buttonRow = $"{CM.Glyphs.VLine}es {CM.Glyphs.RightBracket} {btn2} {btn3} {CM.Glyphs.LeftBracket} neve{CM.Glyphs.VLine}";
+		(runstate, var dlg) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		Assert.Equal (new Size (width, 1), dlg.Frame.Size);
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		buttonRow =
+			$"{CM.Glyphs.VLine}{CM.Glyphs.LeftBracket} yes {CM.Glyphs.LeftBracket} no {CM.Glyphs.LeftBracket} maybe {CM.Glyphs.LeftBracket} never {CM.Glyphs.RightBracket}{CM.Glyphs.VLine}";
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		buttonRow = $"{CM.Glyphs.VLine}{CM.Glyphs.RightBracket} {btn2} {btn3} {btn4}{CM.Glyphs.VLine}";
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2} {btn3} {CM.Glyphs.LeftBracket} n{CM.Glyphs.VLine}";
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void ButtonAlignment_Four_Wider ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+
+		// E.g "|[ yes ][ no ][ maybe ]|"
+		var btn1Text = "yes";
+		var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
+		var btn2Text = "no";
+		var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
+		var btn3Text = "你你你你你"; // This is a wide char
+		var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
+		// Requires a Nerd Font
+		var btn4Text = "\uE36E\uE36F\uE370\uE371\uE372\uE373";
+		var btn4 = $"{CM.Glyphs.LeftBracket} {btn4Text} {CM.Glyphs.RightBracket}";
+
+		// Note extra spaces to make dialog even wider
+		//                         123456                           123456
+		var buttonRow = $"{CM.Glyphs.VLine}      {btn1} {btn2} {btn3} {btn4}      {CM.Glyphs.VLine}";
+		var width = buttonRow.GetColumns ();
+		d.SetBufferSize (width, 3);
+
+		// Default - Center
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		buttonRow = $"{CM.Glyphs.VLine}{btn1}     {btn2}     {btn3}     {btn4}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.GetColumns ());
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		buttonRow = $"{CM.Glyphs.VLine}            {btn1} {btn2} {btn3} {btn4}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.GetColumns ());
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2} {btn3} {btn4}            {CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.GetColumns ());
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void ButtonAlignment_Four_WideOdd ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+
+		// E.g "|[ yes ][ no ][ maybe ]|"
+		var btn1Text = "really long button 1";
+		var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
+		var btn2Text = "really long button 2";
+		var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
+		var btn3Text = "really long button 3";
+		var btn3 = $"{CM.Glyphs.LeftBracket} {btn3Text} {CM.Glyphs.RightBracket}";
+		var btn4Text = "really long button 44"; // 44 is intentional to make length different than rest
+		var btn4 = $"{CM.Glyphs.LeftBracket} {btn4Text} {CM.Glyphs.RightBracket}";
+
+		// Note extra spaces to make dialog even wider
+		//                         123456                          1234567
+		var buttonRow = $"{CM.Glyphs.VLine}      {btn1} {btn2} {btn3} {btn4}      {CM.Glyphs.VLine}";
+		var width = buttonRow.Length;
+		d.SetBufferSize (buttonRow.Length, 1);
+
+		// Default - Center
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		buttonRow = $"{CM.Glyphs.VLine}{btn1}     {btn2}     {btn3}     {btn4}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		buttonRow = $"{CM.Glyphs.VLine}            {btn1} {btn2} {btn3} {btn4}{CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2} {btn3} {btn4}            {CM.Glyphs.VLine}";
+		Assert.Equal (width, buttonRow.Length);
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void Zero_Buttons_Works ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+
+		var buttonRow = $"{CM.Glyphs.VLine}        {CM.Glyphs.VLine}";
+		var width = buttonRow.Length;
+		d.SetBufferSize (buttonRow.Length, 3);
+
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, null);
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void One_Button_Works ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "";
+		var btnText = "ok";
+		var buttonRow = $"{CM.Glyphs.VLine}   {CM.Glyphs.LeftBracket} {btnText} {CM.Glyphs.RightBracket}   {CM.Glyphs.VLine}";
+
+		var width = buttonRow.Length;
+		d.SetBufferSize (buttonRow.Length, 10);
+
+		(runstate, var _) = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void Add_Button_Works ()
+	{
+		RunState runstate = null;
+
+		var d = (FakeDriver)Driver;
+
+		var title = "1234";
+		var btn1Text = "yes";
+		var btn1 = $"{CM.Glyphs.LeftBracket} {btn1Text} {CM.Glyphs.RightBracket}";
+		var btn2Text = "no";
+		var btn2 = $"{CM.Glyphs.LeftBracket} {btn2Text} {CM.Glyphs.RightBracket}";
+
+		// We test with one button first, but do this to get the width right for 2
+		var width = $@"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}".Length;
+		d.SetBufferSize (width, 1);
+
+		// Default (center)
+		var dlg = new Dialog (new Button (btn1Text)) { Title = title, Width = width, Height = 1, ButtonAlignment = Dialog.ButtonAlignments.Center };
+		// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
+		dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
+		runstate = Begin (dlg);
+		var buttonRow = $"{CM.Glyphs.VLine}     {btn1}    {CM.Glyphs.VLine}";
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+
+		// Now add a second button
+		buttonRow = $"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}";
+		dlg.AddButton (new Button (btn2Text));
+		var first = false;
+		RunIteration (ref runstate, ref first);
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Justify
+		dlg = new Dialog (new Button (btn1Text)) { Title = title, Width = width, Height = 1, ButtonAlignment = Dialog.ButtonAlignments.Justify };
+		// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
+		dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
+		runstate = Begin (dlg);
+		buttonRow = $"{CM.Glyphs.VLine}         {btn1}{CM.Glyphs.VLine}";
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+
+		// Now add a second button
+		buttonRow = $"{CM.Glyphs.VLine}{btn1}   {btn2}{CM.Glyphs.VLine}";
+		dlg.AddButton (new Button (btn2Text));
+		first = false;
+		RunIteration (ref runstate, ref first);
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Right
+		dlg = new Dialog (new Button (btn1Text)) { Title = title, Width = width, Height = 1, ButtonAlignment = Dialog.ButtonAlignments.Right };
+		// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
+		dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
+		runstate = Begin (dlg);
+		buttonRow = $"{CM.Glyphs.VLine}{new string (' ', width - btn1.Length - 2)}{btn1}{CM.Glyphs.VLine}";
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+
+		// Now add a second button
+		buttonRow = $"{CM.Glyphs.VLine}  {btn1} {btn2}{CM.Glyphs.VLine}";
+		dlg.AddButton (new Button (btn2Text));
+		first = false;
+		RunIteration (ref runstate, ref first);
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+
+		// Left
+		dlg = new Dialog (new Button (btn1Text)) { Title = title, Width = width, Height = 1, ButtonAlignment = Dialog.ButtonAlignments.Left };
+		// Create with no top or bottom border to simplify testing button layout (no need to account for title etc..)
+		dlg.Border.Thickness = new Thickness (1, 0, 1, 0);
+		runstate = Begin (dlg);
+		buttonRow = $"{CM.Glyphs.VLine}{btn1}{new string (' ', width - btn1.Length - 2)}{CM.Glyphs.VLine}";
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+
+		// Now add a second button
+		buttonRow = $"{CM.Glyphs.VLine}{btn1} {btn2}  {CM.Glyphs.VLine}";
+		dlg.AddButton (new Button (btn2Text));
+		first = false;
+		RunIteration (ref runstate, ref first);
+		TestHelpers.AssertDriverContentsWithFrameAre ($"{buttonRow}", output);
+		End (runstate);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void FileDialog_FileSystemWatcher ()
+	{
+		for (var i = 0; i < 8; i++) {
+			var fd = new FileDialog ();
+			fd.Ready += (s, e) => RequestStop ();
+			Run (fd);
 		}
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Dialog_Opened_From_Another_Dialog ()
-		{
-			((FakeDriver)Application.Driver).SetBufferSize (30, 10);
+	[Fact] [AutoInitShutdown]
+	public void Dialog_Opened_From_Another_Dialog ()
+	{
+		((FakeDriver)Driver).SetBufferSize (30, 10);
 
-			var btn1 = new Button ("press me 1");
-			Button btn2 = null;
-			Button btn3 = null;
-			string expected = null;
-			btn1.Clicked += (s, e) => {
-				btn2 = new Button ("Show Sub");
-				btn3 = new Button ("Close");
-				btn3.Clicked += (s, e) => Application.RequestStop ();
-				btn2.Clicked += (s, e) => {
-					// Don't test MessageBox in Dialog unit tests!
-					var subBtn = new Button ("Ok") { IsDefault = true };
-					var subDlg = new Dialog (subBtn) { Text = "ya", Width = 20, Height = 5 };
-					subBtn.Clicked += (s, e) => Application.RequestStop (subDlg);
-					Application.Run (subDlg);
-				};
-				var dlg = new Dialog (btn2, btn3);
-
-				Application.Run (dlg);
+		var btn1 = new Button ("press me 1");
+		Button btn2 = null;
+		Button btn3 = null;
+		string expected = null;
+		btn1.Clicked += (s, e) => {
+			btn2 = new Button ("Show Sub");
+			btn3 = new Button ("Close");
+			btn3.Clicked += (s, e) => RequestStop ();
+			btn2.Clicked += (s, e) => {
+				// Don't test MessageBox in Dialog unit tests!
+				var subBtn = new Button ("Ok") { IsDefault = true };
+				var subDlg = new Dialog (subBtn) { Text = "ya", Width = 20, Height = 5 };
+				subBtn.Clicked += (s, e) => RequestStop (subDlg);
+				Run (subDlg);
 			};
-			var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} Ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+			var dlg = new Dialog (btn2, btn3);
 
-			var iterations = -1;
-			Application.Iteration += (s, a) => {
-				iterations++;
-				if (iterations == 0) {
-					Assert.True (btn1.NewKeyDownEvent (new (KeyCode.Space)));
-				} else if (iterations == 1) {
-					expected = @$"
+			Run (dlg);
+		};
+		var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} Ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+
+		var iterations = -1;
+		Iteration += (s, a) => {
+			iterations++;
+			if (iterations == 0) {
+				Assert.True (btn1.NewKeyDownEvent (new Key (KeyCode.Space)));
+			} else if (iterations == 1) {
+				expected = @$"
   ┌───────────────────────┐
   │                       │
   │                       │
@@ -818,11 +809,11 @@ namespace Terminal.Gui.DialogTests {
   │                       │
   │{CM.Glyphs.LeftBracket} Show Sub {CM.Glyphs.RightBracket} {CM.Glyphs.LeftBracket} Close {CM.Glyphs.RightBracket} │
   └───────────────────────┘";
-					TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+				TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
-					Assert.True (btn2.NewKeyDownEvent (new (KeyCode.Space)));
-				} else if (iterations == 2) {
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				Assert.True (btn2.NewKeyDownEvent (new Key (KeyCode.Space)));
+			} else if (iterations == 2) {
+				TestHelpers.AssertDriverContentsWithFrameAre (@$"
   ┌───────────────────────┐
   │  ┌──────────────────┐ │
   │  │ya                │ │
@@ -832,257 +823,323 @@ namespace Terminal.Gui.DialogTests {
   │{CM.Glyphs.LeftBracket} Show Sub {CM.Glyphs.RightBracket} {CM.Glyphs.LeftBracket} Close {CM.Glyphs.RightBracket} │
   └───────────────────────┘", output);
 
-					Assert.True (Application.Current.NewKeyDownEvent (new (KeyCode.Enter)));
-				} else if (iterations == 3) {
-					TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+				Assert.True (Current.NewKeyDownEvent (new Key (KeyCode.Enter)));
+			} else if (iterations == 3) {
+				TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
-					Assert.True (btn3.NewKeyDownEvent (new (KeyCode.Space)));
-				} else if (iterations == 4) {
-					TestHelpers.AssertDriverContentsWithFrameAre ("", output);
+				Assert.True (btn3.NewKeyDownEvent (new Key (KeyCode.Space)));
+			} else if (iterations == 4) {
+				TestHelpers.AssertDriverContentsWithFrameAre ("", output);
 
-					Application.RequestStop ();
-				}
-			};
+				RequestStop ();
+			}
+		};
 
-			Application.Run ();
-			Application.Shutdown ();
+		Run ();
+		Shutdown ();
 
-			Assert.Equal (4, iterations);
-		}
+		Assert.Equal (4, iterations);
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Dialog_In_Window_With_Size_One_Button_Aligns ()
-		{
-			((FakeDriver)Application.Driver).SetBufferSize (20, 5);
+	[Fact] [AutoInitShutdown]
+	public void Dialog_In_Window_With_Size_One_Button_Aligns ()
+	{
+		((FakeDriver)Driver).SetBufferSize (20, 5);
 
-			var win = new Window ();
+		var win = new Window ();
 
-			int iterations = 0;
-			Application.Iteration += (s, a) => {
-				if (++iterations > 2) {
-					Application.RequestStop ();
-				}
-			};
-			var btn = $"{CM.Glyphs.LeftBracket} Ok {CM.Glyphs.RightBracket}";
+		var iterations = 0;
+		Iteration += (s, a) => {
+			if (++iterations > 2) {
+				RequestStop ();
+			}
+		};
+		var btn = $"{CM.Glyphs.LeftBracket} Ok {CM.Glyphs.RightBracket}";
 
-			win.Loaded += (s, a) => {
-				var dlg = new Dialog (new Button ("Ok")) { Width = 18, Height = 3 };
+		win.Loaded += (s, a) => {
+			var dlg = new Dialog (new Button ("Ok")) { Width = 18, Height = 3 };
 
-				dlg.Loaded += (s, a) => {
-					Application.Refresh ();
-					var expected = @$"
+			dlg.Loaded += (s, a) => {
+				Refresh ();
+				var expected = @$"
 ┌──────────────────┐
 │┌────────────────┐│
 ││     {btn}     ││
 │└────────────────┘│
 └──────────────────┘";
-					_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
-				};
-
-				Application.Run (dlg);
+				_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 			};
-			Application.Run (win);
-		}
 
-		//		[Theory, AutoInitShutdown]
-		//		[InlineData (5)]
-		//		//[InlineData (6)]
-		//		//[InlineData (7)]
-		//		//[InlineData (8)]
-		//		//[InlineData (9)]
-		//		public void Dialog_In_Window_Without_Size_One_Button_Aligns (int height)
-		//		{
-		//			((FakeDriver)Application.Driver).SetBufferSize (20, height);
-		//			var win = new Window ();
+			Run (dlg);
+		};
+		Run (win);
+	}
 
-		//			Application.Iteration += (s, a) => {
-		//				var dlg = new Dialog ("Test", new Button ("Ok"));
+	//		[Theory, AutoInitShutdown]
+	//		[InlineData (5)]
+	//		//[InlineData (6)]
+	//		//[InlineData (7)]
+	//		//[InlineData (8)]
+	//		//[InlineData (9)]
+	//		public void Dialog_In_Window_Without_Size_One_Button_Aligns (int height)
+	//		{
+	//			((FakeDriver)Application.Driver).SetBufferSize (20, height);
+	//			var win = new Window ();
 
-		//				dlg.LayoutComplete += (s, a) => {
-		//					Application.Refresh ();
-		//					// BUGBUG: This seems wrong; is it a bug in Dim.Percent(85)??
-		//					var expected = @"
-		//┌┌┤Test├─────────┐─┐
-		//││               │ │
-		//││     [ Ok ]    │ │
-		//│└───────────────┘ │
-		//└──────────────────┘";
-		//					_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+	//			Application.Iteration += (s, a) => {
+	//				var dlg = new Dialog ("Test", new Button ("Ok"));
 
-		//					dlg.RequestStop ();
-		//					win.RequestStop ();
-		//				};
+	//				dlg.LayoutComplete += (s, a) => {
+	//					Application.Refresh ();
+	//					// BUGBUG: This seems wrong; is it a bug in Dim.Percent(85)??
+	//					var expected = @"
+	//┌┌┤Test├─────────┐─┐
+	//││               │ │
+	//││     [ Ok ]    │ │
+	//│└───────────────┘ │
+	//└──────────────────┘";
+	//					_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
-		//				Application.Run (dlg);
-		//			};
+	//					dlg.RequestStop ();
+	//					win.RequestStop ();
+	//				};
 
-		//			Application.Run (win);
-		//			Application.Shutdown ();
-		//		}
+	//				Application.Run (dlg);
+	//			};
 
-		[Fact, AutoInitShutdown]
-		public void Dialog_In_Window_With_TextField_And_Button_AnchorEnd ()
-		{
-			((FakeDriver)Application.Driver).SetBufferSize (20, 5);
+	//			Application.Run (win);
+	//			Application.Shutdown ();
+	//		}
 
-			var win = new Window ();
+	[Fact] [AutoInitShutdown]
+	public void Dialog_In_Window_With_TextField_And_Button_AnchorEnd ()
+	{
+		((FakeDriver)Driver).SetBufferSize (20, 5);
 
-			int iterations = 0;
-			Application.Iteration += (s, a) => {
-				if (++iterations > 2) {
-					Application.RequestStop ();
-				}
+		var win = new Window ();
+
+		var iterations = 0;
+		Iteration += (s, a) => {
+			if (++iterations > 2) {
+				RequestStop ();
+			}
+		};
+		var b = $"{CM.Glyphs.LeftBracket} Ok {CM.Glyphs.RightBracket}";
+
+		win.Loaded += (s, a) => {
+			var dlg = new Dialog { Width = 18, Height = 3 };
+			Button btn = null;
+			btn = new Button ("Ok") {
+				X = Pos.AnchorEnd () - Pos.Function (Btn_Width)
 			};
-			var b = $"{CM.Glyphs.LeftBracket} Ok {CM.Glyphs.RightBracket}";
+			int Btn_Width () => btn?.Bounds.Width ?? 0;
+			var tf = new TextField ("01234567890123456789") {
+				Width = Dim.Fill (1) - Dim.Function (Btn_Width)
+			};
 
-			win.Loaded += (s, a) => {
-				var dlg = new Dialog () { Width = 18, Height = 3 };
-				Button btn = null;
-				btn = new Button ("Ok") {
-					X = Pos.AnchorEnd () - Pos.Function (Btn_Width)
-				};
-				int Btn_Width ()
-				{
-					return (btn?.Bounds.Width) ?? 0;
-				}
-				var tf = new TextField ("01234567890123456789") {
-					Width = Dim.Fill (1) - Dim.Function (Btn_Width)
-				};
-
-				dlg.Loaded += (s, a) => {
-					Application.Refresh ();
-					Assert.Equal (new Rect (10, 0, 6, 1), btn.Frame);
-					Assert.Equal (new Rect (0, 0, 6, 1), btn.Bounds);
-					var expected = @$"
+			dlg.Loaded += (s, a) => {
+				Refresh ();
+				Assert.Equal (new Rect (10, 0, 6, 1), btn.Frame);
+				Assert.Equal (new Rect (0,  0, 6, 1), btn.Bounds);
+				var expected = @$"
 ┌──────────────────┐
 │┌────────────────┐│
 ││23456789  {b}││
 │└────────────────┘│
 └──────────────────┘";
-					_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
+				_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
-					dlg.SetNeedsLayout ();
-					dlg.LayoutSubviews ();
-					Application.Refresh ();
-					Assert.Equal (new Rect (10, 0, 6, 1), btn.Frame);
-					Assert.Equal (new Rect (0, 0, 6, 1), btn.Bounds);
-					expected = @$"
+				dlg.SetNeedsLayout ();
+				dlg.LayoutSubviews ();
+				Refresh ();
+				Assert.Equal (new Rect (10, 0, 6, 1), btn.Frame);
+				Assert.Equal (new Rect (0,  0, 6, 1), btn.Bounds);
+				expected = @$"
 ┌──────────────────┐
 │┌────────────────┐│
 ││23456789  {b}││
 │└────────────────┘│
 └──────────────────┘";
-					_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
-				};
-				dlg.Add (btn, tf);
-
-				Application.Run (dlg);
+				_ = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 			};
-			Application.Run (win);
-		}
+			dlg.Add (btn, tf);
 
-		[Fact]
-		[AutoInitShutdown]
-		public void KeyBindings_Esc_Closes ()
-		{
-			// test that Esc is bound to the Cancel command
-			var dlg = new Dialog ();
-			var dlgClosed = false;
-			dlg.Closed += (s, e) => {
-				dlgClosed = true;
-			};
-			
-			int iterations = 0;
-			Application.Iteration += (s, a) => {
-				dlg.NewKeyDownEvent (Key.Esc);
+			Run (dlg);
+		};
+		Run (win);
+	}
 
-				if (++iterations > 1) {
-					Assert.Fail ();
-				}
-			};
-			Application.Run (dlg);
-		}
+	[Fact]
+	[AutoInitShutdown]
+	public void KeyBindings_Esc_Closes ()
+	{
+		// test that Esc is bound to the Cancel command
+		var dlg = new Dialog ();
+		var dlgClosed = false;
+		dlg.Closed += (s, e) => {
+			dlgClosed = true;
+		};
 
+		var iterations = 0;
+		Iteration += (s, a) => {
+			dlg.NewKeyDownEvent (Key.Esc);
 
-		[Fact]
-		[AutoInitShutdown]
-		public void KeyBindings_Enter_No_Default_Button_NoOp ()
-		{
-			// test that Enter does nothing if there's no default button
-			var dlg = new Dialog ();
-			int iterations = 0;
-			Application.Iteration += (s, a) => {
-				if (++iterations > 1) {
-					Application.RequestStop ();
-				}
-				dlg.NewKeyDownEvent (Key.Enter);
-			};
-			Application.Run (dlg);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void KeyBindings_Enter_Invokes_Default_Button ()
-		{
-			var dlg = new Dialog ();
-			var ok = new Button () {
-				Text = "Ok",
-				IsDefault = true
-			};
-
-			ok.Clicked += (s, e) => {
-				Application.RequestStop ();
-			};
-
-			dlg.AddButton (ok);
-			
-			int iterations = 0;
-			void JustButtonIteration (object sender, IterationEventArgs e)
-			{
-				if (++iterations > 1) {
-					Assert.Fail ();
-					Application.RequestStop ();
-				}
-				dlg.NewKeyDownEvent (Key.Enter);
+			if (++iterations > 1) {
+				Assert.Fail ();
 			}
-			
-			Application.Iteration += JustButtonIteration;
-			Application.Run (dlg);
-			Application.Iteration -= JustButtonIteration;
+		};
+		Run (dlg);
+		Assert.True (dlgClosed);
+	}
 
-			// Now try it without a default button being focused
-			dlg = new Dialog ();
-			ok = new Button () {
-				Text = "Ok",
-				IsDefault = true
-			};
 
-			ok.Clicked += (s, e) => {
-				Application.RequestStop ();
-			};
-			
-			dlg.AddButton (ok);
-
-			var tf = new TextField () {
-				Text = "text",
-			};
-
-			dlg.Add (tf);
-
-			iterations = 0;
-			void ButtonAndTextFieldIteration (object sender, IterationEventArgs e)
-			{
-				if (++iterations > 1) {
-					Assert.Fail ();
-					Application.RequestStop ();
-				}
-				tf.SetFocus ();
-				dlg.NewKeyDownEvent (Key.Enter);
+	[Fact]
+	[AutoInitShutdown]
+	public void KeyBindings_Enter_No_Default_Button_NoOp ()
+	{
+		// test that Enter does nothing if there's no default button
+		var dlg = new Dialog ();
+		var iterations = 0;
+		Iteration += (s, a) => {
+			if (++iterations > 1) {
+				// If we get here, the test passed
+				RequestStop ();
 			}
+			dlg.NewKeyDownEvent (Key.Enter);
+		};
+		Run (dlg);
 
-			Application.Iteration += ButtonAndTextFieldIteration;
-			Application.Run (dlg);
-			Application.Iteration -= JustButtonIteration;
+		Assert.Equal (2, iterations);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void KeyBindings_Enter_Causes_Default_Button_Click ()
+	{
+		var dlg = new Dialog ();
+		var ok = new Button {
+			Text = "Ok",
+			IsDefault = true
+		};
+
+		var okClicked = false;
+		ok.Clicked += (s, e) => {
+			okClicked = true;
+			RequestStop ();
+		};
+
+		dlg.AddButton (ok);
+
+		var iterations = 0;
+		void JustButtonIteration (object sender, IterationEventArgs e)
+		{
+			if (++iterations > 1) {
+				Assert.Fail ();
+				RequestStop ();
+			}
+			Assert.True (ok.HasFocus);
+			dlg.NewKeyDownEvent (Key.Enter);
+		}
+
+		Iteration += JustButtonIteration;
+		Run (dlg);
+		Assert.True (okClicked);
+		Assert.Equal (1, iterations);
+		Iteration -= JustButtonIteration;
+		iterations = 0;
+		okClicked = false;
+
+		// Now try it without a default button being focused 
+		dlg = new Dialog ();
+		ok = new Button {
+			Text = "Ok",
+			IsDefault = true
+		};
+
+		ok.Clicked += (s, e) => {
+			okClicked = true;
+			RequestStop ();
+		};
+
+		dlg.AddButton (ok);
+
+		var focusableView = new View {
+			CanFocus = true
+		};
+
+		dlg.Add (focusableView);
+
+		void ButtonAndFocusableViewIteration (object sender, IterationEventArgs e)
+		{
+			if (++iterations > 1) {
+				Assert.Fail ();
+				RequestStop ();
+			}
+			focusableView.SetFocus ();
+			Assert.False (ok.HasFocus);
+			dlg.NewKeyDownEvent (Key.Enter);
+		}
+
+		Iteration += ButtonAndFocusableViewIteration;
+		Run (dlg);
+		Assert.Equal (1, iterations);
+		Iteration -= ButtonAndFocusableViewIteration;
+		iterations = 0;
+		okClicked = false;
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void KeyBindings_Enter_With_Focused_ViewThatEatsEnter_NoOp ()
+	{
+		var dlg = new Dialog ();
+		var ok = new Button {
+			Text = "Ok",
+			IsDefault = true
+		};
+
+		// Now try it without a default button being focused, with a view that 
+		// handles Enter. 
+		dlg = new Dialog ();
+		ok = new Button {
+			Text = "Ok",
+			IsDefault = true
+		};
+
+		var okClicked = false;
+		ok.Clicked += (s, e) => {
+			okClicked = true;
+			RequestStop ();
+		};
+
+		dlg.AddButton (ok);
+
+		var focusableView = new ViewThatEatsEnter ();
+
+		dlg.Add (focusableView);
+
+		var iterations = 0;
+		void Iteration (object sender, IterationEventArgs e)
+		{
+			if (++iterations > 1) {
+				RequestStop ();
+			}
+			focusableView.SetFocus ();
+			dlg.NewKeyDownEvent (Key.Enter);
+		}
+
+		Application.Iteration += Iteration;
+		Run (dlg);
+		Assert.Equal (2, iterations);
+		Assert.False (okClicked);
+	}
+
+	class ViewThatEatsEnter : View {
+		public ViewThatEatsEnter ()
+		{
+			CanFocus = true;
+			AddCommand (Command.Select, () => true);
+			KeyBindings.Add (Key.Enter, Command.Select);
 		}
 	}
 }

--- a/UnitTests/Dialogs/DialogTests.cs
+++ b/UnitTests/Dialogs/DialogTests.cs
@@ -983,17 +983,39 @@ namespace Terminal.Gui.DialogTests {
 
 		[Fact]
 		[AutoInitShutdown]
-		public void KeyBindings_Esc_Cancels ()
+		public void KeyBindings_Esc_Closes ()
 		{
 			// test that Esc is bound to the Cancel command
+			var dlg = new Dialog ();
+			var dlgClosed = false;
+			dlg.Closed += (s, e) => {
+				dlgClosed = true;
+			};
+			
+			int iterations = 0;
+			Application.Iteration += (s, a) => {
+				dlg.NewKeyDownEvent (Key.Esc);
+
+				if (++iterations > 1) {
+					Assert.Fail ();
+				}
+			};
+			Application.Run (dlg);
+		}
+
+
+		[Fact]
+		[AutoInitShutdown]
+		public void KeyBindings_Enter_No_Default_Button_NoOp ()
+		{
+			// test that Enter does nothing if there's no default button
 			var dlg = new Dialog ();
 			int iterations = 0;
 			Application.Iteration += (s, a) => {
 				if (++iterations > 1) {
-					Assert.Fail ();
 					Application.RequestStop ();
 				}
-				dlg.NewKeyDownEvent (Key.Esc);
+				dlg.NewKeyDownEvent (Key.Enter);
 			};
 			Application.Run (dlg);
 		}

--- a/UnitTests/Dialogs/MessageBoxTests.cs
+++ b/UnitTests/Dialogs/MessageBoxTests.cs
@@ -1,15 +1,13 @@
-﻿using Microsoft.VisualBasic;
-using System.Text;
+﻿using System.Text;
 using Xunit;
 using Xunit.Abstractions;
-using static Terminal.Gui.Application;
 
 namespace Terminal.Gui.DialogTests;
 
 public class MessageBoxTests {
-	readonly ITestOutputHelper output;
+	readonly ITestOutputHelper _output;
 
-	public MessageBoxTests (ITestOutputHelper output) => this.output = output;
+	public MessageBoxTests (ITestOutputHelper output) => _output = output;
 
 	[Fact]
 	[AutoInitShutdown]
@@ -192,7 +190,7 @@ public class MessageBoxTests {
                 │                                              │
                 │                                              │
                 └──────────────────────────────────────────────┘
-", output);
+", _output);
 
 				Application.RequestStop ();
 			}
@@ -236,7 +234,7 @@ public class MessageBoxTests {
 ║│                {btn}                │║
 ║└────────────────────────────────────────┘║
 ╚══════════════════════════════════════════╝
-", output);
+", _output);
 
 				Application.RequestStop ();
 			}
@@ -270,7 +268,7 @@ public class MessageBoxTests {
                                     │ ge  │
                                     │ Ok {CM.Glyphs.RightDefaultIndicator}│
                                     └─────┘
-", output);
+", _output);
 
 				Application.RequestStop ();
 			}
@@ -302,7 +300,7 @@ public class MessageBoxTests {
                                   │         │
                                   │{btn} │
                                   └─────────┘
-", output);
+", _output);
 
 				Application.RequestStop ();
 			}
@@ -342,7 +340,7 @@ public class MessageBoxTests {
 ║│                │║
 ║│    {btn}   │║
 ║└────────────────┘║
-╚══════════════════╝", output);
+╚══════════════════╝", _output);
 				Assert.Equal (new Size (20 - 2, 10 - 2), Application.Current.Frame.Size);
 				Application.RequestStop ();
 
@@ -360,7 +358,7 @@ public class MessageBoxTests {
 ║│ffffffffffffffff│║
 ║│ffffffffffffffff│║
 ║│    {btn}   │║
-╚└────────────────┘╝", output);
+╚└────────────────┘╝", _output);
 				Application.RequestStop ();
 			}
 		};
@@ -403,7 +401,7 @@ public class MessageBoxTests {
 ║ │              │ ║
 ║ │   {btn}  │ ║
 ║ └──────────────┘ ║
-╚══════════════════╝", output);
+╚══════════════════╝", _output);
 				Application.RequestStop ();
 
 				// Really long text
@@ -420,7 +418,7 @@ public class MessageBoxTests {
 ║│ffffffffffffffff│║
 ║│ffffffffffffffff│║
 ║│    {btn}   │║
-╚└────────────────┘╝", output);
+╚└────────────────┘╝", _output);
 				Application.RequestStop ();
 			}
 		};
@@ -458,7 +456,7 @@ ffffffffffffffffffff
 ────────────────────
 ║                  ║
 ║                  ║
-╚══════════════════╝", output);
+╚══════════════════╝", _output);
 
 				Application.RequestStop ();
 
@@ -476,7 +474,7 @@ ffffffffffffffffffff
 ────────────────────
 ║                  ║
 ║                  ║
-╚══════════════════╝", output);
+╚══════════════════╝", _output);
 
 				Application.RequestStop ();
 			}
@@ -519,7 +517,7 @@ ff ff ff ff ff ff ff
 ────────────────────
 ║                  ║
 ║                  ║
-╚══════════════════╝", output);
+╚══════════════════╝", _output);
 				Application.RequestStop ();
 
 				// Really long text
@@ -536,7 +534,7 @@ ffffffffffffffffffff
 ────────────────────
 ║                  ║
 ║                  ║
-╚══════════════════╝", output);
+╚══════════════════╝", _output);
 				Application.RequestStop ();
 			}
 		};
@@ -574,7 +572,7 @@ ffffffffffffffffffff
                 │                                              │
                 │                                              │
                 │                   {CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}                   │
-                └──────────────────────────────────────────────┘", output);
+                └──────────────────────────────────────────────┘", _output);
 				} else {
 					TestHelpers.AssertDriverContentsWithFrameAre (@$"
                 ┌──────────────────────────────────────────────┐
@@ -582,7 +580,7 @@ ffffffffffffffffffff
                 │                                              │
                 │                                              │
                 │                   {CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}                   │
-                └──────────────────────────────────────────────┘", output);
+                └──────────────────────────────────────────────┘", _output);
 				}
 				Application.RequestStop ();
 			}

--- a/UnitTests/Dialogs/MessageBoxTests.cs
+++ b/UnitTests/Dialogs/MessageBoxTests.cs
@@ -1,195 +1,192 @@
-﻿using System.Threading.Tasks;
+﻿using Microsoft.VisualBasic;
+using System.Text;
 using Xunit;
 using Xunit.Abstractions;
-using System.Text;
-using Terminal.Gui;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using static Terminal.Gui.Application;
 
-namespace Terminal.Gui.DialogTests {
+namespace Terminal.Gui.DialogTests;
 
-	public class MessageBoxTests {
-		readonly ITestOutputHelper output;
+public class MessageBoxTests {
+	readonly ITestOutputHelper output;
 
-		public MessageBoxTests (ITestOutputHelper output)
-		{
-			this.output = output;
-		}
+	public MessageBoxTests (ITestOutputHelper output) => this.output = output;
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Size_Default ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+	[Fact]
+	[AutoInitShutdown]
+	public void Size_Default ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		((FakeDriver)Application.Driver).SetBufferSize (100, 100);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (string.Empty, string.Empty, null);
+			if (iterations == 0) {
+				MessageBox.Query (string.Empty, string.Empty, null);
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
 
-					Assert.IsType<Dialog> (Application.Current);
-					// Default size is Percent(60) 
-					Assert.Equal (new Size ((int)(100 * .60), 5), Application.Current.Frame.Size);
+				Assert.IsType<Dialog> (Application.Current);
+				// Default size is Percent(60) 
+				Assert.Equal (new Size ((int)(100 * .60), 5), Application.Current.Frame.Size);
 
-					Application.RequestStop ();
-				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Location_Default ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+	[Fact]
+	[AutoInitShutdown]
+	public void Location_Default ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		((FakeDriver)Application.Driver).SetBufferSize (100, 100);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (string.Empty, string.Empty, null);
+			if (iterations == 0) {
+				MessageBox.Query (string.Empty, string.Empty, null);
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
 
-					Assert.IsType<Dialog> (Application.Current);
-					// Default location is centered, so
-					// X = (100 / 2) - (60 / 2) = 20
-					// Y = (100 / 2) - (5 / 2) = 47
-					Assert.Equal (new Point (20, 47), Application.Current.Frame.Location);
+				Assert.IsType<Dialog> (Application.Current);
+				// Default location is centered, so
+				// X = (100 / 2) - (60 / 2) = 20
+				// Y = (100 / 2) - (5 / 2) = 47
+				Assert.Equal (new Point (20, 47), Application.Current.Frame.Location);
 
-					Application.RequestStop ();
-				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
 
-		[Theory]
-		[InlineData (0, 0)]
-		[InlineData (1, 1)]
-		[InlineData (7, 5)]
-		[InlineData (50, 50)]
-		[AutoInitShutdown]
-		public void Size_Not_Default_No_Message (int height, int width)
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+	[Theory]
+	[InlineData (0, 0)]
+	[InlineData (1, 1)]
+	[InlineData (7, 5)]
+	[InlineData (50, 50)]
+	[AutoInitShutdown]
+	public void Size_Not_Default_No_Message (int height, int width)
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		((FakeDriver)Application.Driver).SetBufferSize (100, 100);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (height, width, string.Empty, string.Empty, null);
+			if (iterations == 0) {
+				MessageBox.Query (height, width, string.Empty, string.Empty, null);
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
 
-					Assert.IsType<Dialog> (Application.Current);
-					Assert.Equal (new Size (height, width), Application.Current.Frame.Size);
+				Assert.IsType<Dialog> (Application.Current);
+				Assert.Equal (new Size (height, width), Application.Current.Frame.Size);
 
-					Application.RequestStop ();
-				}
-			};
-		}
+				Application.RequestStop ();
+			}
+		};
+	}
 
-		[Theory]
-		[InlineData (0, 0, "1")]
-		[InlineData (1, 1, "1")]
-		[InlineData (7, 5, "1")]
-		[InlineData (50, 50, "1")]
-		[InlineData (0, 0, "message")]
-		[InlineData (1, 1, "message")]
-		[InlineData (7, 5, "message")]
-		[InlineData (50, 50, "message")]
-		[AutoInitShutdown]
-		public void Size_Not_Default_Message (int height, int width, string message)
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+	[Theory]
+	[InlineData (0, 0, "1")]
+	[InlineData (1, 1, "1")]
+	[InlineData (7, 5, "1")]
+	[InlineData (50, 50, "1")]
+	[InlineData (0, 0, "message")]
+	[InlineData (1, 1, "message")]
+	[InlineData (7, 5, "message")]
+	[InlineData (50, 50, "message")]
+	[AutoInitShutdown]
+	public void Size_Not_Default_Message (int height, int width, string message)
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		((FakeDriver)Application.Driver).SetBufferSize (100, 100);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (height, width, string.Empty, message, null);
+			if (iterations == 0) {
+				MessageBox.Query (height, width, string.Empty, message, null);
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
 
-					Assert.IsType<Dialog> (Application.Current);
-					Assert.Equal (new Size (height, width), Application.Current.Frame.Size);
+				Assert.IsType<Dialog> (Application.Current);
+				Assert.Equal (new Size (height, width), Application.Current.Frame.Size);
 
-					Application.RequestStop ();
-				}
-			};
-		}
+				Application.RequestStop ();
+			}
+		};
+	}
 
-		[Theory]
-		[InlineData (0, 0, "1")]
-		[InlineData (1, 1, "1")]
-		[InlineData (7, 5, "1")]
-		[InlineData (50, 50, "1")]
-		[InlineData (0, 0, "message")]
-		[InlineData (1, 1, "message")]
-		[InlineData (7, 5, "message")]
-		[InlineData (50, 50, "message")]
-		[AutoInitShutdown]
-		public void Size_Not_Default_Message_Button (int height, int width, string message)
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			((FakeDriver)Application.Driver).SetBufferSize (100, 100);
+	[Theory]
+	[InlineData (0, 0, "1")]
+	[InlineData (1, 1, "1")]
+	[InlineData (7, 5, "1")]
+	[InlineData (50, 50, "1")]
+	[InlineData (0, 0, "message")]
+	[InlineData (1, 1, "message")]
+	[InlineData (7, 5, "message")]
+	[InlineData (50, 50, "message")]
+	[AutoInitShutdown]
+	public void Size_Not_Default_Message_Button (int height, int width, string message)
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		((FakeDriver)Application.Driver).SetBufferSize (100, 100);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (height, width, string.Empty, message, "_Ok");
+			if (iterations == 0) {
+				MessageBox.Query (height, width, string.Empty, message, "_Ok");
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
 
-					Assert.IsType<Dialog> (Application.Current);
-					Assert.Equal (new Size (height, width), Application.Current.Frame.Size);
+				Assert.IsType<Dialog> (Application.Current);
+				Assert.Equal (new Size (height, width), Application.Current.Frame.Size);
 
-					Application.RequestStop ();
-				}
-			};
-		}
+				Application.RequestStop ();
+			}
+		};
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Size_None_No_Buttons ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
+	[Fact]
+	[AutoInitShutdown]
+	public void Size_None_No_Buttons ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query ("Title", "Message");
+			if (iterations == 0) {
+				MessageBox.Query ("Title", "Message");
 
-					Application.RequestStop ();
+				Application.RequestStop ();
 
-				} else if (iterations == 1) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@"
+			} else if (iterations == 1) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@"
                 ┌┤Title├───────────────────────────────────────┐
                 │                   Message                    │
                 │                                              │
@@ -197,39 +194,40 @@ namespace Terminal.Gui.DialogTests {
                 └──────────────────────────────────────────────┘
 ", output);
 
-					Application.RequestStop ();
-				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Size_No_With_Button ()
-		{
-			Application.Top.BorderStyle = LineStyle.Double;
-			var iterations = -1;
-			Application.Begin (Application.Top);
+	[Fact]
+	[AutoInitShutdown]
+	public void Size_No_With_Button ()
+	{
+		Application.Top.BorderStyle = LineStyle.Double;
+		var iterations = -1;
+		Application.Begin (Application.Top);
 
-			var aboutMessage = new StringBuilder ();
-			aboutMessage.AppendLine (@"0123456789012345678901234567890123456789");
-			aboutMessage.AppendLine (@"https://github.com/gui-cs/Terminal.Gui");
-			var message = aboutMessage.ToString ();
-			var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} Ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+		var aboutMessage = new StringBuilder ();
+		aboutMessage.AppendLine (@"0123456789012345678901234567890123456789");
+		aboutMessage.AppendLine (@"https://github.com/gui-cs/Terminal.Gui");
+		var message = aboutMessage.ToString ();
+		var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} Ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
 
-			((FakeDriver)Application.Driver).SetBufferSize (40 + 4, 8);
+		((FakeDriver)Application.Driver).SetBufferSize (40 + 4, 8);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
+			if (iterations == 0) {
 
-					MessageBox.Query (string.Empty, message, "_Ok");
+				MessageBox.Query (string.Empty, message, "_Ok");
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@$"
 ╔══════════════════════════════════════════╗
 ║┌────────────────────────────────────────┐║
 ║│0123456789012345678901234567890123456789│║
@@ -240,32 +238,33 @@ namespace Terminal.Gui.DialogTests {
 ╚══════════════════════════════════════════╝
 ", output);
 
-					Application.RequestStop ();
-				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Size_Tiny_Fixed_Size ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
+	[Fact]
+	[AutoInitShutdown]
+	public void Size_Tiny_Fixed_Size ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (7, 5, string.Empty, "Message", "_Ok");
+			if (iterations == 0) {
+				MessageBox.Query (7, 5, string.Empty, "Message", "_Ok");
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
 
-					Assert.Equal (new Size (7, 5), Application.Current.Frame.Size);
+				Assert.Equal (new Size (7, 5), Application.Current.Frame.Size);
 
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				TestHelpers.AssertDriverContentsWithFrameAre (@$"
                                     ┌─────┐
                                     │Messa│
                                     │ ge  │
@@ -273,30 +272,31 @@ namespace Terminal.Gui.DialogTests {
                                     └─────┘
 ", output);
 
-					Application.RequestStop ();
-				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Size_JustBigEnough_Fixed_Size ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} Ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+	[Fact]
+	[AutoInitShutdown]
+	public void Size_JustBigEnough_Fixed_Size ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} Ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (11, 5, string.Empty, "Message", "_Ok");
+			if (iterations == 0) {
+				MessageBox.Query (11, 5, string.Empty, "Message", "_Ok");
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@$"
                                   ┌─────────┐
                                   │ Message │
                                   │         │
@@ -304,34 +304,35 @@ namespace Terminal.Gui.DialogTests {
                                   └─────────┘
 ", output);
 
-					Application.RequestStop ();
-				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Message_Long_Without_Spaces_WrapMessage_True ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			Application.Top.BorderStyle = LineStyle.Double;
-			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+	[Fact]
+	[AutoInitShutdown]
+	public void Message_Long_Without_Spaces_WrapMessage_True ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		Application.Top.BorderStyle = LineStyle.Double;
+		((FakeDriver)Application.Driver).SetBufferSize (20, 10);
 
-			var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
-			Application.Iteration += (s, a) => {
-				iterations++;
+		var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					// 50 characters should make the height of the wrapped text 7
-					MessageBox.Query (string.Empty, new string ('f', 50), defaultButton: 0, wrapMessage: true, "btn");
+			if (iterations == 0) {
+				// 50 characters should make the height of the wrapped text 7
+				MessageBox.Query (string.Empty, new string ('f', 50), 0, true, "btn");
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
 
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				TestHelpers.AssertDriverContentsWithFrameAre (@$"
 ╔══════════════════╗
 ║┌────────────────┐║
 ║│ffffffffffffffff│║
@@ -342,14 +343,14 @@ namespace Terminal.Gui.DialogTests {
 ║│    {btn}   │║
 ║└────────────────┘║
 ╚══════════════════╝", output);
-					Assert.Equal (new Size (20 - 2, 10 - 2), Application.Current.Frame.Size);
-					Application.RequestStop ();
+				Assert.Equal (new Size (20 - 2, 10 - 2), Application.Current.Frame.Size);
+				Application.RequestStop ();
 
-					// Really long text
-					MessageBox.Query (string.Empty, new string ('f', 500), defaultButton: 0, wrapMessage: true, "btn");
-				} else if (iterations == 2) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				// Really long text
+				MessageBox.Query (string.Empty, new string ('f', 500), 0, true, "btn");
+			} else if (iterations == 2) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@$"
 ╔┌────────────────┐╗
 ║│ffffffffffffffff│║
 ║│ffffffffffffffff│║
@@ -360,37 +361,39 @@ namespace Terminal.Gui.DialogTests {
 ║│ffffffffffffffff│║
 ║│    {btn}   │║
 ╚└────────────────┘╝", output);
-					Application.RequestStop ();
+				Application.RequestStop ();
+			}
+		};
+
+		Application.Run ();
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void Message_With_Spaces_WrapMessage_True ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		Application.Top.BorderStyle = LineStyle.Double;
+		((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+
+		var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+
+		Application.Iteration += (s, a) => {
+			iterations++;
+
+			if (iterations == 0) {
+				var sb = new StringBuilder ();
+				for (var i = 0; i < 17; i++) {
+					sb.Append ("ff ");
 				}
-			};
 
-			Application.Run ();
-		}
+				MessageBox.Query (string.Empty, sb.ToString (), 0, true, "btn");
 
-		[Fact, AutoInitShutdown]
-		public void Message_With_Spaces_WrapMessage_True ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			Application.Top.BorderStyle = LineStyle.Double;
-			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
-
-			var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
-
-			Application.Iteration += (s, a) => {
-				iterations++;
-
-				if (iterations == 0) {
-					var sb = new StringBuilder ();
-					for (int i = 0; i < 17; i++)
-						sb.Append ("ff ");
-
-					MessageBox.Query (string.Empty, sb.ToString (), defaultButton: 0, wrapMessage: true, "btn");
-
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@$"
 ╔══════════════════╗
 ║ ┌──────────────┐ ║
 ║ │ff ff ff ff ff│ ║
@@ -401,13 +404,13 @@ namespace Terminal.Gui.DialogTests {
 ║ │   {btn}  │ ║
 ║ └──────────────┘ ║
 ╚══════════════════╝", output);
-					Application.RequestStop ();
+				Application.RequestStop ();
 
-					// Really long text
-					MessageBox.Query (string.Empty, new string ('f', 500), defaultButton: 0, wrapMessage: true, "btn");
-				} else if (iterations == 2) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				// Really long text
+				MessageBox.Query (string.Empty, new string ('f', 500), 0, true, "btn");
+			} else if (iterations == 2) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@$"
 ╔┌────────────────┐╗
 ║│ffffffffffffffff│║
 ║│ffffffffffffffff│║
@@ -418,33 +421,34 @@ namespace Terminal.Gui.DialogTests {
 ║│ffffffffffffffff│║
 ║│    {btn}   │║
 ╚└────────────────┘╝", output);
-					Application.RequestStop ();
-				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Message_Without_Spaces_WrapMessage_False ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			Application.Top.BorderStyle = LineStyle.Double;
-			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+	[Fact]
+	[AutoInitShutdown]
+	public void Message_Without_Spaces_WrapMessage_False ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		Application.Top.BorderStyle = LineStyle.Double;
+		((FakeDriver)Application.Driver).SetBufferSize (20, 10);
 
-			var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+		var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (string.Empty, new string ('f', 50), defaultButton: 0, wrapMessage: false, "btn");
+			if (iterations == 0) {
+				MessageBox.Query (string.Empty, new string ('f', 50), 0, false, "btn");
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@"
 ╔══════════════════╗
 ║                  ║
 ────────────────────
@@ -456,13 +460,13 @@ ffffffffffffffffffff
 ║                  ║
 ╚══════════════════╝", output);
 
-					Application.RequestStop ();
+				Application.RequestStop ();
 
-					// Really long text
-					MessageBox.Query (string.Empty, new string ('f', 500), defaultButton: 0, wrapMessage: false, "btn");
-				} else if (iterations == 2) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				// Really long text
+				MessageBox.Query (string.Empty, new string ('f', 500), 0, false, "btn");
+			} else if (iterations == 2) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@"
 ╔══════════════════╗
 ║                  ║
 ────────────────────
@@ -474,36 +478,38 @@ ffffffffffffffffffff
 ║                  ║
 ╚══════════════════╝", output);
 
-					Application.RequestStop ();
+				Application.RequestStop ();
+			}
+		};
+
+		Application.Run ();
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void Message_With_Spaces_WrapMessage_False ()
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
+		Application.Top.BorderStyle = LineStyle.Double;
+		((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+		var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+
+		Application.Iteration += (s, a) => {
+			iterations++;
+
+			if (iterations == 0) {
+				var sb = new StringBuilder ();
+				for (var i = 0; i < 17; i++) {
+					sb.Append ("ff ");
 				}
-			};
 
-			Application.Run ();
-		}
+				MessageBox.Query (string.Empty, sb.ToString (), 0, false, "btn");
 
-		[Fact, AutoInitShutdown]
-		public void Message_With_Spaces_WrapMessage_False ()
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
-			Application.Top.BorderStyle = LineStyle.Double;
-			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
-			var btn = $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
-
-			Application.Iteration += (s, a) => {
-				iterations++;
-
-				if (iterations == 0) {
-					var sb = new StringBuilder ();
-					for (int i = 0; i < 17; i++)
-						sb.Append ("ff ");
-
-					MessageBox.Query (string.Empty, sb.ToString (), defaultButton: 0, wrapMessage: false, "btn");
-
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@"
 ╔══════════════════╗
 ║                  ║
 ────────────────────
@@ -514,13 +520,13 @@ ff ff ff ff ff ff ff
 ║                  ║
 ║                  ║
 ╚══════════════════╝", output);
-					Application.RequestStop ();
+				Application.RequestStop ();
 
-					// Really long text
-					MessageBox.Query (string.Empty, new string ('f', 500), defaultButton: 0, wrapMessage: false, "btn");
-				} else if (iterations == 2) {
-					Application.Refresh ();
-					TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				// Really long text
+				MessageBox.Query (string.Empty, new string ('f', 500), 0, false, "btn");
+			} else if (iterations == 2) {
+				Application.Refresh ();
+				TestHelpers.AssertDriverContentsWithFrameAre (@"
 ╔══════════════════╗
 ║                  ║
 ────────────────────
@@ -531,57 +537,158 @@ ffffffffffffffffffff
 ║                  ║
 ║                  ║
 ╚══════════════════╝", output);
-					Application.RequestStop ();
-				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
 
-		[Theory, AutoInitShutdown]
-		[InlineData (" ", true, 1)]
-		[InlineData (" ", false, 1)]
-		[InlineData ("", true, 1)]
-		[InlineData ("", false, 1)]
-		[InlineData ("\n", true, 1)]
-		[InlineData ("\n", false, 1)]
-		[InlineData (" \n", true, 1)]
-		[InlineData (" \n", false, 2)]
-		public void Message_Empty_Or_A_NewLline_WrapMessagge_True_Or_False (string message, bool wrapMessage, int linesLength)
-		{
-			var iterations = -1;
-			Application.Begin (Application.Top);
+	[Theory]
+	[AutoInitShutdown]
+	[InlineData (" ", true, 1)]
+	[InlineData (" ", false, 1)]
+	[InlineData ("", true, 1)]
+	[InlineData ("", false, 1)]
+	[InlineData ("\n", true, 1)]
+	[InlineData ("\n", false, 1)]
+	[InlineData (" \n", true, 1)]
+	[InlineData (" \n", false, 2)]
+	public void Message_Empty_Or_A_NewLline_WrapMessagge_True_Or_False (string message, bool wrapMessage, int linesLength)
+	{
+		var iterations = -1;
+		Application.Begin (Application.Top);
 
-			Application.Iteration += (s, a) => {
-				iterations++;
+		Application.Iteration += (s, a) => {
+			iterations++;
 
-				if (iterations == 0) {
-					MessageBox.Query (string.Empty, message, 0, wrapMessage, "ok");
+			if (iterations == 0) {
+				MessageBox.Query (string.Empty, message, 0, wrapMessage, "ok");
 
-					Application.RequestStop ();
-				} else if (iterations == 1) {
-					Application.Refresh ();
-					if (linesLength == 1) {
-						TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				Application.RequestStop ();
+			} else if (iterations == 1) {
+				Application.Refresh ();
+				if (linesLength == 1) {
+					TestHelpers.AssertDriverContentsWithFrameAre (@$"
                 ┌──────────────────────────────────────────────┐
                 │                                              │
                 │                                              │
                 │                   {CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}                   │
                 └──────────────────────────────────────────────┘", output);
-					} else {
-						TestHelpers.AssertDriverContentsWithFrameAre (@$"
+				} else {
+					TestHelpers.AssertDriverContentsWithFrameAre (@$"
                 ┌──────────────────────────────────────────────┐
                 │                                              │
                 │                                              │
                 │                                              │
                 │                   {CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} ok {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}                   │
                 └──────────────────────────────────────────────┘", output);
-					}
-					Application.RequestStop ();
 				}
-			};
+				Application.RequestStop ();
+			}
+		};
 
-			Application.Run ();
-		}
+		Application.Run ();
+	}
+
+
+	[Fact]
+	[AutoInitShutdown]
+	public void KeyBindings_Esc_Closes ()
+	{
+		Application.Begin (Application.Top);
+
+		var result = 999;
+
+		var iteration = 0;
+		Application.Iteration += (s, a) => {
+			iteration++;
+			switch (iteration) {
+			case 1:
+				result = MessageBox.Query (title: string.Empty, message: string.Empty, defaultButton: 0, wrapMessage: false, "btn0", "btn1");
+				Application.RequestStop ();
+				break;
+
+			case 2:
+				Application.OnKeyDown (Key.Esc);
+				break;
+
+			default:
+				Assert.Fail ();
+				break;
+
+			}
+		};
+		Application.Run ();
+
+		Assert.Equal (-1, result);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void KeyBindings_Enter_Causes_Focused_Button_Click ()
+	{
+		Application.Begin (Application.Top);
+
+		var result = -1;
+
+		var iteration = 0;
+		Application.Iteration += (s, a) => {
+			iteration++;
+			switch (iteration) {
+			case 1:
+				result = MessageBox.Query (title: string.Empty, message: string.Empty, defaultButton: 0, wrapMessage: false, "btn0", "btn1");
+				Application.RequestStop ();
+				break;
+
+			case 2:
+				// Tab to btn2
+				Application.OnKeyDown (Key.Tab);
+				Application.OnKeyDown (Key.Enter);
+				break;
+			
+			default:
+				Assert.Fail ();
+				break;
+
+			}
+		};
+		Application.Run ();
+
+		Assert.Equal (1, result);
+	}
+
+	[Fact]
+	[AutoInitShutdown]
+	public void KeyBindings_Space_Causes_Focused_Button_Click ()
+	{
+		Application.Begin (Application.Top);
+
+		var result = -1;
+
+		var iteration = 0;
+		Application.Iteration += (s, a) => {
+			iteration++;
+			switch (iteration) {
+			case 1:
+				result = MessageBox.Query (title: string.Empty, message: string.Empty, defaultButton: 0, wrapMessage: false, "btn0", "btn1");
+				Application.RequestStop ();
+				break;
+				
+			case 2:
+				// Tab to btn2
+				Application.OnKeyDown (Key.Tab);
+				Application.OnKeyDown (Key.Space);
+				break;
+
+			default:
+				Assert.Fail ();
+				break;
+
+			}
+		};
+		Application.Run ();
+
+		Assert.Equal (1, result);
 	}
 }

--- a/UnitTests/Views/ButtonTests.cs
+++ b/UnitTests/Views/ButtonTests.cs
@@ -78,39 +78,57 @@ namespace Terminal.Gui.ViewsTests {
 			Application.Top.Add (btn);
 			Application.Begin (Application.Top);
 
+			// Hot key. Both alone and with alt
 			Assert.Equal (KeyCode.T, btn.HotKey);
 			Assert.True (btn.NewKeyDownEvent (new (KeyCode.T)));
 			Assert.True (clicked);
 			clicked = false;
+
 			Assert.True (btn.NewKeyDownEvent (new (KeyCode.T | KeyCode.AltMask)));
 			Assert.True (clicked);
 			clicked = false;
+
+			Assert.True (btn.NewKeyDownEvent (btn.HotKey));
+			Assert.True (clicked);
+			clicked = false;
+
+			// IsDefault = false
+			// Space and Enter should work
 			Assert.False (btn.IsDefault);
-			Assert.False (btn.NewKeyDownEvent (new (KeyCode.Enter)));
-			Assert.False (clicked);
+			Assert.True (btn.NewKeyDownEvent (new (KeyCode.Enter)));
+			Assert.True (clicked);
+			clicked = false;
+
+			// IsDefault = true
+			// Space and Enter should work
 			btn.IsDefault = true;
-			Assert.False (btn.NewKeyDownEvent (new (KeyCode.Enter)));
+			Assert.True (btn.NewKeyDownEvent (new (KeyCode.Enter)));
+			Assert.True (clicked);
+			clicked = false;
+
+			// Toplevel does not handle Enter, so it should get passed on to button
 			Assert.True (Application.Top.NewKeyDownEvent (new (KeyCode.Enter)));
 			Assert.True (clicked);
 			clicked = false;
-			Assert.True (btn.NewKeyDownEvent (new (KeyCode.AltMask | KeyCode.T)));
+
+			// Direct
+			Assert.True (btn.NewKeyDownEvent (new (KeyCode.Enter)));
 			Assert.True (clicked);
 			clicked = false;
-			Assert.True (Application.Top.NewKeyDownEvent (new (KeyCode.Enter)));
-			Assert.True (clicked);
-			clicked = false;
+
 			Assert.True (btn.NewKeyDownEvent (new (KeyCode.Space)));
 			Assert.True (clicked);
 			clicked = false;
+
 			Assert.True (btn.NewKeyDownEvent (new ((KeyCode)'T')));
 			Assert.True (clicked);
 			clicked = false;
-			Assert.True (btn.NewKeyDownEvent (btn.HotKey));
-			Assert.True (clicked);
+
+			// Change hotkey:
 			btn.Text = "Te_st";
-			clicked = false;
 			Assert.True (btn.NewKeyDownEvent (btn.HotKey));
 			Assert.True (clicked);
+			clicked = false;
 		}
 
 		[Fact]

--- a/UnitTests/Views/WindowTests.cs
+++ b/UnitTests/Views/WindowTests.cs
@@ -1,130 +1,122 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
-//using GraphViewTests = Terminal.Gui.Views.GraphViewTests;
 
-// Alias Console to MockConsole so we don't accidentally use Console
-using Console = Terminal.Gui.FakeConsole;
-using System.Text;
+namespace Terminal.Gui.ViewsTests; 
 
-namespace Terminal.Gui.ViewsTests {
-	public class WindowTests {
-		readonly ITestOutputHelper output;
+public class WindowTests {
+	readonly ITestOutputHelper _output;
 
-		public WindowTests (ITestOutputHelper output)
-		{
-			this.output = output;
-		}
+	public WindowTests (ITestOutputHelper output) => this._output = output;
 
-		[Fact]
-		public void New_Initializes ()
-		{
-			// Parameterless
-			var r = new Window ();
-			Assert.NotNull (r);
-			Assert.Equal (string.Empty, r.Title);
-			Assert.Equal (LayoutStyle.Computed, r.LayoutStyle);
-			Assert.Equal ("Window()(0,0,0,0)", r.ToString ());
-			Assert.True (r.CanFocus);
-			Assert.False (r.HasFocus);
-			Assert.Equal (new Rect (0, 0, 0, 0), r.Bounds);
-			Assert.Equal (new Rect (0, 0, 0, 0), r.Frame);
-			Assert.Null (r.Focused);
-			Assert.NotNull (r.ColorScheme);
-			Assert.Equal (Dim.Fill (0), r.Width);
-			Assert.Equal (Dim.Fill (0), r.Height);
-			Assert.Null (r.X);
-			Assert.Null (r.Y);
-			Assert.False (r.IsCurrentTop);
-			Assert.Empty (r.Id);
-			Assert.False (r.WantContinuousButtonPressed);
-			Assert.False (r.WantMousePositionReports);
-			Assert.Null (r.SuperView);
-			Assert.Null (r.MostFocused);
-			Assert.Equal (TextDirection.LeftRight_TopBottom, r.TextDirection);
+	[Fact]
+	public void New_Initializes ()
+	{
+		// Parameterless
+		var r = new Window ();
+		Assert.NotNull (r);
+		Assert.Equal (string.Empty,         r.Title);
+		Assert.Equal (LayoutStyle.Computed, r.LayoutStyle);
+		Assert.Equal ("Window()(0,0,0,0)",  r.ToString ());
+		Assert.True (r.CanFocus);
+		Assert.False (r.HasFocus);
+		Assert.Equal (new Rect (0, 0, 0, 0), r.Bounds);
+		Assert.Equal (new Rect (0, 0, 0, 0), r.Frame);
+		Assert.Null (r.Focused);
+		Assert.NotNull (r.ColorScheme);
+		Assert.Equal (Dim.Fill (), r.Width);
+		Assert.Equal (Dim.Fill (), r.Height);
+		Assert.Null (r.X);
+		Assert.Null (r.Y);
+		Assert.False (r.IsCurrentTop);
+		Assert.Empty (r.Id);
+		Assert.False (r.WantContinuousButtonPressed);
+		Assert.False (r.WantMousePositionReports);
+		Assert.Null (r.SuperView);
+		Assert.Null (r.MostFocused);
+		Assert.Equal (TextDirection.LeftRight_TopBottom, r.TextDirection);
 
-			// Empty Rect
-			r = new Window (Rect.Empty) { Title = "title" };
-			Assert.NotNull (r);
-			Assert.Equal ("title", r.Title);
-			Assert.Equal (LayoutStyle.Absolute, r.LayoutStyle);
-			Assert.Equal ("Window(title)(0,0,0,0)", r.ToString ());
-			Assert.True (r.CanFocus);
-			Assert.False (r.HasFocus);
-			Assert.Equal (new Rect (0, 0, 0, 0), r.Bounds);
-			Assert.Equal (new Rect (0, 0, 0, 0), r.Frame);
-			Assert.Null (r.Focused);
-			Assert.NotNull (r.ColorScheme);
-			Assert.Null (r.Width);       // All view Dim are initialized now in the IsAdded setter,
-			Assert.Null (r.Height);      // avoiding Dim errors.
-			Assert.Null (r.X);           // All view Pos are initialized now in the IsAdded setter,
-			Assert.Null (r.Y);           // avoiding Pos errors.
-			Assert.False (r.IsCurrentTop);
-			Assert.Equal (r.Title, r.Id);
-			Assert.False (r.WantContinuousButtonPressed);
-			Assert.False (r.WantMousePositionReports);
-			Assert.Null (r.SuperView);
-			Assert.Null (r.MostFocused);
-			Assert.Equal (TextDirection.LeftRight_TopBottom, r.TextDirection);
+		// Empty Rect
+		r = new Window (Rect.Empty) { Title = "title" };
+		Assert.NotNull (r);
+		Assert.Equal ("title",                  r.Title);
+		Assert.Equal (LayoutStyle.Absolute,     r.LayoutStyle);
+		Assert.Equal ("Window(title)(0,0,0,0)", r.ToString ());
+		Assert.True (r.CanFocus);
+		Assert.False (r.HasFocus);
+		Assert.Equal (new Rect (0, 0, 0, 0), r.Bounds);
+		Assert.Equal (new Rect (0, 0, 0, 0), r.Frame);
+		Assert.Null (r.Focused);
+		Assert.NotNull (r.ColorScheme);
+		Assert.Null (r.Width);  // All view Dim are initialized now in the IsAdded setter,
+		Assert.Null (r.Height); // avoiding Dim errors.
+		Assert.Null (r.X);      // All view Pos are initialized now in the IsAdded setter,
+		Assert.Null (r.Y);      // avoiding Pos errors.
+		Assert.False (r.IsCurrentTop);
+		Assert.Equal (r.Title, r.Id);
+		Assert.False (r.WantContinuousButtonPressed);
+		Assert.False (r.WantMousePositionReports);
+		Assert.Null (r.SuperView);
+		Assert.Null (r.MostFocused);
+		Assert.Equal (TextDirection.LeftRight_TopBottom, r.TextDirection);
 
-			// Rect with values
-			r = new Window (new Rect (1, 2, 3, 4)) { Title = "title" };
-			Assert.Equal ("title", r.Title);
-			Assert.NotNull (r);
-			Assert.Equal (LayoutStyle.Absolute, r.LayoutStyle);
-			Assert.Equal ("Window(title)(1,2,3,4)", r.ToString ());
-			Assert.True (r.CanFocus);
-			Assert.False (r.HasFocus);
-			Assert.Equal (new Rect (0, 0, 1, 2), r.Bounds);
-			Assert.Equal (new Rect (1, 2, 3, 4), r.Frame);
-			Assert.Null (r.Focused);
-			Assert.NotNull (r.ColorScheme);
-			Assert.Null (r.Width);
-			Assert.Null (r.Height);
-			Assert.Null (r.X);
-			Assert.Null (r.Y);
-			Assert.False (r.IsCurrentTop);
-			Assert.Equal (r.Title, r.Id);
-			Assert.False (r.WantContinuousButtonPressed);
-			Assert.False (r.WantMousePositionReports);
-			Assert.Null (r.SuperView);
-			Assert.Null (r.MostFocused);
-			Assert.Equal (TextDirection.LeftRight_TopBottom, r.TextDirection);
-			r.Dispose ();
-		}
+		// Rect with values
+		r = new Window (new Rect (1, 2, 3, 4)) { Title = "title" };
+		Assert.Equal ("title", r.Title);
+		Assert.NotNull (r);
+		Assert.Equal (LayoutStyle.Absolute,     r.LayoutStyle);
+		Assert.Equal ("Window(title)(1,2,3,4)", r.ToString ());
+		Assert.True (r.CanFocus);
+		Assert.False (r.HasFocus);
+		Assert.Equal (new Rect (0, 0, 1, 2), r.Bounds);
+		Assert.Equal (new Rect (1, 2, 3, 4), r.Frame);
+		Assert.Null (r.Focused);
+		Assert.NotNull (r.ColorScheme);
+		Assert.Null (r.Width);
+		Assert.Null (r.Height);
+		Assert.Null (r.X);
+		Assert.Null (r.Y);
+		Assert.False (r.IsCurrentTop);
+		Assert.Equal (r.Title, r.Id);
+		Assert.False (r.WantContinuousButtonPressed);
+		Assert.False (r.WantMousePositionReports);
+		Assert.Null (r.SuperView);
+		Assert.Null (r.MostFocused);
+		Assert.Equal (TextDirection.LeftRight_TopBottom, r.TextDirection);
+		r.Dispose ();
+	}
 
-		[Fact, AutoInitShutdown]
-		public void MenuBar_And_StatusBar_Inside_Window ()
-		{
-			var menu = new MenuBar (new MenuBarItem [] {
-				new MenuBarItem ("File", new MenuItem [] {
-					new MenuItem ("Open", "", null),
-					new MenuItem ("Quit", "", null),
-				}),
-				new MenuBarItem ("Edit", new MenuItem [] {
-					new MenuItem ("Copy", "", null),
-				})
-			});
+	[Fact] [AutoInitShutdown]
+	public void MenuBar_And_StatusBar_Inside_Window ()
+	{
+		var menu = new MenuBar (new MenuBarItem [] {
+			new ("File", new MenuItem [] {
+				new ("Open", "", null),
+				new ("Quit", "", null)
+			}),
+			new ("Edit", new MenuItem [] {
+				new ("Copy", "", null)
+			})
+		});
 
-			var sb = new StatusBar (new StatusItem [] {
-				new StatusItem (KeyCode.CtrlMask | KeyCode.Q, "~^Q~ Quit", null),
-				new StatusItem (KeyCode.CtrlMask | KeyCode.O, "~^O~ Open", null),
-				new StatusItem (KeyCode.CtrlMask | KeyCode.C, "~^C~ Copy", null),
-			});
+		var sb = new StatusBar (new StatusItem [] {
+			new (KeyCode.CtrlMask | KeyCode.Q, "~^Q~ Quit", null),
+			new (KeyCode.CtrlMask | KeyCode.O, "~^O~ Open", null),
+			new (KeyCode.CtrlMask | KeyCode.C, "~^C~ Copy", null)
+		});
 
-			var fv = new FrameView ("Frame View") {
-				Y = 1,
-				Width = Dim.Fill (),
-				Height = Dim.Fill (1)
-			};
-			var win = new Window ();
-			win.Add (menu, sb, fv);
-			var top = Application.Top;
-			top.Add (win);
-			Application.Begin (top);
-			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+		var fv = new FrameView ("Frame View") {
+			Y = 1,
+			Width = Dim.Fill (),
+			Height = Dim.Fill (1)
+		};
+		var win = new Window ();
+		win.Add (menu, sb, fv);
+		var top = Application.Top;
+		top.Add (win);
+		Application.Begin (top);
+		((FakeDriver)Application.Driver).SetBufferSize (20, 10);
 
-			TestHelpers.AssertDriverContentsWithFrameAre (@"
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
 ┌──────────────────┐
 │ File  Edit       │
 │┌┤Frame View├────┐│
@@ -134,11 +126,11 @@ namespace Terminal.Gui.ViewsTests {
 ││                ││
 │└────────────────┘│
 │ ^Q Quit │ ^O Open│
-└──────────────────┘", output);
+└──────────────────┘", _output);
 
-			((FakeDriver)Application.Driver).SetBufferSize (40, 20);
+		((FakeDriver)Application.Driver).SetBufferSize (40, 20);
 
-			TestHelpers.AssertDriverContentsWithFrameAre (@"
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
 ┌──────────────────────────────────────┐
 │ File  Edit                           │
 │┌┤Frame View├────────────────────────┐│
@@ -158,11 +150,11 @@ namespace Terminal.Gui.ViewsTests {
 ││                                    ││
 │└────────────────────────────────────┘│
 │ ^Q Quit │ ^O Open │ ^C Copy          │
-└──────────────────────────────────────┘", output);
+└──────────────────────────────────────┘", _output);
 
-			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+		((FakeDriver)Application.Driver).SetBufferSize (20, 10);
 
-			TestHelpers.AssertDriverContentsWithFrameAre (@"
+		TestHelpers.AssertDriverContentsWithFrameAre (@"
 ┌──────────────────┐
 │ File  Edit       │
 │┌┤Frame View├────┐│
@@ -172,42 +164,75 @@ namespace Terminal.Gui.ViewsTests {
 ││                ││
 │└────────────────┘│
 │ ^Q Quit │ ^O Open│
-└──────────────────┘", output);
-		}
+└──────────────────┘", _output);
+	}
 
-		[Fact, AutoInitShutdown]
-		public void OnCanFocusChanged_Only_Must_ContentView_Forces_SetFocus_After_IsInitialized_Is_True ()
-		{
-			var win1 = new Window () { Id = "win1", Width = 10, Height = 1 };
-			var view1 = new View () { Id = "view1", Width = Dim.Fill (), Height = Dim.Fill (), CanFocus = true };
-			var win2 = new Window () { Id = "win2", Y = 6, Width = 10, Height = 1 };
-			var view2 = new View () { Id = "view2", Width = Dim.Fill (), Height = Dim.Fill (), CanFocus = true };
-			win2.Add (view2);
-			win1.Add (view1, win2);
+	[Fact] [AutoInitShutdown]
+	public void OnCanFocusChanged_Only_Must_ContentView_Forces_SetFocus_After_IsInitialized_Is_True ()
+	{
+		var win1 = new Window { Id = "win1", Width = 10, Height = 1 };
+		var view1 = new View { Id = "view1", Width = Dim.Fill (), Height = Dim.Fill (), CanFocus = true };
+		var win2 = new Window { Id = "win2", Y = 6, Width = 10, Height = 1 };
+		var view2 = new View { Id = "view2", Width = Dim.Fill (), Height = Dim.Fill (), CanFocus = true };
+		win2.Add (view2);
+		win1.Add (view1, win2);
 
-			Application.Begin (win1);
+		Application.Begin (win1);
 
-			Assert.True (win1.HasFocus);
-			Assert.True (view1.HasFocus);
-			Assert.False (win2.HasFocus);
-			Assert.False (view2.HasFocus);
-		}
+		Assert.True (win1.HasFocus);
+		Assert.True (view1.HasFocus);
+		Assert.False (win2.HasFocus);
+		Assert.False (view2.HasFocus);
+	}
 
-		[Fact, AutoInitShutdown]
-		public void Activating_MenuBar_By_Alt_Key_Does_Not_Throw ()
-		{
-			var menu = new MenuBar (new MenuBarItem [] {
-				new MenuBarItem ("Child", new MenuItem [] {
-					new MenuItem ("_Create Child", "", null)
-				})
-			});
-			var win = new Window ();
-			win.Add (menu);
-			Application.Top.Add (win);
-			Application.Begin (Application.Top);
+	[Fact] [AutoInitShutdown]
+	public void Activating_MenuBar_By_Alt_Key_Does_Not_Throw ()
+	{
+		var menu = new MenuBar (new MenuBarItem [] {
+			new ("Child", new MenuItem [] {
+				new ("_Create Child", "", null)
+			})
+		});
+		var win = new Window ();
+		win.Add (menu);
+		Application.Top.Add (win);
+		Application.Begin (Application.Top);
 
-			var exception = Record.Exception (() => win.NewKeyDownEvent (new (KeyCode.AltMask)));
-			Assert.Null (exception);
-		}
+		var exception = Record.Exception (() => win.NewKeyDownEvent (new Key (KeyCode.AltMask)));
+		Assert.Null (exception);
+	}
+
+	public static TheoryData<Toplevel> ButtonContainers =>
+		new () {
+			{ new Window () },
+			{ new Dialog () }
+		};
+
+
+	[Theory, AutoInitShutdown]
+	[MemberData (nameof (ButtonContainers))]
+	public void With_Default_Button_Enter_Invokes_Accept_Action (Toplevel container)
+	{
+		var view = new View () { CanFocus = true };
+		var btnOk = new Button ("Accept") { IsDefault = true };
+		btnOk.Clicked += (s, e) => view.Text = "Test";
+		var btnCancel = new Button ("Cancel");
+		btnCancel.Clicked += (s, e) => view.Text = "";
+
+		container.Add (view, btnOk, btnCancel);
+		var rs = Application.Begin (container);
+
+		Assert.True (view.HasFocus);
+		Assert.Equal ("", view.Text);
+		Assert.True (Application.OnKeyDown (new Key (KeyCode.Enter)));
+		Assert.True (view.HasFocus);
+		Assert.Equal ("Test", view.Text);
+
+		btnOk.IsDefault = false;
+		btnCancel.IsDefault = true;
+		Assert.True (Application.OnKeyDown (new Key (KeyCode.Enter)));
+		Assert.True (view.HasFocus);
+		Assert.Equal ("", view.Text);
+		Application.End (rs);
 	}
 }


### PR DESCRIPTION
## Fixes

- Fixes #3072
- Fixes #3148 

## Todo:

- [x] Fix `Button`'s key bindings
- [x] Move `Enter` key binding from `Toplevel` to `Dialog`
- [x] Add better unit tests

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
