### PR TITLE
Fixes #2944. TreeView ColorGetter not disposing sometimes causes unit test error.

### DIFF
--- a/UnitTests/Views/MenuTests.cs
+++ b/UnitTests/Views/MenuTests.cs
@@ -17,18 +17,17 @@ public class MenuTests {
 	// TODO: Create more low-level unit tests for Menu and MenuItem
 	
 	[Fact]
-	public void Menu_Constuctors_Defaults ()
+	public void Menu_Constructors_Defaults ()
 	{
 		Assert.Throws<ArgumentNullException> (() => new Menu (null, 0, 0, null));
 
 		var menu = new Menu (new MenuBar (), 0, 0, new MenuBarItem ());
 		Assert.Empty (menu.Title);
 		Assert.Empty (menu.Text);
-
 	}
 
 	[Fact]
-	public void MenuItem_Constuctors_Defaults ()
+	public void MenuItem_Constructors_Defaults ()
 	{
 		var menuItem = new MenuItem ();
 		Assert.Equal ("", menuItem.Title);
@@ -38,7 +37,7 @@ public class MenuTests {
 		Assert.Null (menuItem.Parent);
 		Assert.Equal (KeyCode.Null, menuItem.Shortcut);
 
-		menuItem = new MenuItem ("Test", "Help", Run, () => { return true; }, new MenuItem (), KeyCode.F1);
+		menuItem = new MenuItem ("Test", "Help", Run, () => true, new MenuItem (), KeyCode.F1);
 		Assert.Equal ("Test", menuItem.Title);
 		Assert.Equal ("Help", menuItem.Help);
 		Assert.Equal (Run, menuItem.Action);

--- a/UnitTests/Views/TreeViewTests.cs
+++ b/UnitTests/Views/TreeViewTests.cs
@@ -832,6 +832,7 @@ namespace Terminal.Gui.ViewsTests {
 			Assert.Null (tv.GetObjectRow (n1_2));
 			Assert.Equal (0, tv.GetObjectRow (n2));
 		}
+
 		[Fact, AutoInitShutdown]
 		public void TestTreeViewColor ()
 		{
@@ -851,6 +852,10 @@ namespace Terminal.Gui.ViewsTests {
 
 			tv.ColorScheme = new ColorScheme ();
 			tv.LayoutSubviews ();
+
+			// Unsubscribe any previous assigned delegate
+			tv.ColorGetter = (_) => tv.ColorScheme;
+
 			tv.Draw ();
 
 			// create a new color scheme
@@ -866,10 +871,10 @@ namespace Terminal.Gui.ViewsTests {
 ", output);
 			// Should all be the same color
 			TestHelpers.AssertDriverColorsAre (@"
+00000000
+00000000
 0000000000
-0000000000
-0000000000
-0000000000
+000000
 ", driver: Application.Driver,
 				new [] { tv.ColorScheme.Normal, pink });
 

--- a/UnitTests/Views/TreeViewTests.cs
+++ b/UnitTests/Views/TreeViewTests.cs
@@ -853,7 +853,7 @@ namespace Terminal.Gui.ViewsTests {
 			tv.ColorScheme = new ColorScheme ();
 			tv.LayoutSubviews ();
 
-			// Subscribe to return on the current color scheme
+			// Subscribe to return only the current color scheme
 			// Maybe some other test wasn't totally disposed some tree view
 			tv.ColorGetter = (_) => tv.ColorScheme;
 

--- a/UnitTests/Views/TreeViewTests.cs
+++ b/UnitTests/Views/TreeViewTests.cs
@@ -853,7 +853,8 @@ namespace Terminal.Gui.ViewsTests {
 			tv.ColorScheme = new ColorScheme ();
 			tv.LayoutSubviews ();
 
-			// Unsubscribe any previous assigned delegate
+			// Subscribe to return on the current color scheme
+			// Maybe some other test wasn't totally disposed some tree view
 			tv.ColorGetter = (_) => tv.ColorScheme;
 
 			tv.Draw ();

--- a/UnitTests/Views/TreeViewTests.cs
+++ b/UnitTests/Views/TreeViewTests.cs
@@ -837,8 +837,9 @@ namespace Terminal.Gui.ViewsTests {
 		public void TestTreeViewColor ()
 		{
 			var tv = new TreeView { Width = 20, Height = 10 };
-			tv.BeginInit ();
-			tv.EndInit ();
+			Application.Top.Add (tv);
+			Application.Begin (Application.Top);
+
 			var n1 = new TreeNode ("normal");
 			var n1_1 = new TreeNode ("pink");
 			var n1_2 = new TreeNode ("normal");
@@ -852,11 +853,6 @@ namespace Terminal.Gui.ViewsTests {
 
 			tv.ColorScheme = new ColorScheme ();
 			tv.LayoutSubviews ();
-
-			// Subscribe to return only the current color scheme
-			// Maybe some other test wasn't totally disposed some tree view
-			tv.ColorGetter = (_) => tv.ColorScheme;
-
 			tv.Draw ();
 
 			// create a new color scheme


### PR DESCRIPTION
Fixes #2944 - One more try to fix this issue.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
