### PR TITLE
Fix GraphViewExample.

### DIFF
--- a/UICatalog/Scenarios/GraphViewExample.cs
+++ b/UICatalog/Scenarios/GraphViewExample.cs
@@ -18,6 +18,7 @@ public class GraphViewExample : Scenario {
 	GraphView _graphView;
 	MenuItem _miDiags;
 	MenuItem _miShowBorder;
+	Thickness _thickness = new Thickness (1, 1, 1, 1);
 
 	public override void Setup ()
 	{
@@ -77,9 +78,9 @@ public class GraphViewExample : Scenario {
 			Height = Dim.Fill (),
 			BorderStyle = LineStyle.Single
 		};
-		_graphView.Border.Thickness = new Thickness (1, 1, 1, 1);
-		_graphView.Margin.Thickness = new Thickness (1, 1, 1, 1);
-		_graphView.Padding.Thickness = new Thickness (1, 1, 1, 1);
+		_graphView.Border.Thickness = _thickness;
+		_graphView.Margin.Thickness = _thickness;
+		_graphView.Padding.Thickness = _thickness;
 
 		Win.Add (_graphView);
 
@@ -110,9 +111,9 @@ public class GraphViewExample : Scenario {
 
 		if (_miShowBorder.Checked == true) {
 			_graphView.BorderStyle = LineStyle.Single;
-			_graphView.Border.Thickness = new Thickness (1, 3, 1, 1);
-			_graphView.Margin.Thickness = new Thickness (2, 2, 2, 2);
-			_graphView.Padding.Thickness = new Thickness (2, 2, 2, 2);
+			_graphView.Border.Thickness = _thickness;
+			_graphView.Margin.Thickness = _thickness;
+			_graphView.Padding.Thickness = _thickness;
 		} else {
 			_graphView.BorderStyle = LineStyle.None;
 			_graphView.Margin.Thickness = Thickness.Empty;

--- a/UICatalog/Scenarios/GraphViewExample.cs
+++ b/UICatalog/Scenarios/GraphViewExample.cs
@@ -61,14 +61,11 @@ public class GraphViewExample : Scenario {
 					CheckType = MenuItemCheckStyle.Checked
 				},
 				_miDiags = new MenuItem ("Dri_ver Diagnostics", "", () => EnableDiagnostics ()) {
-					Checked = false,
+					Checked = ConsoleDriver.Diagnostics == (ConsoleDriver.DiagnosticFlags.FramePadding | ConsoleDriver.DiagnosticFlags.FrameRuler),
 					CheckType = MenuItemCheckStyle.Checked
 				}
 			})
 		});
-		if (ConsoleDriver.Diagnostics == (ConsoleDriver.DiagnosticFlags.FramePadding | ConsoleDriver.DiagnosticFlags.FrameRuler)) {
-			_miDiags.Checked = true;
-		}
 		Application.Top.Add (menu);
 
 		_graphView = new GraphView {

--- a/UICatalog/Scenarios/GraphViewExample.cs
+++ b/UICatalog/Scenarios/GraphViewExample.cs
@@ -64,17 +64,22 @@ public class GraphViewExample : Scenario {
 					CheckType = MenuItemCheckStyle.Checked
 				}
 			})
-
 		});
+		if (ConsoleDriver.Diagnostics == (ConsoleDriver.DiagnosticFlags.FramePadding | ConsoleDriver.DiagnosticFlags.FrameRuler)) {
+			_miDiags.Checked = true;
+		}
 		Application.Top.Add (menu);
 
 		_graphView = new GraphView {
 			X = 0,
 			Y = 0,
-			Width = 60,
+			Width = Dim.Percent (70),
 			Height = Dim.Fill (),
 			BorderStyle = LineStyle.Single
 		};
+		_graphView.Border.Thickness = new Thickness (1, 1, 1, 1);
+		_graphView.Margin.Thickness = new Thickness (1, 1, 1, 1);
+		_graphView.Padding.Thickness = new Thickness (1, 1, 1, 1);
 
 		Win.Add (_graphView);
 


### PR DESCRIPTION
Fixes GraphViewExample. I only used the Dim.Percent for Width and I decrease the thickness at start to show more the graph. I also fix the diagnostic to enable the check if it's enabled at start.