### PR TITLE
Fixes #3318. v1-MouseClick should be invoked only once on a mouse click.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -2894,9 +2894,14 @@ namespace Terminal.Gui {
 				return false;
 			}
 
-			var args = new MouseEventArgs (mouseEvent);
-			if (OnMouseClick (args))
-				return true;
+			if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Clicked) || mouseEvent.Flags.HasFlag (MouseFlags.Button2Clicked)
+				|| mouseEvent.Flags.HasFlag (MouseFlags.Button3Clicked) || mouseEvent.Flags.HasFlag (MouseFlags.Button4Clicked)) {
+
+				var args = new MouseEventArgs (mouseEvent);
+				if (OnMouseClick (args)) {
+					return true;
+				}
+			}
 			if (MouseEvent (mouseEvent))
 				return true;
 

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -2894,8 +2894,8 @@ namespace Terminal.Gui {
 				return false;
 			}
 
-			if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Clicked) || mouseEvent.Flags.HasFlag (MouseFlags.Button2Clicked)
-				|| mouseEvent.Flags.HasFlag (MouseFlags.Button3Clicked) || mouseEvent.Flags.HasFlag (MouseFlags.Button4Clicked)) {
+			if ((mouseEvent.Flags & MouseFlags.Button1Clicked) != 0 || (mouseEvent.Flags & MouseFlags.Button2Clicked) != 0
+				|| (mouseEvent.Flags & MouseFlags.Button3Clicked) != 0 || (mouseEvent.Flags & MouseFlags.Button4Clicked) != 0) {
 
 				var args = new MouseEventArgs (mouseEvent);
 				if (OnMouseClick (args)) {

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -4582,16 +4582,18 @@ Test", output);
 000000", new Attribute [] { Colors.TopLevel.Normal, Colors.TopLevel.Focus });
 		}
 
-		[Fact]
-		public void OnMouseClick_Is_Only_Raised_Once ()
+		[Theory]
+		[InlineData (MouseFlags.Button1Pressed, MouseFlags.Button1Released, MouseFlags.Button1Clicked)]
+		[InlineData (MouseFlags.Button1Pressed | MouseFlags.ButtonCtrl, MouseFlags.Button1Released | MouseFlags.ButtonCtrl, MouseFlags.Button1Clicked | MouseFlags.ButtonCtrl)]
+		public void OnMouseClick_Is_Only_Raised_Once (MouseFlags pressed, MouseFlags released, MouseFlags clicked)
 		{
 			var mouseClicks = 0;
 			var view = new View ();
 			view.MouseClick += (_) => mouseClicks++;
 
-			view.OnMouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Pressed });
-			view.OnMouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Released });
-			view.OnMouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Clicked });
+			view.OnMouseEvent (new MouseEvent () { Flags = pressed });
+			view.OnMouseEvent (new MouseEvent () { Flags = released });
+			view.OnMouseEvent (new MouseEvent () { Flags = clicked });
 
 			Assert.Equal (1, mouseClicks);
 		}

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -4583,7 +4583,7 @@ Test", output);
 		}
 
 		[Fact]
-		public void OnMouseClick_Is_Only_Fired_Once ()
+		public void OnMouseClick_Is_Only_Raised_Once ()
 		{
 			var mouseClicks = 0;
 			var view = new View ();

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -4581,5 +4581,19 @@ Test", output);
 011110
 000000", new Attribute [] { Colors.TopLevel.Normal, Colors.TopLevel.Focus });
 		}
+
+		[Fact]
+		public void OnMouseClick_Is_Only_Fired_Once ()
+		{
+			var mouseClicks = 0;
+			var view = new View ();
+			view.MouseClick += (_) => mouseClicks++;
+
+			view.OnMouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Pressed });
+			view.OnMouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Released });
+			view.OnMouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Clicked });
+
+			Assert.Equal (1, mouseClicks);
+		}
 	}
 }


### PR DESCRIPTION
## Fixes

- Fixes #3318

## Proposed Changes/Todos

- [x] Only consider clicked event of any button
- [x] Added unit test for proof

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
