### PR TITLE
Fixes #2571. Wizards background shifts to gray when focusing, looks bad.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1500,8 +1500,11 @@ namespace Terminal.Gui {
 				(GetType ().IsNestedPublic && !IsOverridden (this, "Redraw") || GetType ().Name == "View") &&
 				(!NeedDisplay.IsEmpty || ChildNeedsDisplay || LayoutNeeded)) {
 
-				Clear ();
-				SetChildNeedsDisplay ();
+				if (ColorScheme != null) {
+					Driver.SetAttribute (GetNormalColor ());
+					Clear ();
+					SetChildNeedsDisplay ();
+				}
 			}
 
 			if (!ustring.IsNullOrEmpty (TextFormatter.Text)) {

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="ReportGenerator" Version="5.2.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.6.5" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -4579,7 +4579,7 @@ Test", output);
 			TestHelpers.AssertDriverColorsAre (@"
 000000
 011110
-000000", [Colors.TopLevel.Normal, Colors.TopLevel.Focus]);
+000000", new Attribute [] { Colors.TopLevel.Normal, Colors.TopLevel.Focus });
 		}
 	}
 }

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -4563,5 +4563,23 @@ Label", output);
 			TestHelpers.AssertDriverContentsAre (@"
 Label", output);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void View_Instance_Use_Attribute_Normal_On_Draw ()
+		{
+			var view = new View { Id = "view", X = 1, Y = 1, Width = 4, Height = 1, Text = "Test", CanFocus = true };
+			var root = new View { Id = "root", Width = Dim.Fill (), Height = Dim.Fill () };
+			root.Add (view);
+			Application.Top.Add (root);
+			Application.Begin (Application.Top);
+
+			TestHelpers.AssertDriverContentsAre (@"
+Test", output);
+
+			TestHelpers.AssertDriverColorsAre (@"
+000000
+011110
+000000", [Colors.TopLevel.Normal, Colors.TopLevel.Focus]);
+		}
 	}
 }


### PR DESCRIPTION
## Fixes

- Fixes #2571

## Proposed Changes/Todos

- [x] Allowing containers to use the normal attribute instead of the focused color
- [ ] Adding unit test

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
