### PR TITLE
Fixes #3234. ProcessContinuousButtonPressedAsync is always passing the start location.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -260,7 +260,7 @@ public static class EscSeqUtils {
 	/// </summary>
 	/// <param name="code">One of the 16 color codes.</param>
 	/// <returns></returns>
-	public static string CSI_SetBackgroundColor (AnsiColorCode code) => CSI_SetGraphicsRendition ((int)code+10);
+	public static string CSI_SetBackgroundColor (AnsiColorCode code) => CSI_SetGraphicsRendition ((int)code + 10);
 
 	/// <summary>
 	/// ESC[38;5;{id}m - Set foreground color (256 colors)
@@ -743,7 +743,7 @@ public static class EscSeqUtils {
 	private static bool isButtonClicked;
 	private static bool isButtonDoubleClicked;
 	private static bool isButtonTripleClicked;
-	private static Point point;
+	private static Point? point;
 
 	/// <summary>
 	/// Gets the <see cref="MouseFlags"/> mouse button flags and the position.
@@ -974,18 +974,21 @@ public static class EscSeqUtils {
 			lastMouseButtonPressed = buttonState;
 			isButtonPressed = true;
 
-			if ((mouseFlags [0] & MouseFlags.ReportMousePosition) == 0) {
-				point = new Point () {
-					X = pos.X,
-					Y = pos.Y
-				};
+			if (point is null) {
+				point = pos;
+			}
 
+			if ((mouseFlags [0] & MouseFlags.ReportMousePosition) == 0) {
 				Application.MainLoop.AddIdle (() => {
 					Task.Run (async () => await ProcessContinuousButtonPressedAsync (buttonState, continuousButtonPressedHandler));
 					return false;
 				});
-			} else if (mouseFlags [0] == MouseFlags.ReportMousePosition) {
-				isButtonPressed = false;
+			} else if (mouseFlags [0].HasFlag (MouseFlags.ReportMousePosition)) {
+				point = pos;
+				// The isButtonPressed must always be true, otherwise we can lose the feature
+				// If mouse flags has ReportMousePosition this feature won't run
+				// but is always prepared with the new location
+				//isButtonPressed = false;
 			}
 
 		} else if (isButtonDoubleClicked && (buttonState == MouseFlags.Button1Pressed || buttonState == MouseFlags.Button2Pressed ||
@@ -1026,7 +1029,7 @@ public static class EscSeqUtils {
 
 			if (isButtonTripleClicked) {
 				isButtonTripleClicked = false;
-			} else if (pos.X == point.X && pos.Y == point.Y) {
+			} else if (pos.X == point?.X && pos.Y == point?.Y) {
 				mouseFlags.Add (GetButtonClicked (buttonState));
 				isButtonClicked = true;
 				Application.MainLoop.AddIdle (() => {
@@ -1085,17 +1088,17 @@ public static class EscSeqUtils {
 	{
 		while (isButtonPressed) {
 			await Task.Delay (100);
-			//var me = new MouseEvent () {
-			//	X = point.X,
-			//	Y = point.Y,
-			//	Flags = mouseFlag
-			//};
+			var me = new MouseEvent () {
+				X = point?.X ?? 0,
+				Y = point?.Y ?? 0,
+				Flags = mouseFlag
+			};
 
 			var view = Application.WantContinuousButtonPressedView;
 			if (view == null)
 				break;
 			if (isButtonPressed && lastMouseButtonPressed != null && (mouseFlag & MouseFlags.ReportMousePosition) == 0) {
-				Application.Invoke (() => continuousButtonPressedHandler (mouseFlag, point));
+				Application.Invoke (() => continuousButtonPressedHandler (mouseFlag, point ?? Point.Empty));
 			}
 		}
 	}

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -1088,11 +1088,6 @@ public static class EscSeqUtils {
 	{
 		while (isButtonPressed) {
 			await Task.Delay (100);
-			var me = new MouseEvent () {
-				X = point?.X ?? 0,
-				Y = point?.Y ?? 0,
-				Flags = mouseFlag
-			};
 
 			var view = Application.WantContinuousButtonPressedView;
 			if (view == null)

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -826,7 +826,7 @@ internal class WindowsDriver : ConsoleDriver {
 		// TODO: if some other Windows-based terminal supports true color, update this logic to not
 		// force 16color mode (.e.g ConEmu which really doesn't work well at all).
 		_isWindowsTerminal = _isWindowsTerminal = Environment.GetEnvironmentVariable ("WT_SESSION") != null ||
-		                                          Environment.GetEnvironmentVariable ("VSAPPIDNAME") != null;
+							  Environment.GetEnvironmentVariable ("VSAPPIDNAME") != null;
 		if (!_isWindowsTerminal) {
 			Force16Colors = true;
 		}
@@ -1190,11 +1190,12 @@ internal class WindowsDriver : ConsoleDriver {
 				break;
 			}
 
-			if (_point == null) {
+			if (_point is null) {
 				_point = p;
 			}
 
-			if (mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved) {
+			if (mouseEvent.EventFlags.HasFlag (WindowsConsole.EventFlags.MouseMoved)) {
+				_pointMove = p;
 				mouseFlag |= MouseFlags.ReportMousePosition;
 				_isButtonReleased = false;
 				_processButtonClick = false;


### PR DESCRIPTION
## Fixes

- Fixes #3234

## Proposed Changes/Todos

- [x] WindowsDriver
- [x] EscSeqUtils used by CursesDriver and NetDriver.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
