### PR TITLE
Fixes documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ dotnet run
 ## Documentation 
 
 * [Documentation Home](https://gui-cs.github.io/Terminal.Gui/index.html)
-* [Terminal.Gui Overview](https://gui-cs.github.io/Terminal.Gui/articles/overview.html)
-* [List of Views/Controls](https://gui-cs.github.io/Terminal.Gui/articles/views.html)
-* [Conceptual Documentation](https://gui-cs.github.io/Terminal.Gui/articles/index.html)
-* [API Documentation](https://gui-cs.github.io/Terminal.Gui)
+* [Terminal.Gui Overview](https://gui-cs.github.io/Terminal.Gui/docs/overview.html)
+* [List of Views/Controls](https://gui-cs.github.io/Terminal.Gui/docs/views.html)
+* [Conceptual Documentation](https://gui-cs.github.io/Terminal.Gui/docs/index.html)
+* [API Documentation](https://gui-cs.github.io/Terminal.Gui/api/Terminal.Gui)
 
 _The Documentation matches the most recent Nuget release from the `main` branch ([![Version](https://img.shields.io/nuget/v/Terminal.Gui.svg)](https://www.nuget.org/packages/Terminal.Gui))_
 


### PR DESCRIPTION
## Fixes

No issue opened. Some links on the README leads to a 404, I am not sure if this is intentional given the v2 changes. This PR fixes the broken links and leads to the v1 documentation.

Feel free to close if it is not the correct fix!

## Proposed Changes/Todos

- Fixes links

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
