### PR TITLE
Fixes #3189. TextValidateField doesn't show the cursor and doesn't have TextChanged event.

### DIFF
--- a/Terminal.Gui/Views/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextValidateField.cs
@@ -472,10 +472,18 @@ namespace Terminal.Gui {
 			// Fixed = true, is for inputs that have fixed width, like masked ones.
 			// Fixed = false, is for normal input.
 			// When it's right-aligned and it's a normal input, the cursor behaves differently.
+			int curPos;
 			if (_provider?.Fixed == false && TextAlignment == TextAlignment.Right) {
-				Move (_cursorPosition + left - 1, 0);
+				curPos = _cursorPosition + left - 1;
+				Move (curPos, 0);
 			} else {
-				Move (_cursorPosition + left, 0);
+				curPos = _cursorPosition + left;
+				Move (curPos, 0);
+			}
+			if (curPos >= Bounds.Width) {
+				Application.Driver.SetCursorVisibility (CursorVisibility.Invisible);
+			} else {
+				Application.Driver.SetCursorVisibility (CursorVisibility.Default);
 			}
 		}
 
@@ -644,6 +652,22 @@ namespace Terminal.Gui {
 
 				return _provider.IsValid;
 			}
+		}
+
+		///<inheritdoc/>
+		public override bool OnEnter (View view)
+		{
+			Application.Driver.SetCursorVisibility (CursorVisibility.Default);
+
+			return base.OnEnter (view);
+		}
+
+		///<inheritdoc/>
+		public override bool OnLeave (View view)
+		{
+			Application.Driver.SetCursorVisibility (CursorVisibility.Invisible);
+
+			return base.OnLeave (view);
 		}
 	}
 }

--- a/Terminal.Gui/Views/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextValidateField.cs
@@ -6,7 +6,6 @@
 //
 
 using System.Text;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -104,7 +103,7 @@ namespace Terminal.Gui {
 		/// <para><a href="https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.maskedtextbox.mask?view=net-5.0">Masking elements</a></para>
 		/// </summary>
 		public class NetMaskedTextProvider : ITextValidateProvider {
-			MaskedTextProvider provider;
+			MaskedTextProvider _provider;
 
 			/// <summary>
 			/// Empty Constructor
@@ -119,13 +118,13 @@ namespace Terminal.Gui {
 			/// </summary>
 			public string Mask {
 				get {
-					return provider?.Mask;
+					return _provider?.Mask;
 				}
 				set {
-					var current = provider != null ? provider.ToString (false, false) : string.Empty;
-					provider = new MaskedTextProvider (value == string.Empty ? "&&&&&&" : value);
+					var current = _provider != null ? _provider.ToString (false, false) : string.Empty;
+					_provider = new MaskedTextProvider (value == string.Empty ? "&&&&&&" : value);
 					if (string.IsNullOrEmpty (current) == false) {
-						provider.Set (current);
+						_provider.Set (current);
 					}
 				}
 			}
@@ -133,32 +132,32 @@ namespace Terminal.Gui {
 			///<inheritdoc/>
 			public string Text {
 				get {
-					return provider.ToString ();
+					return _provider.ToString ();
 				}
 				set {
-					provider.Set (value);
+					_provider.Set (value);
 				}
 			}
 
 			///<inheritdoc/>
-			public bool IsValid => provider.MaskCompleted;
+			public bool IsValid => _provider.MaskCompleted;
 
 			///<inheritdoc/>
 			public bool Fixed => true;
 
 			///<inheritdoc/>
-			public string DisplayText => provider.ToDisplayString ();
+			public string DisplayText => _provider.ToDisplayString ();
 
 			///<inheritdoc/>
 			public int Cursor (int pos)
 			{
 				if (pos < 0) {
 					return CursorStart ();
-				} else if (pos > provider.Length) {
+				} else if (pos > _provider.Length) {
 					return CursorEnd ();
 				} else {
-					var p = provider.FindEditPositionFrom (pos, false);
-					if (p == -1) p = provider.FindEditPositionFrom (pos, true);
+					var p = _provider.FindEditPositionFrom (pos, false);
+					if (p == -1) p = _provider.FindEditPositionFrom (pos, true);
 					return p;
 				}
 			}
@@ -167,44 +166,44 @@ namespace Terminal.Gui {
 			public int CursorStart ()
 			{
 				return
-					provider.IsEditPosition (0)
+					_provider.IsEditPosition (0)
 					? 0
-					: provider.FindEditPositionFrom (0, true);
+					: _provider.FindEditPositionFrom (0, true);
 			}
 
 			///<inheritdoc/>
 			public int CursorEnd ()
 			{
 				return
-					provider.IsEditPosition (provider.Length - 1)
-					? provider.Length - 1
-					: provider.FindEditPositionFrom (provider.Length, false);
+					_provider.IsEditPosition (_provider.Length - 1)
+					? _provider.Length - 1
+					: _provider.FindEditPositionFrom (_provider.Length, false);
 			}
 
 			///<inheritdoc/>
 			public int CursorLeft (int pos)
 			{
-				var c = provider.FindEditPositionFrom (pos - 1, false);
+				var c = _provider.FindEditPositionFrom (pos - 1, false);
 				return c == -1 ? pos : c;
 			}
 
 			///<inheritdoc/>
 			public int CursorRight (int pos)
 			{
-				var c = provider.FindEditPositionFrom (pos + 1, true);
+				var c = _provider.FindEditPositionFrom (pos + 1, true);
 				return c == -1 ? pos : c;
 			}
 
 			///<inheritdoc/>
 			public bool Delete (int pos)
 			{
-				return provider.Replace (' ', pos);// .RemoveAt (pos);
+				return _provider.Replace (' ', pos);// .RemoveAt (pos);
 			}
 
 			///<inheritdoc/>
 			public bool InsertAt (char ch, int pos)
 			{
-				return provider.Replace (ch, pos);
+				return _provider.Replace (ch, pos);
 			}
 		}
 		#endregion
@@ -215,9 +214,9 @@ namespace Terminal.Gui {
 		/// Regex Provider for TextValidateField.
 		/// </summary>
 		public class TextRegexProvider : ITextValidateProvider {
-			Regex regex;
-			List<Rune> text;
-			List<Rune> pattern;
+			Regex _regex;
+			List<Rune> _text;
+			List<Rune> _pattern;
 
 			/// <summary>
 			/// Empty Constructor.
@@ -232,10 +231,10 @@ namespace Terminal.Gui {
 			/// </summary>
 			public string Pattern {
 				get {
-					return StringExtensions.ToString (pattern);
+					return StringExtensions.ToString (_pattern);
 				}
 				set {
-					pattern = value.ToRuneList ();
+					_pattern = value.ToRuneList ();
 					CompileMask ();
 					SetupText ();
 				}
@@ -244,10 +243,10 @@ namespace Terminal.Gui {
 			///<inheritdoc/>
 			public string Text {
 				get {
-					return StringExtensions.ToString (text);
+					return StringExtensions.ToString (_text);
 				}
 				set {
-					text = value != string.Empty ? value.ToRuneList () : null;
+					_text = value != string.Empty ? value.ToRuneList () : null;
 					SetupText ();
 				}
 			}
@@ -258,7 +257,7 @@ namespace Terminal.Gui {
 			///<inheritdoc/>
 			public bool IsValid {
 				get {
-					return Validate (text);
+					return Validate (_text);
 				}
 			}
 
@@ -272,7 +271,7 @@ namespace Terminal.Gui {
 
 			bool Validate (List<Rune> text)
 			{
-				var match = regex.Match (StringExtensions.ToString (text));
+				var match = _regex.Match (StringExtensions.ToString (text));
 				return match.Success;
 			}
 
@@ -281,7 +280,7 @@ namespace Terminal.Gui {
 			{
 				if (pos < 0) {
 					return CursorStart ();
-				} else if (pos >= text.Count) {
+				} else if (pos >= _text.Count) {
 					return CursorEnd ();
 				} else {
 					return pos;
@@ -297,7 +296,7 @@ namespace Terminal.Gui {
 			///<inheritdoc/>
 			public int CursorEnd ()
 			{
-				return text.Count;
+				return _text.Count;
 			}
 
 			///<inheritdoc/>
@@ -312,7 +311,7 @@ namespace Terminal.Gui {
 			///<inheritdoc/>
 			public int CursorRight (int pos)
 			{
-				if (pos < text.Count) {
+				if (pos < _text.Count) {
 					return pos + 1;
 				}
 				return pos;
@@ -321,8 +320,8 @@ namespace Terminal.Gui {
 			///<inheritdoc/>
 			public bool Delete (int pos)
 			{
-				if (text.Count > 0 && pos < text.Count) {
-					text.RemoveAt (pos);
+				if (_text.Count > 0 && pos < _text.Count) {
+					_text.RemoveAt (pos);
 				}
 				return true;
 			}
@@ -330,10 +329,10 @@ namespace Terminal.Gui {
 			///<inheritdoc/>
 			public bool InsertAt (char ch, int pos)
 			{
-				var aux = text.ToList ();
+				var aux = _text.ToList ();
 				aux.Insert (pos, (Rune)ch);
 				if (Validate (aux) || ValidateOnInput == false) {
-					text.Insert (pos, (Rune)ch);
+					_text.Insert (pos, (Rune)ch);
 					return true;
 				}
 				return false;
@@ -341,11 +340,11 @@ namespace Terminal.Gui {
 
 			void SetupText ()
 			{
-				if (text != null && IsValid) {
+				if (_text != null && IsValid) {
 					return;
 				}
 
-				text = new List<Rune> ();
+				_text = new List<Rune> ();
 			}
 
 			/// <summary>
@@ -353,7 +352,7 @@ namespace Terminal.Gui {
 			/// </summary>
 			private void CompileMask ()
 			{
-				regex = new Regex (StringExtensions.ToString (pattern), RegexOptions.Compiled);
+				_regex = new Regex (StringExtensions.ToString (_pattern), RegexOptions.Compiled);
 			}
 		}
 		#endregion
@@ -364,8 +363,8 @@ namespace Terminal.Gui {
 	/// </summary>
 	public class TextValidateField : View {
 
-		ITextValidateProvider provider;
-		int cursorPosition = 0;
+		ITextValidateProvider _provider;
+		int _cursorPosition;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="TextValidateField"/> class using <see cref="LayoutStyle.Computed"/> positioning.
@@ -415,11 +414,11 @@ namespace Terminal.Gui {
 		/// Provider
 		/// </summary>
 		public ITextValidateProvider Provider {
-			get => provider;
+			get => _provider;
 			set {
-				provider = value;
-				if (provider.Fixed == true) {
-					this.Width = provider.DisplayText == string.Empty ? 10 : Text.Length;
+				_provider = value;
+				if (_provider.Fixed == true) {
+					this.Width = _provider.DisplayText == string.Empty ? 10 : Text.Length;
 				}
 				HomeKeyHandler ();
 				SetNeedsDisplay ();
@@ -431,11 +430,11 @@ namespace Terminal.Gui {
 		{
 			if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed)) {
 
-				var c = provider.Cursor (mouseEvent.X - GetMargins (Frame.Width).left);
-				if (provider.Fixed == false && TextAlignment == TextAlignment.Right && Text.Length > 0) {
+				var c = _provider.Cursor (mouseEvent.X - GetMargins (Frame.Width).left);
+				if (_provider.Fixed == false && TextAlignment == TextAlignment.Right && Text.Length > 0) {
 					c += 1;
 				}
-				cursorPosition = c;
+				_cursorPosition = c;
 				SetFocus ();
 				SetNeedsDisplay ();
 				return true;
@@ -448,17 +447,17 @@ namespace Terminal.Gui {
 		/// </summary>
 		public new string Text {
 			get {
-				if (provider == null) {
+				if (_provider == null) {
 					return string.Empty;
 				}
 
-				return provider.Text;
+				return _provider.Text;
 			}
 			set {
-				if (provider == null) {
+				if (_provider == null) {
 					return;
 				}
-				provider.Text = value;
+				_provider.Text = value;
 
 				SetNeedsDisplay ();
 			}
@@ -472,10 +471,10 @@ namespace Terminal.Gui {
 			// Fixed = true, is for inputs thar have fixed width, like masked ones.
 			// Fixed = false, is for normal input.
 			// When it's right-aligned and it's a normal input, the cursor behaves differently.
-			if (provider?.Fixed == false && TextAlignment == TextAlignment.Right) {
-				Move (cursorPosition + left - 1, 0);
+			if (_provider?.Fixed == false && TextAlignment == TextAlignment.Right) {
+				Move (_cursorPosition + left - 1, 0);
 			} else {
-				Move (cursorPosition + left, 0);
+				Move (_cursorPosition + left, 0);
 			}
 		}
 
@@ -503,7 +502,7 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override void OnDrawContent (Rect contentArea)
 		{
-			if (provider == null) {
+			if (_provider == null) {
 				Move (0, 0);
 				Driver.AddStr ("Error: ITextValidateProvider not set!");
 				return;
@@ -525,8 +524,8 @@ namespace Terminal.Gui {
 			// Content
 			Driver.SetAttribute (textColor);
 			// Content
-			for (int i = 0; i < provider.DisplayText.Length; i++) {
-				Driver.AddRune ((Rune)provider.DisplayText [i]);
+			for (int i = 0; i < _provider.DisplayText.Length; i++) {
+				Driver.AddRune ((Rune)_provider.DisplayText [i]);
 			}
 
 			// Right Margin
@@ -542,10 +541,10 @@ namespace Terminal.Gui {
 		/// <returns>True if moved.</returns>
 		bool CursorLeft ()
 		{
-			var current = cursorPosition;
-			cursorPosition = provider.CursorLeft (cursorPosition);
+			var current = _cursorPosition;
+			_cursorPosition = _provider.CursorLeft (_cursorPosition);
 			SetNeedsDisplay ();
-			return current != cursorPosition;
+			return current != _cursorPosition;
 		}
 
 		/// <summary>
@@ -554,10 +553,10 @@ namespace Terminal.Gui {
 		/// <returns>True if moved.</returns>
 		bool CursorRight ()
 		{
-			var current = cursorPosition;
-			cursorPosition = provider.CursorRight (cursorPosition);
+			var current = _cursorPosition;
+			_cursorPosition = _provider.CursorRight (_cursorPosition);
 			SetNeedsDisplay ();
-			return current != cursorPosition;
+			return current != _cursorPosition;
 		}
 
 		/// <summary>
@@ -566,11 +565,11 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		bool BackspaceKeyHandler ()
 		{
-			if (provider.Fixed == false && TextAlignment == TextAlignment.Right && cursorPosition <= 1) {
+			if (_provider.Fixed == false && TextAlignment == TextAlignment.Right && _cursorPosition <= 1) {
 				return false;
 			}
-			cursorPosition = provider.CursorLeft (cursorPosition);
-			provider.Delete (cursorPosition);
+			_cursorPosition = _provider.CursorLeft (_cursorPosition);
+			_provider.Delete (_cursorPosition);
 			SetNeedsDisplay ();
 			return true;
 		}
@@ -581,10 +580,10 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		bool DeleteKeyHandler ()
 		{
-			if (provider.Fixed == false && TextAlignment == TextAlignment.Right) {
-				cursorPosition = provider.CursorLeft (cursorPosition);
+			if (_provider.Fixed == false && TextAlignment == TextAlignment.Right) {
+				_cursorPosition = _provider.CursorLeft (_cursorPosition);
 			}
-			provider.Delete (cursorPosition);
+			_provider.Delete (_cursorPosition);
 			SetNeedsDisplay ();
 			return true;
 		}
@@ -595,7 +594,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		bool HomeKeyHandler ()
 		{
-			cursorPosition = provider.CursorStart ();
+			_cursorPosition = _provider.CursorStart ();
 			SetNeedsDisplay ();
 			return true;
 		}
@@ -606,7 +605,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		bool EndKeyHandler ()
 		{
-			cursorPosition = provider.CursorEnd ();
+			_cursorPosition = _provider.CursorEnd ();
 			SetNeedsDisplay ();
 			return true;
 		}
@@ -614,17 +613,17 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override bool OnProcessKeyDown (Key a)
 		{
-			if (provider == null) {
+			if (_provider == null) {
 				return false;
 			}
 
 			if (a.AsRune == default) {
 				return false;
 			}
-			
+
 			var key = a.AsRune;
 
-			var inserted = provider.InsertAt ((char)key.Value, cursorPosition);
+			var inserted = _provider.InsertAt ((char)key.Value, _cursorPosition);
 
 			if (inserted) {
 				CursorRight ();
@@ -638,11 +637,11 @@ namespace Terminal.Gui {
 		/// </summary>
 		public virtual bool IsValid {
 			get {
-				if (provider == null) {
+				if (_provider == null) {
 					return false;
 				}
 
-				return provider.IsValid;
+				return _provider.IsValid;
 			}
 		}
 	}

--- a/Terminal.Gui/Views/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextValidateField.cs
@@ -411,15 +411,6 @@ namespace Terminal.Gui {
 		int _defaultLength = 10;
 
 		/// <summary>
-		/// Changed event, raised when the text has changed.
-		/// <remarks>
-		/// This event is raised when the <see cref="Text"/> changes.
-		/// The passed <see cref="EventArgs"/> is a <see cref="string"/> containing the old value.
-		/// </remarks>
-		/// </summary>
-		public event EventHandler<TextChangedEventArgs> TextChanged;
-
-		/// <summary>
 		/// Initializes a new instance of the <see cref="TextValidateField"/> class using <see cref="LayoutStyle.Computed"/> positioning.
 		/// </summary>
 		public TextValidateField () : this (null) { }
@@ -441,8 +432,6 @@ namespace Terminal.Gui {
 			Height = 1;
 			CanFocus = true;
 
-			Provider.TextChanged += Provider_TextChanged;
-
 			// Things this view knows how to do
 			AddCommand (Command.LeftHome, () => { HomeKeyHandler (); return true; });
 			AddCommand (Command.RightEnd, () => { EndKeyHandler (); return true; });
@@ -462,9 +451,6 @@ namespace Terminal.Gui {
 			KeyBindings.Add (KeyCode.CursorLeft, Command.Left);
 			KeyBindings.Add (KeyCode.CursorRight, Command.Right);
 		}
-
-		private void Provider_TextChanged (object sender, TextChangedEventArgs e) =>
-			TextChanged?.Invoke (this, new TextChangedEventArgs (e.OldValue));
 
 		/// <summary>
 		/// Provider

--- a/Terminal.Gui/Views/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextValidateField.cs
@@ -419,7 +419,7 @@ namespace Terminal.Gui {
 			set {
 				_provider = value;
 				if (_provider.Fixed) {
-					this.Width = _provider.DisplayText == string.Empty ? 10 : Text.Length;
+					this.Width = _provider.DisplayText == string.Empty ? _defaultLength : _provider.DisplayText.Length;
 				}
 				// HomeKeyHandler already call SetNeedsDisplay
 				HomeKeyHandler ();

--- a/Terminal.Gui/Views/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextValidateField.cs
@@ -480,7 +480,7 @@ namespace Terminal.Gui {
 				curPos = _cursorPosition + left;
 				Move (curPos, 0);
 			}
-			if (curPos >= Bounds.Width) {
+			if (curPos < 0 || curPos >= Bounds.Width) {
 				Application.Driver.SetCursorVisibility (CursorVisibility.Invisible);
 			} else {
 				Application.Driver.SetCursorVisibility (CursorVisibility.Default);

--- a/Terminal.Gui/Views/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextValidateField.cs
@@ -382,10 +382,10 @@ namespace Terminal.Gui {
 				Provider = provider;
 			}
 
-			Initialize ();
+			SetInitialProperties ();
 		}
 
-		void Initialize ()
+		void SetInitialProperties ()
 		{
 			Height = 1;
 			CanFocus = true;
@@ -468,7 +468,7 @@ namespace Terminal.Gui {
 		{
 			var (left, _) = GetMargins (Frame.Width);
 
-			// Fixed = true, is for inputs thar have fixed width, like masked ones.
+			// Fixed = true, is for inputs that have fixed width, like masked ones.
 			// Fixed = false, is for normal input.
 			// When it's right-aligned and it's a normal input, the cursor behaves differently.
 			if (_provider?.Fixed == false && TextAlignment == TextAlignment.Right) {

--- a/Terminal.Gui/Views/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextValidateField.cs
@@ -123,7 +123,7 @@ namespace Terminal.Gui {
 				set {
 					var current = _provider != null ? _provider.ToString (false, false) : string.Empty;
 					_provider = new MaskedTextProvider (value == string.Empty ? "&&&&&&" : value);
-					if (string.IsNullOrEmpty (current) == false) {
+					if (!string.IsNullOrEmpty (current)) {
 						_provider.Set (current);
 					}
 				}
@@ -365,6 +365,7 @@ namespace Terminal.Gui {
 
 		ITextValidateProvider _provider;
 		int _cursorPosition;
+		int _defaultLength = 10;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="TextValidateField"/> class using <see cref="LayoutStyle.Computed"/> positioning.
@@ -417,11 +418,11 @@ namespace Terminal.Gui {
 			get => _provider;
 			set {
 				_provider = value;
-				if (_provider.Fixed == true) {
+				if (_provider.Fixed) {
 					this.Width = _provider.DisplayText == string.Empty ? 10 : Text.Length;
 				}
+				// HomeKeyHandler already call SetNeedsDisplay
 				HomeKeyHandler ();
-				SetNeedsDisplay ();
 			}
 		}
 
@@ -430,9 +431,9 @@ namespace Terminal.Gui {
 		{
 			if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed)) {
 
-				var c = _provider.Cursor (mouseEvent.X - GetMargins (Frame.Width).left);
+				var c = _provider.Cursor (mouseEvent.X - GetMargins (Bounds.Width).left);
 				if (_provider.Fixed == false && TextAlignment == TextAlignment.Right && Text.Length > 0) {
-					c += 1;
+					c++;
 				}
 				_cursorPosition = c;
 				SetFocus ();
@@ -466,7 +467,7 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override void PositionCursor ()
 		{
-			var (left, _) = GetMargins (Frame.Width);
+			var (left, _) = GetMargins (Bounds.Width);
 
 			// Fixed = true, is for inputs that have fixed width, like masked ones.
 			// Fixed = false, is for normal input.

--- a/UICatalog/Scenarios/Text.cs
+++ b/UICatalog/Scenarios/Text.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 using Terminal.Gui;
 using Terminal.Gui.TextValidateProviders;
 
-namespace UICatalog.Scenarios; 
+namespace UICatalog.Scenarios;
 
 [ScenarioMetadata ("Text Input Controls", "Tests all text input controls")]
 [ScenarioCategory ("Controls")]
@@ -161,12 +161,12 @@ public class Text : Scenario {
 		};
 		Win.Add (labelMirroringHexEditor);
 
-			var dateField = new DateField (System.DateTime.Now) {
-				X = 1,
-				Y = Pos.Bottom (hexEditor) + 1,
-				Width = 20
-			};
-			Win.Add (dateField);
+		var dateField = new DateField (System.DateTime.Now) {
+			X = 1,
+			Y = Pos.Bottom (hexEditor) + 1,
+			Width = 20
+		};
+		Win.Add (dateField);
 
 		var labelMirroringDateField = new Label (dateField.Text) {
 			X = Pos.Right (dateField) + 1,
@@ -199,20 +199,31 @@ public class Text : Scenario {
 		_timeField.TimeChanged += TimeChanged;
 
 		// MaskedTextProvider - uses .NET MaskedTextProvider
-		var netProviderLabel = new Label ("NetMaskedTextProvider [ 999 000 LLL >LLL| AAA aaa ]") {
+		var netProviderLabel = new Label ("NetMaskedTextProvider [ 999 000 LLL >LLL |AAA aaa ]") {
 			X = Pos.Left (dateField),
 			Y = Pos.Bottom (dateField) + 1
 		};
 		Win.Add (netProviderLabel);
 
-		var netProvider = new NetMaskedTextProvider ("999 000 LLL > LLL | AAA aaa");
+		var netProvider = new NetMaskedTextProvider ("999 000 LLL >LLL |AAA aaa");
 
 		var netProviderField = new TextValidateField (netProvider) {
 			X = Pos.Right (netProviderLabel) + 1,
 			Y = Pos.Y (netProviderLabel)
 		};
-
 		Win.Add (netProviderField);
+
+		var labelMirroringNetProviderField = new Label (netProviderField.Text) {
+			X = Pos.Right (netProviderField) + 1,
+			Y = Pos.Top (netProviderField),
+			Width = Dim.Width (netProviderField),
+			Height = Dim.Height (netProviderField)
+		};
+		Win.Add (labelMirroringNetProviderField);
+
+		netProviderField.TextChanged += (s, prev) => {
+			labelMirroringNetProviderField.Text = netProviderField.Text;
+		};
 
 		// TextRegexProvider - Regex provider implemented by Terminal.Gui
 		var regexProvider = new Label ("TextRegexProvider [ ^([0-9]?[0-9]?[0-9]|1000)$ ]") {
@@ -228,8 +239,19 @@ public class Text : Scenario {
 			Width = 30,
 			TextAlignment = TextAlignment.Centered
 		};
-
 		Win.Add (regexProviderField);
+
+		var labelMirroringRegexProviderField = new Label (regexProviderField.Text) {
+			X = Pos.Right (regexProviderField) + 1,
+			Y = Pos.Top (regexProviderField),
+			Width = Dim.Width (regexProviderField),
+			Height = Dim.Height (regexProviderField)
+		};
+		Win.Add (labelMirroringRegexProviderField);
+
+		regexProviderField.TextChanged += (s, prev) => {
+			labelMirroringRegexProviderField.Text = regexProviderField.Text;
+		};
 
 		var labelAppendAutocomplete = new Label ("Append Autocomplete:") {
 			Y = Pos.Y (regexProviderField) + 2,
@@ -237,7 +259,7 @@ public class Text : Scenario {
 		};
 		var appendAutocompleteTextField = new TextField {
 			X = Pos.Right (labelAppendAutocomplete),
-			Y = Pos.Bottom (labelAppendAutocomplete),
+			Y = Pos.Top (labelAppendAutocomplete),
 			Width = Dim.Fill ()
 		};
 		appendAutocompleteTextField.Autocomplete = new AppendAutocomplete (appendAutocompleteTextField);

--- a/UICatalog/Scenarios/Text.cs
+++ b/UICatalog/Scenarios/Text.cs
@@ -221,7 +221,7 @@ public class Text : Scenario {
 		};
 		Win.Add (labelMirroringNetProviderField);
 
-		netProviderField.TextChanged += (s, prev) => {
+		netProviderField.Provider.TextChanged += (s, prev) => {
 			labelMirroringNetProviderField.Text = netProviderField.Text;
 		};
 
@@ -249,7 +249,7 @@ public class Text : Scenario {
 		};
 		Win.Add (labelMirroringRegexProviderField);
 
-		regexProviderField.TextChanged += (s, prev) => {
+		regexProviderField.Provider.TextChanged += (s, prev) => {
 			labelMirroringRegexProviderField.Text = regexProviderField.Text;
 		};
 

--- a/UnitTests/Views/TextValidateFieldTests.cs
+++ b/UnitTests/Views/TextValidateFieldTests.cs
@@ -1,568 +1,541 @@
-﻿using System;
-using System.Reflection;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Terminal.Gui.TextValidateProviders;
 
 using Xunit;
 
-namespace Terminal.Gui.ViewsTests {
+namespace Terminal.Gui.ViewsTests;
 
-	// TODO: These tests shouild not rely on AutoInitShutdown / Application
+public class TextValidateField_NET_Provider_Tests {
 
-	public class TextValidateField_NET_Provider_Tests {
+	[Fact]
+	public void Initialized_With_Cursor_On_First_Editable_Character ()
+	{
+		//                                                            *
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Initialized_With_Cursor_On_First_Editable_Character ()
-		{
-			//                                                            *
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
+		field.NewKeyDownEvent (new (KeyCode.D1));
 
-			field.NewKeyDownEvent (new (KeyCode.D1));
-
-			Assert.Equal ("--(1___)--", field.Provider.DisplayText);
-			Assert.Equal ("--(1   )--", field.Text);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Input_Ilegal_Character ()
-		{
-			//                                                            *
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			field.NewKeyDownEvent (new (KeyCode.A));
-
-			Assert.Equal ("--(    )--", field.Text);
-			Assert.Equal ("--(____)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Home_Key_First_Editable_Character ()
-		{
-			//                                                            *
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			field.NewKeyDownEvent (new (KeyCode.CursorRight));
-			field.NewKeyDownEvent (new (KeyCode.CursorRight));
-			field.NewKeyDownEvent (new (KeyCode.Home));
-
-			field.NewKeyDownEvent (new (KeyCode.D1));
-
-			Assert.Equal ("--(1___)--", field.Provider.DisplayText);
-			Assert.Equal ("--(1   )--", field.Text);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void End_Key_Last_Editable_Character ()
-		{
-			//                                                               *
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			field.NewKeyDownEvent (new (KeyCode.End));
-
-			field.NewKeyDownEvent (new (KeyCode.D1));
-
-			Assert.Equal ("--(___1)--", field.Provider.DisplayText);
-			Assert.Equal ("--(   1)--", field.Text);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Right_Key_Stops_In_Last_Editable_Character ()
-		{
-			//                                                               *
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			for (int i = 0; i < 10; i++) {
-				field.NewKeyDownEvent (new (KeyCode.CursorRight));
-			}
-			field.NewKeyDownEvent (new (KeyCode.D1));
-
-			Assert.Equal ("--(___1)--", field.Provider.DisplayText);
-			Assert.Equal ("--(   1)--", field.Text);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Left_Key_Stops_In_First_Editable_Character ()
-		{
-			//                                                            *
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			for (int i = 0; i < 10; i++) {
-				field.NewKeyDownEvent (new (KeyCode.CursorLeft));
-			}
-			field.NewKeyDownEvent (new (KeyCode.D1));
-
-			Assert.Equal ("--(1___)--", field.Provider.DisplayText);
-			Assert.Equal ("--(1   )--", field.Text);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void When_Valid_Is_Valid_True ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			field.NewKeyDownEvent (new (KeyCode.D1));
-			Assert.Equal ("--(1   )--", field.Text);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.D2));
-			Assert.Equal ("--(12  )--", field.Text);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.D3));
-			Assert.Equal ("--(123 )--", field.Text);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.D4));
-			Assert.Equal ("--(1234)--", field.Text);
-			Assert.True (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Insert_Skips_Non_Editable_Characters ()
-		{
-			//                                                            ** **
-			//                                                         01234567890
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(00-00)--")) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			field.NewKeyDownEvent (new (KeyCode.D1));
-			Assert.Equal ("--(1_-__)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.D2));
-			Assert.Equal ("--(12-__)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.D3));
-			Assert.Equal ("--(12-3_)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.D4));
-			Assert.Equal ("--(12-34)--", field.Provider.DisplayText);
-			Assert.True (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Initial_Value_Exact_Valid ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			Assert.Equal ("--(1234)--", field.Text);
-			Assert.True (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Initial_Value_Bigger_Than_Mask_Discarded ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "12345" }) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			Assert.Equal ("--(____)--", field.Provider.DisplayText);
-			Assert.Equal ("--(    )--", field.Text);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Initial_Value_Smaller_Than_Mask_Accepted ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "123" }) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			Assert.Equal ("--(123_)--", field.Provider.DisplayText);
-			Assert.Equal ("--(123 )--", field.Text);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Delete_Key_Doesnt_Move_Cursor ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			Assert.Equal ("--(1234)--", field.Provider.DisplayText);
-			Assert.True (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.Delete));
-			field.NewKeyDownEvent (new (KeyCode.Delete));
-			field.NewKeyDownEvent (new (KeyCode.Delete));
-
-			Assert.Equal ("--(_234)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.CursorRight));
-			field.NewKeyDownEvent (new (KeyCode.CursorRight));
-
-			field.NewKeyDownEvent (new (KeyCode.Delete));
-			field.NewKeyDownEvent (new (KeyCode.Delete));
-			field.NewKeyDownEvent (new (KeyCode.Delete));
-
-			Assert.Equal ("--(_2_4)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Backspace_Key_Deletes_Previous_Character ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
-
-			// Go to the end.
-			field.NewKeyDownEvent (new (KeyCode.End));
-
-			field.NewKeyDownEvent (new (KeyCode.Backspace));
-			Assert.Equal ("--(12_4)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.Backspace));
-			Assert.Equal ("--(1__4)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-
-			field.NewKeyDownEvent (new (KeyCode.Backspace));
-			Assert.Equal ("--(___4)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-
-			// One more
-			field.NewKeyDownEvent (new (KeyCode.Backspace));
-			Assert.Equal ("--(___4)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Set_Text_After_Initialization ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Left,
-				Width = 30
-			};
-
-			field.Text = "1234";
-
-			Assert.Equal ("--(1234)--", field.Text);
-			Assert.True (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void Changing_The_Mask_Tries_To_Keep_The_Previous_Text ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Left,
-				Width = 30
-			};
-
-			field.Text = "1234";
-			Assert.Equal ("--(1234)--", field.Text);
-			Assert.True (field.IsValid);
-
-			var provider = field.Provider as NetMaskedTextProvider;
-			provider.Mask = "--------(00000000)--------";
-			Assert.Equal ("--------(1234____)--------", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
-		[AutoInitShutdown]
-		public void MouseClick_Right_X_Greater_Than_Text_Width_Goes_To_Last_Editable_Position ()
-		{
-			//                                                            ****
-			//                                                         0123456789
-			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
-				TextAlignment = TextAlignment.Left,
-				Width = 30
-			};
-
-			field.NewKeyDownEvent (new (KeyCode.D1));
-
-			Assert.Equal ("--(1___)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-
-			field.MouseEvent (new MouseEvent () { X = 25, Flags = MouseFlags.Button1Pressed });
-
-			field.NewKeyDownEvent (new (KeyCode.D1));
-
-			Assert.Equal ("--(1__1)--", field.Provider.DisplayText);
-			Assert.False (field.IsValid);
-		}
+		Assert.Equal ("--(1___)--", field.Provider.DisplayText);
+		Assert.Equal ("--(1   )--", field.Text);
 	}
 
-	public class TextValidateField_Regex_Provider_Tests {
+	[Fact]
+	public void Input_Ilegal_Character ()
+	{
+		//                                                            *
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Input_Without_Validate_On_Input ()
-		{
-			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
-				Width = 20
-			};
+		field.NewKeyDownEvent (new (KeyCode.A));
 
-			field.NewKeyDownEvent (new (KeyCode.D1));
-			Assert.Equal ("1", field.Text);
-			Assert.False (field.IsValid);
+		Assert.Equal ("--(    )--", field.Text);
+		Assert.Equal ("--(____)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+	}
 
-			field.NewKeyDownEvent (new (KeyCode.D2));
-			Assert.Equal ("12", field.Text);
-			Assert.False (field.IsValid);
+	[Fact]
+	public void Home_Key_First_Editable_Character ()
+	{
+		//                                                            *
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
 
-			field.NewKeyDownEvent (new (KeyCode.D3));
-			Assert.Equal ("123", field.Text);
-			Assert.True (field.IsValid);
+		field.NewKeyDownEvent (new (KeyCode.CursorRight));
+		field.NewKeyDownEvent (new (KeyCode.CursorRight));
+		field.NewKeyDownEvent (new (KeyCode.Home));
 
-			field.NewKeyDownEvent (new (KeyCode.D4));
-			Assert.Equal ("1234", field.Text);
-			Assert.False (field.IsValid);
+		field.NewKeyDownEvent (new (KeyCode.D1));
+
+		Assert.Equal ("--(1___)--", field.Provider.DisplayText);
+		Assert.Equal ("--(1   )--", field.Text);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void End_Key_Last_Editable_Character ()
+	{
+		//                                                               *
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		field.NewKeyDownEvent (new (KeyCode.End));
+
+		field.NewKeyDownEvent (new (KeyCode.D1));
+
+		Assert.Equal ("--(___1)--", field.Provider.DisplayText);
+		Assert.Equal ("--(   1)--", field.Text);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void Right_Key_Stops_In_Last_Editable_Character ()
+	{
+		//                                                               *
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		for (int i = 0; i < 10; i++) {
+			field.NewKeyDownEvent (new (KeyCode.CursorRight));
+		}
+		field.NewKeyDownEvent (new (KeyCode.D1));
+
+		Assert.Equal ("--(___1)--", field.Provider.DisplayText);
+		Assert.Equal ("--(   1)--", field.Text);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void Left_Key_Stops_In_First_Editable_Character ()
+	{
+		//                                                            *
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		for (int i = 0; i < 10; i++) {
+			field.NewKeyDownEvent (new (KeyCode.CursorLeft));
+		}
+		field.NewKeyDownEvent (new (KeyCode.D1));
+
+		Assert.Equal ("--(1___)--", field.Provider.DisplayText);
+		Assert.Equal ("--(1   )--", field.Text);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void When_Valid_Is_Valid_True ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		field.NewKeyDownEvent (new (KeyCode.D1));
+		Assert.Equal ("--(1   )--", field.Text);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D2));
+		Assert.Equal ("--(12  )--", field.Text);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D3));
+		Assert.Equal ("--(123 )--", field.Text);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D4));
+		Assert.Equal ("--(1234)--", field.Text);
+		Assert.True (field.IsValid);
+	}
+
+	[Fact]
+	public void Insert_Skips_Non_Editable_Characters ()
+	{
+		//                                                            ** **
+		//                                                         01234567890
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(00-00)--")) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		field.NewKeyDownEvent (new (KeyCode.D1));
+		Assert.Equal ("--(1_-__)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D2));
+		Assert.Equal ("--(12-__)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D3));
+		Assert.Equal ("--(12-3_)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D4));
+		Assert.Equal ("--(12-34)--", field.Provider.DisplayText);
+		Assert.True (field.IsValid);
+	}
+
+	[Fact]
+	public void Initial_Value_Exact_Valid ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		Assert.Equal ("--(1234)--", field.Text);
+		Assert.True (field.IsValid);
+	}
+
+	[Fact]
+	public void Initial_Value_Bigger_Than_Mask_Discarded ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "12345" }) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		Assert.Equal ("--(____)--", field.Provider.DisplayText);
+		Assert.Equal ("--(    )--", field.Text);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void Initial_Value_Smaller_Than_Mask_Accepted ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "123" }) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		Assert.Equal ("--(123_)--", field.Provider.DisplayText);
+		Assert.Equal ("--(123 )--", field.Text);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void Delete_Key_Doesnt_Move_Cursor ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		Assert.Equal ("--(1234)--", field.Provider.DisplayText);
+		Assert.True (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.Delete));
+		field.NewKeyDownEvent (new (KeyCode.Delete));
+		field.NewKeyDownEvent (new (KeyCode.Delete));
+
+		Assert.Equal ("--(_234)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.CursorRight));
+		field.NewKeyDownEvent (new (KeyCode.CursorRight));
+
+		field.NewKeyDownEvent (new (KeyCode.Delete));
+		field.NewKeyDownEvent (new (KeyCode.Delete));
+		field.NewKeyDownEvent (new (KeyCode.Delete));
+
+		Assert.Equal ("--(_2_4)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void Backspace_Key_Deletes_Previous_Character ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		// Go to the end.
+		field.NewKeyDownEvent (new (KeyCode.End));
+
+		field.NewKeyDownEvent (new (KeyCode.Backspace));
+		Assert.Equal ("--(12_4)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.Backspace));
+		Assert.Equal ("--(1__4)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.Backspace));
+		Assert.Equal ("--(___4)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+
+		// One more
+		field.NewKeyDownEvent (new (KeyCode.Backspace));
+		Assert.Equal ("--(___4)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void Set_Text_After_Initialization ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Left,
+			Width = 30
+		};
+
+		field.Text = "1234";
+
+		Assert.Equal ("--(1234)--", field.Text);
+		Assert.True (field.IsValid);
+	}
+
+	[Fact]
+	public void Changing_The_Mask_Tries_To_Keep_The_Previous_Text ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Left,
+			Width = 30
+		};
+
+		field.Text = "1234";
+		Assert.Equal ("--(1234)--", field.Text);
+		Assert.True (field.IsValid);
+
+		var provider = field.Provider as NetMaskedTextProvider;
+		provider.Mask = "--------(00000000)--------";
+		Assert.Equal ("--------(1234____)--------", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void MouseClick_Right_X_Greater_Than_Text_Width_Goes_To_Last_Editable_Position ()
+	{
+		//                                                            ****
+		//                                                         0123456789
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Left,
+			Width = 30
+		};
+
+		field.NewKeyDownEvent (new (KeyCode.D1));
+
+		Assert.Equal ("--(1___)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+		Assert.Equal ("--(1   )--", field.Provider.Text);
+
+		field.MouseEvent (new MouseEvent () { X = 25, Flags = MouseFlags.Button1Pressed });
+
+		field.NewKeyDownEvent (new (KeyCode.D1));
+
+		Assert.Equal ("--(1__1)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+		Assert.Equal ("--(1  1)--", field.Provider.Text);
+	}
+}
+
+public class TextValidateField_Regex_Provider_Tests {
+
+	[Fact]
+	public void Input_Without_Validate_On_Input ()
+	{
+		var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
+			Width = 20
+		};
+
+		field.NewKeyDownEvent (new (KeyCode.D1));
+		Assert.Equal ("1", field.Text);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D2));
+		Assert.Equal ("12", field.Text);
+		Assert.False (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D3));
+		Assert.Equal ("123", field.Text);
+		Assert.True (field.IsValid);
+
+		field.NewKeyDownEvent (new (KeyCode.D4));
+		Assert.Equal ("1234", field.Text);
+		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void Input_With_Validate_On_Input_Set_Text ()
+	{
+		var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$")) {
+			Width = 20
+		};
+
+		// Input dosen't validates the pattern.
+		field.NewKeyDownEvent (new (KeyCode.D1));
+		Assert.Equal ("", field.Text);
+		Assert.False (field.IsValid);
+
+		// Dosen't match
+		field.Text = "12356";
+		Assert.Equal ("", field.Text);
+		Assert.False (field.IsValid);
+
+		// Yes.
+		field.Text = "123";
+		Assert.Equal ("123", field.Text);
+		Assert.True (field.IsValid);
+	}
+
+	[Fact]
+	public void Text_With_All_Charset ()
+	{
+		var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$")) {
+			Width = 20
+		};
+
+		var text = "";
+		for (int i = 0; i < 255; i++) {
+			text += (char)i;
 		}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Input_With_Validate_On_Input_Set_Text ()
-		{
-			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$")) {
-				Width = 20
-			};
+		field.Text = text;
 
-			// Input dosen't validates the pattern.
-			field.NewKeyDownEvent (new (KeyCode.D1));
-			Assert.Equal ("", field.Text);
-			Assert.False (field.IsValid);
+		Assert.False (field.IsValid);
+	}
 
-			// Dosen't match
-			field.Text = "12356";
-			Assert.Equal ("", field.Text);
-			Assert.False (field.IsValid);
+	[Fact]
+	public void Mask_With_Invalid_Pattern_Exception ()
+	{
+		// Regex Exception
+		// Maybe it's not the right behaviour.
 
-			// Yes.
-			field.Text = "123";
-			Assert.Equal ("123", field.Text);
-			Assert.True (field.IsValid);
+		var mask = "";
+		for (int i = 0; i < 255; i++) {
+			mask += (char)i;
 		}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Text_With_All_Charset ()
-		{
-			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$")) {
+		try {
+			var field = new TextValidateField (new TextRegexProvider (mask)) {
 				Width = 20
 			};
-
-			var text = "";
-			for (int i = 0; i < 255; i++) {
-				text += (char)i;
-			}
-
-			field.Text = text;
-
-			Assert.False (field.IsValid);
+		} catch (RegexParseException ex) {
+			Assert.True (true, ex.Message);
+			return;
 		}
+		Assert.True (false);
+	}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Mask_With_Invalid_Pattern_Exception ()
-		{
-			// Regex Exception
-			// Maybe it's not the right behaviour.
+	[Fact]
+	public void Home_Key_First_Editable_Character ()
+	{
+		// Range 0 to 1000
+		// Accepts 001 too.
+		var field = new TextValidateField (new TextRegexProvider ("^[0-9]?[0-9]?[0-9]|1000$")) {
+			Width = 20
+		};
 
-			var mask = "";
-			for (int i = 0; i < 255; i++) {
-				mask += (char)i;
-			}
+		field.NewKeyDownEvent (new (KeyCode.D1));
+		field.NewKeyDownEvent (new (KeyCode.D0));
+		field.NewKeyDownEvent (new (KeyCode.D0));
+		field.NewKeyDownEvent (new (KeyCode.D0));
 
-			try {
-				var field = new TextValidateField (new TextRegexProvider (mask)) {
-					Width = 20
-				};
-			} catch (RegexParseException ex) {
-				Assert.True (true, ex.Message);
-				return;
-			}
-			Assert.True (false);
-		}
+		Assert.Equal ("1000", field.Text);
+		Assert.True (field.IsValid);
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Home_Key_First_Editable_Character ()
-		{
-			// Range 0 to 1000
-			// Accepts 001 too.
-			var field = new TextValidateField (new TextRegexProvider ("^[0-9]?[0-9]?[0-9]|1000$")) {
-				Width = 20
-			};
+		// HOME KEY
+		field.NewKeyDownEvent (new (KeyCode.Home));
 
-			field.NewKeyDownEvent (new (KeyCode.D1));
+		// DELETE
+		field.NewKeyDownEvent (new (KeyCode.Delete));
+
+		Assert.Equal ("000", field.Text);
+		Assert.True (field.IsValid);
+	}
+
+	[Fact]
+	public void End_Key_End_Of_Input ()
+	{
+		// Exactly 5 numbers
+		var field = new TextValidateField (new TextRegexProvider ("^[0-9]{5}$") { ValidateOnInput = false }) {
+			Width = 20
+		};
+
+		for (int i = 0; i < 4; i++) {
 			field.NewKeyDownEvent (new (KeyCode.D0));
-			field.NewKeyDownEvent (new (KeyCode.D0));
-			field.NewKeyDownEvent (new (KeyCode.D0));
-
-			Assert.Equal ("1000", field.Text);
-			Assert.True (field.IsValid);
-
-			// HOME KEY
-			field.NewKeyDownEvent (new (KeyCode.Home));
-
-			// DELETE
-			field.NewKeyDownEvent (new (KeyCode.Delete));
-
-			Assert.Equal ("000", field.Text);
-			Assert.True (field.IsValid);
 		}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void End_Key_End_Of_Input ()
-		{
-			// Exactly 5 numbers
-			var field = new TextValidateField (new TextRegexProvider ("^[0-9]{5}$") { ValidateOnInput = false }) {
-				Width = 20
-			};
+		Assert.Equal ("0000", field.Text);
+		Assert.False (field.IsValid);
 
-			for (int i = 0; i < 4; i++) {
-				field.NewKeyDownEvent (new (KeyCode.D0));
-			}
+		// HOME KEY
+		field.NewKeyDownEvent (new (KeyCode.Home));
 
-			Assert.Equal ("0000", field.Text);
-			Assert.False (field.IsValid);
+		// END KEY
+		field.NewKeyDownEvent (new (KeyCode.End));
 
-			// HOME KEY
-			field.NewKeyDownEvent (new (KeyCode.Home));
+		// Insert 9
+		field.NewKeyDownEvent (new (KeyCode.D9));
 
-			// END KEY
-			field.NewKeyDownEvent (new (KeyCode.End));
+		Assert.Equal ("00009", field.Text);
+		Assert.True (field.IsValid);
 
-			// Insert 9
-			field.NewKeyDownEvent (new (KeyCode.D9));
+		// Insert 9
+		field.NewKeyDownEvent (new (KeyCode.D9));
 
-			Assert.Equal ("00009", field.Text);
-			Assert.True (field.IsValid);
+		Assert.Equal ("000099", field.Text);
+		Assert.False (field.IsValid);
+	}
 
-			// Insert 9
-			field.NewKeyDownEvent (new (KeyCode.D9));
+	[Fact]
+	public void Right_Key_Stops_At_End_And_Insert ()
+	{
+		var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
 
-			Assert.Equal ("000099", field.Text);
-			Assert.False (field.IsValid);
+		field.Text = "123";
+
+		for (int i = 0; i < 10; i++) {
+			field.NewKeyDownEvent (new (KeyCode.CursorRight));
 		}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Right_Key_Stops_At_End_And_Insert ()
-		{
-			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
+		Assert.Equal ("123", field.Text);
+		Assert.True (field.IsValid);
 
-			field.Text = "123";
+		// Insert 4
+		field.NewKeyDownEvent (new (KeyCode.D4));
 
-			for (int i = 0; i < 10; i++) {
-				field.NewKeyDownEvent (new (KeyCode.CursorRight));
-			}
+		Assert.Equal ("1234", field.Text);
+		Assert.False (field.IsValid);
+	}
 
-			Assert.Equal ("123", field.Text);
-			Assert.True (field.IsValid);
+	[Fact]
+	public void Left_Key_Stops_At_Start_And_Insert ()
+	{
+		var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
 
-			// Insert 4
-			field.NewKeyDownEvent (new (KeyCode.D4));
+		field.Text = "123";
 
-			Assert.Equal ("1234", field.Text);
-			Assert.False (field.IsValid);
+		for (int i = 0; i < 10; i++) {
+			field.NewKeyDownEvent (new (KeyCode.CursorLeft));
 		}
 
-		[Fact]
-		[AutoInitShutdown]
-		public void Left_Key_Stops_At_Start_And_Insert ()
-		{
-			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
-				TextAlignment = TextAlignment.Centered,
-				Width = 20
-			};
+		Assert.Equal ("123", field.Text);
+		Assert.True (field.IsValid);
 
-			field.Text = "123";
+		// Insert 4
+		field.NewKeyDownEvent (new (KeyCode.D4));
 
-			for (int i = 0; i < 10; i++) {
-				field.NewKeyDownEvent (new (KeyCode.CursorLeft));
-			}
-
-			Assert.Equal ("123", field.Text);
-			Assert.True (field.IsValid);
-
-			// Insert 4
-			field.NewKeyDownEvent (new (KeyCode.D4));
-
-			Assert.Equal ("4123", field.Text);
-			Assert.False (field.IsValid);
-		}
+		Assert.Equal ("4123", field.Text);
+		Assert.False (field.IsValid);
 	}
 }

--- a/UnitTests/Views/TextValidateFieldTests.cs
+++ b/UnitTests/Views/TextValidateFieldTests.cs
@@ -365,7 +365,7 @@ public class TextValidateField_NET_Provider_Tests {
 			Width = 30
 		};
 
-		field.TextChanged += (sender, e) => wasTextChanged = true;
+		field.Provider.TextChanged += (sender, e) => wasTextChanged = true;
 
 		field.NewKeyDownEvent (new (KeyCode.D1));
 
@@ -583,7 +583,7 @@ public class TextValidateField_Regex_Provider_Tests {
 			Width = 20
 		};
 
-		field.TextChanged += (sender, e) => wasTextChanged = true;
+		field.Provider.TextChanged += (sender, e) => wasTextChanged = true;
 
 		field.NewKeyDownEvent (new (KeyCode.D1));
 

--- a/UnitTests/Views/TextValidateFieldTests.cs
+++ b/UnitTests/Views/TextValidateFieldTests.cs
@@ -354,6 +354,26 @@ public class TextValidateField_NET_Provider_Tests {
 		Assert.NotEqual (field.Provider.DisplayText.Length, field.Provider.Text.Length);
 		Assert.Equal (new string (' ', field.Text.Length), field.Provider.Text);
 	}
+
+	[Fact]
+	public void OnTextChanged_TextChanged_Event ()
+	{
+		var wasTextChanged = false;
+
+		var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
+			TextAlignment = TextAlignment.Left,
+			Width = 30
+		};
+
+		field.TextChanged += (sender, e) => wasTextChanged = true;
+
+		field.NewKeyDownEvent (new (KeyCode.D1));
+
+		Assert.Equal ("--(1___)--", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+		Assert.Equal ("--(1   )--", field.Provider.Text);
+		Assert.True (wasTextChanged);
+	}
 }
 
 public class TextValidateField_Regex_Provider_Tests {
@@ -551,5 +571,25 @@ public class TextValidateField_Regex_Provider_Tests {
 
 		Assert.Equal ("4123", field.Text);
 		Assert.False (field.IsValid);
+	}
+
+	[Fact]
+	public void OnTextChanged_TextChanged_Event ()
+	{
+		var wasTextChanged = false;
+
+		var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
+			TextAlignment = TextAlignment.Centered,
+			Width = 20
+		};
+
+		field.TextChanged += (sender, e) => wasTextChanged = true;
+
+		field.NewKeyDownEvent (new (KeyCode.D1));
+
+		Assert.Equal ("1", field.Provider.DisplayText);
+		Assert.False (field.IsValid);
+		Assert.Equal ("1", field.Provider.Text);
+		Assert.True (wasTextChanged);
 	}
 }

--- a/UnitTests/Views/TextValidateFieldTests.cs
+++ b/UnitTests/Views/TextValidateFieldTests.cs
@@ -340,6 +340,20 @@ public class TextValidateField_NET_Provider_Tests {
 		Assert.False (field.IsValid);
 		Assert.Equal ("--(1  1)--", field.Provider.Text);
 	}
+
+	[Fact]
+	public void Default_Width_Is_Always_Equal_To_The_Provider_DisplayText_Length ()
+	{
+		// 9-Digit or space, optional. 0-Digit, required. L-Letter, required.
+		// > Shift up. Converts all characters that follow to uppercase.
+		// | Disable a previous shift up or shift down.
+		// A-Alphanumeric, required. a-Alphanumeric, optional.
+		var field = new TextValidateField (new NetMaskedTextProvider ("999 000 LLL >LLL |AAA aaa"));
+
+		Assert.Equal (field.Bounds.Width, field.Provider.DisplayText.Length);
+		Assert.NotEqual (field.Provider.DisplayText.Length, field.Provider.Text.Length);
+		Assert.Equal (new string (' ', field.Text.Length), field.Provider.Text);
+	}
 }
 
 public class TextValidateField_Regex_Provider_Tests {


### PR DESCRIPTION
## Fixes

- Fixes #3189

## Proposed Changes/Todos

- [x] Show and hide cursor
- [x] Add OnTextChanged method
- [x] Add TextChanged event

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

![image](https://github.com/gui-cs/Terminal.Gui/assets/13117724/1369a8a3-3415-4ffd-85e1-e691a1773900)
