### PR TITLE
Fixes #3317. v1-Listvew mouse event doesn't cause a SelectedItemChanged event to fire

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -875,7 +875,7 @@ namespace Terminal.Gui {
 		/// <inheritdoc/>
 		public void Render (ListView container, ConsoleDriver driver, bool marked, int item, int col, int line, int width, int start = 0)
 		{
-			var savedClip = container.ClipToBounds();
+			var savedClip = container.ClipToBounds ();
 			container.Move (col - start, line);
 			var t = src? [item];
 			if (t == null) {

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -802,8 +802,6 @@ namespace Terminal.Gui {
 			selected = top + me.Y;
 			if (AllowsAll ()) {
 				Source.SetMark (SelectedItem, !Source.IsMarked (SelectedItem));
-				SetNeedsDisplay ();
-				return true;
 			}
 			OnSelectedChanged ();
 			SetNeedsDisplay ();

--- a/UnitTests/Views/ListViewTests.cs
+++ b/UnitTests/Views/ListViewTests.cs
@@ -547,7 +547,7 @@ Item 6", output);
 		}
 
 		[Fact]
-		public void SelectedItemChanged_Event_Is_Also_Fired_With_AllowsMarking_True_By_Keyboard_Or_Mouse ()
+		public void SelectedItemChanged_Event_Is_Also_Raised_With_AllowsMarking_True_By_Keyboard_Or_Mouse ()
 		{
 			var itemChanged = 0;
 			var lv = new ListView (new List<string> () { "Item1", "Item2", "Item3" }) { Width = 5, Height = 3, AllowsMarking = true };

--- a/UnitTests/Views/ListViewTests.cs
+++ b/UnitTests/Views/ListViewTests.cs
@@ -545,5 +545,24 @@ Item 6", output);
  tem 3
  tem 4", output);
 		}
+
+		[Fact]
+		public void SelectedItemChanged_Event_Is_Also_Fired_With_AllowsMarking_True_By_Keyboard_Or_Mouse ()
+		{
+			var itemChanged = 0;
+			var lv = new ListView (new List<string> () { "Item1", "Item2", "Item3" }) { Width = 5, Height = 3, AllowsMarking = true };
+			lv.SelectedItemChanged += (e) => itemChanged = e.Item;
+
+			Assert.Equal (0, lv.SelectedItem);
+			Assert.Equal (lv.SelectedItem, itemChanged);
+
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers())));
+			Assert.Equal (1, lv.SelectedItem);
+			Assert.Equal (lv.SelectedItem, itemChanged);
+
+			Assert.True (lv.MouseEvent (new MouseEvent(){ X = 0, Y = 2, Flags = MouseFlags.Button1Clicked}));
+			Assert.Equal (2, lv.SelectedItem);
+			Assert.Equal (lv.SelectedItem, itemChanged);
+		}
 	}
 }


### PR DESCRIPTION
## Fixes

- Fixes #3317

## Proposed Changes/Todos

- [x] Also fire event if `AllowsMarking` is `true` on click
- [x] Added unit test for proof

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
