### PR TITLE
Fixes #2252. Pressing the ENTER key in a TextField should not move the focus

### DIFF
--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -219,7 +219,7 @@ namespace Terminal.Gui {
 
 		bool AcceptKey ()
 		{
-			if (!HasFocus) {
+			if (!IsDefault && !HasFocus) {
 				SetFocus ();
 			}
 			OnClicked ();

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -129,6 +129,10 @@ namespace Terminal.Gui {
 		/// Gets or sets whether the <see cref="Button"/> is the default action to activate in a dialog.
 		/// </summary>
 		/// <value><c>true</c> if is default; otherwise, <c>false</c>.</value>
+		/// <remarks>
+		/// If is <see langword="true"/> the current focused view
+		/// will remain focused if the window is not closed.
+		/// </remarks>
 		public bool IsDefault {
 			get => is_default;
 			set {

--- a/UnitTests/Views/ButtonTests.cs
+++ b/UnitTests/Views/ButtonTests.cs
@@ -585,5 +585,21 @@ namespace Terminal.Gui.ViewTests {
 
 			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void IsDefault_True_Does_Not_Get_The_Focus_On_Enter_Key ()
+		{
+			var wasClicked = false;
+			var view = new View { CanFocus = true };
+			var btn = new Button { Text = "Ok", IsDefault = true };
+			btn.Clicked += () => wasClicked = true;
+			Application.Top.Add (view, btn);
+			Application.Begin (Application.Top);
+			Assert.True (view.HasFocus);
+
+			Application.Top.ProcessColdKey (new KeyEvent (Key.Enter, new KeyModifiers ()));
+			Assert.True (view.HasFocus);
+			Assert.True (wasClicked);
+		}
 	}
 }

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -11,6 +11,11 @@
 			"wslDistribution": "Ubuntu"
 		},
 		{
+			"name": "WSL-Ubuntu-20.04",
+			"type": "wsl",
+			"wslDistribution": "Ubuntu-20.04"
+		},
+		{
 			"name": "WSL-Debian",
 			"type": "wsl",
 			"wslDistribution": "Debian"


### PR DESCRIPTION
## Fixes

- Fixes #2252

## Proposed Changes/Todos

- [x] `IsDefault` true doesn't get the focus on the Enter key unless it's already focused.
- [x] Add unit test

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
