### PR TITLE
Fixes #2095. Resizing when a context menu is open causes the Enter event to get spammed

### DIFF
--- a/Terminal.Gui/Views/ContextMenu.cs
+++ b/Terminal.Gui/Views/ContextMenu.cs
@@ -79,7 +79,6 @@ namespace Terminal.Gui {
 			}
 			if (container != null) {
 				container.Closing -= Container_Closing;
-				container.Resized -= Container_Resized;
 			}
 		}
 
@@ -93,7 +92,6 @@ namespace Terminal.Gui {
 			}
 			container = Application.Current;
 			container.Closing += Container_Closing;
-			container.Resized += Container_Resized;
 			var frame = container.Frame;
 			var position = Position;
 			if (Host != null) {
@@ -143,13 +141,6 @@ namespace Terminal.Gui {
 			menuBar.MenuAllClosed += MenuBar_MenuAllClosed;
 			IsShow = true;
 			menuBar.OpenMenu ();
-		}
-
-		private void Container_Resized (Size obj)
-		{
-			if (IsShow) {
-				Show ();
-			}
 		}
 
 		private void Container_Closing (ToplevelClosingEventArgs obj)

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -424,6 +424,10 @@ namespace Terminal.Gui {
 				WantMousePositionReports = host.WantMousePositionReports;
 			}
 
+			if (Application.Current != null) {
+				Application.Current.Resized += Current_Resized;
+			}
+
 			// Things this view knows how to do
 			AddCommand (Command.LineUp, () => MoveUp ());
 			AddCommand (Command.LineDown, () => MoveDown ());
@@ -447,6 +451,13 @@ namespace Terminal.Gui {
 			AddKeyBinding (Key.CursorRight, Command.Right);
 			AddKeyBinding (Key.Esc, Command.Cancel);
 			AddKeyBinding (Key.Enter, Command.Accept);
+		}
+
+		private void Current_Resized (Size obj)
+		{
+			if (host.IsMenuOpen) {
+				host.CloseAllMenus ();
+			}
 		}
 
 		internal Attribute DetermineColorSchemeFor (MenuItem item, int index)
@@ -845,6 +856,15 @@ namespace Terminal.Gui {
 			Application.Driver.SetCursorVisibility (CursorVisibility.Invisible);
 
 			return base.OnEnter (view);
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (Application.Current != null) {
+				Application.Current.Resized -= Current_Resized;
+			}
+
+			base.Dispose (disposing);
 		}
 	}
 

--- a/UnitTests/Menus/ContextMenuTests.cs
+++ b/UnitTests/Menus/ContextMenuTests.cs
@@ -385,6 +385,8 @@ namespace Terminal.Gui.MenuTests {
 		[Fact, AutoInitShutdown]
 		public void Show_Display_At_Zero_If_The_Toplevel_Width_Is_Less_Than_The_Menu_Width ()
 		{
+			((FakeDriver)Application.Driver).SetBufferSize (5, 25);
+
 			var cm = new ContextMenu (0, 0,
 				new MenuBarItem (new MenuItem [] {
 					new MenuItem ("One", "", null),
@@ -397,7 +399,6 @@ namespace Terminal.Gui.MenuTests {
 			cm.Show ();
 			Assert.Equal (new Point (0, 0), cm.Position);
 			Application.Begin (Application.Top);
-			((FakeDriver)Application.Driver).SetBufferSize (5, 25);
 
 			var expected = @"
 ┌────
@@ -416,6 +417,8 @@ namespace Terminal.Gui.MenuTests {
 		[Fact, AutoInitShutdown]
 		public void Show_Display_At_Zero_If_The_Toplevel_Height_Is_Less_Than_The_Menu_Height ()
 		{
+			((FakeDriver)Application.Driver).SetBufferSize (80, 3);
+
 			var cm = new ContextMenu (0, 0,
 				new MenuBarItem (new MenuItem [] {
 					new MenuItem ("One", "", null),
@@ -428,7 +431,6 @@ namespace Terminal.Gui.MenuTests {
 			cm.Show ();
 			Assert.Equal (new Point (0, 0), cm.Position);
 			Application.Begin (Application.Top);
-			((FakeDriver)Application.Driver).SetBufferSize (80, 3);
 
 			var expected = @"
 ┌──────┐

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="ReportGenerator" Version="5.2.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.6.5" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Fixes

- Fixes #2095

## Proposed Changes/Todos

- [x] `ContextMenu` now close on terminal resizing

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
