### PR TITLE
Fixes #3310. View.OnMouseClick now Can/Setfocus.

### DIFF
--- a/Terminal.Gui/View/ViewMouse.cs
+++ b/Terminal.Gui/View/ViewMouse.cs
@@ -146,6 +146,11 @@ public partial class View
             return true;
         }
 
+        if (!HasFocus && CanFocus)
+        {
+            SetFocus ();
+        }
+
         return args.Handled;
     }
 }

--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -30,7 +30,7 @@ public class Label : View
 
     private void Label_MouseClick (object sender, MouseEventEventArgs e)
     {
-        e.Handled = InvokeCommand (Command.Accept) == true;
+        e.Handled = InvokeCommand (Command.HotKey) == true;
     }
 
     private void Label_TitleChanged (object sender, StateEventArgs<string> e)

--- a/UnitTests/View/MouseTests.cs
+++ b/UnitTests/View/MouseTests.cs
@@ -4,21 +4,20 @@ namespace Terminal.Gui.ViewTests;
 
 public class MouseTests (ITestOutputHelper output)
 {
-
     [Theory]
-    [InlineData(false, false, false)]
+    [InlineData (false, false, false)]
     [InlineData (true, false, true)]
     [InlineData (true, true, true)]
     public void MouseClick_SetsFocus_If_CanFocus (bool canFocus, bool setFocus, bool expectedHasFocus)
     {
-        var superView = new View () { CanFocus = true, Height = 1, Width = 15 };
-        var focusedView = new View () { CanFocus = true, Width = 1, Height = 1 };
-        var testView = new View () { CanFocus = canFocus, X = 4, Width = 4, Height = 1 };
+        var superView = new View { CanFocus = true, Height = 1, Width = 15 };
+        var focusedView = new View { CanFocus = true, Width = 1, Height = 1 };
+        var testView = new View { CanFocus = canFocus, X = 4, Width = 4, Height = 1 };
         superView.Add (focusedView, testView);
         superView.BeginInit ();
-        superView.EndInit (); 
-        
-        focusedView.SetFocus();
+        superView.EndInit ();
+
+        focusedView.SetFocus ();
 
         Assert.True (superView.HasFocus);
         Assert.True (focusedView.HasFocus);
@@ -29,8 +28,10 @@ public class MouseTests (ITestOutputHelper output)
             testView.SetFocus ();
         }
 
-        testView.OnMouseEvent (new MouseEvent () { X = 0, Y = 0, Flags = MouseFlags.Button1Clicked });
+        testView.OnMouseEvent (new() { X = 0, Y = 0, Flags = MouseFlags.Button1Clicked });
         Assert.True (superView.HasFocus);
-        Assert.Equal(expectedHasFocus, testView.HasFocus);
+        Assert.Equal (expectedHasFocus, testView.HasFocus);
     }
+
+    // TODO: Add more tests that ensure the above test works with positive adornments
 }

--- a/UnitTests/View/MouseTests.cs
+++ b/UnitTests/View/MouseTests.cs
@@ -1,0 +1,36 @@
+﻿using Xunit.Abstractions;
+
+namespace Terminal.Gui.ViewTests;
+
+public class MouseTests (ITestOutputHelper output)
+{
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData (true, false, true)]
+    [InlineData (true, true, true)]
+    public void MouseClick_SetsFocus_If_CanFocus (bool canFocus, bool setFocus, bool expectedHasFocus)
+    {
+        var superView = new View () { CanFocus = true, Height = 1, Width = 15 };
+        var focusedView = new View () { CanFocus = true, Width = 1, Height = 1 };
+        var testView = new View () { CanFocus = canFocus, X = 4, Width = 4, Height = 1 };
+        superView.Add (focusedView, testView);
+        superView.BeginInit ();
+        superView.EndInit (); 
+        
+        focusedView.SetFocus();
+
+        Assert.True (superView.HasFocus);
+        Assert.True (focusedView.HasFocus);
+        Assert.False (testView.HasFocus);
+
+        if (setFocus)
+        {
+            testView.SetFocus ();
+        }
+
+        testView.OnMouseEvent (new MouseEvent () { X = 0, Y = 0, Flags = MouseFlags.Button1Clicked });
+        Assert.True (superView.HasFocus);
+        Assert.Equal(expectedHasFocus, testView.HasFocus);
+    }
+}

--- a/UnitTests/Views/LabelTests.cs
+++ b/UnitTests/Views/LabelTests.cs
@@ -51,6 +51,27 @@ public class LabelTests
         Assert.True (nextSubview.HasFocus);
     }
 
+
+    [Fact]
+    public void MouseClick_SetsFocus_OnNextSubview ()
+    {
+        var superView = new View () { CanFocus = true, Height = 1, Width = 15};
+        var focusedView = new View () { CanFocus = true, Width = 1, Height = 1 };
+        var label = new Label () { X = 2, Title = "_x" };
+        var nextSubview = new View () { CanFocus = true, X = 4, Width = 4, Height = 1 };
+        superView.Add (label, nextSubview);
+        superView.BeginInit ();
+        superView.EndInit ();
+
+        Assert.False (focusedView.HasFocus);
+        Assert.False (label.HasFocus);
+        Assert.False (nextSubview.HasFocus);
+
+        label.OnMouseEvent (new MouseEvent () { X = 0, Y = 0, Flags = MouseFlags.Button1Clicked });
+        Assert.False (label.HasFocus);
+        Assert.True (nextSubview.HasFocus);
+    }
+
     [Fact]
     public void HotKey_Command_Does_Not_Accept ()
     {

--- a/UnitTests/Views/LabelTests.cs
+++ b/UnitTests/Views/LabelTests.cs
@@ -59,7 +59,7 @@ public class LabelTests
         var focusedView = new View () { CanFocus = true, Width = 1, Height = 1 };
         var label = new Label () { X = 2, Title = "_x" };
         var nextSubview = new View () { CanFocus = true, X = 4, Width = 4, Height = 1 };
-        superView.Add (label, nextSubview);
+        superView.Add (focusedView, label, nextSubview);
         superView.BeginInit ();
         superView.EndInit ();
 


### PR DESCRIPTION
Label now uses Command.HotKey on MouseClick

## Fixes

- Fixes #3310

## Proposed Changes/Todos

- [x] Fix `View.OnMouseClick`
- [x] Fix `Label.MouseClick`
- [x] Add unit tests

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
