### PR TITLE
Fixes #3324. Width and Height are throwing before IsInitialized is true.

### DIFF
--- a/Terminal.Gui/View/Layout/ViewLayout.cs
+++ b/Terminal.Gui/View/Layout/ViewLayout.cs
@@ -219,7 +219,7 @@ public partial class View
         {
             _height = value ?? throw new ArgumentNullException (nameof (value), @$"{nameof (Height)} cannot be null");
 
-            if (AutoSize)
+            if (IsInitialized && AutoSize)
             {
                 throw new InvalidOperationException (@$"Must set AutoSize to false before setting {nameof (Height)}.");
             }
@@ -266,7 +266,7 @@ public partial class View
         {
             _width = value ?? throw new ArgumentNullException (nameof (value), @$"{nameof (Width)} cannot be null");
 
-            if (AutoSize)
+            if (IsInitialized && AutoSize)
             {
                 throw new InvalidOperationException (@$"Must set AutoSize to false before setting {nameof (Width)}.");
             }

--- a/Terminal.Gui/View/Layout/ViewLayout.cs
+++ b/Terminal.Gui/View/Layout/ViewLayout.cs
@@ -1226,7 +1226,7 @@ public partial class View
             SetNeedsDisplay ();
         }
 
-        if (AutoSize)
+        if (IsInitialized && AutoSize)
         {
             if (autosize.Width == 0 || autosize.Height == 0)
             {

--- a/UnitTests/Views/LabelTests.cs
+++ b/UnitTests/Views/LabelTests.cs
@@ -567,12 +567,14 @@ e
     }
 
     [Fact]
-    public void Setting_Width_Height_Before_Set_AutoSize_To_False_Do_Not_Throws ()
+    public void Constructor_Setting_Width_Height_Before_Set_AutoSize_To_False ()
     {
-        var exception = Record.Exception (() => new Label { Width = 10, AutoSize = false });
-        Assert.Null(exception);
+        var label = new Label { Width = 10, AutoSize = false };
+        Assert.Equal("Absolute(10)", label.Width.ToString());
+        Assert.False(label.AutoSize);
 
-        exception = Record.Exception (() => new Label { Height = 10, AutoSize = false });
-        Assert.Null(exception);
+        label = new Label { Height = 10, AutoSize = false };
+        Assert.Equal("Absolute(10)", label.Height.ToString());
+        Assert.False(label.AutoSize);
     }
 }

--- a/UnitTests/Views/LabelTests.cs
+++ b/UnitTests/Views/LabelTests.cs
@@ -566,4 +566,13 @@ e
                                                      );
     }
 
+    [Fact]
+    public void Setting_Width_Height_Before_Set_AutoSize_To_False_Do_Not_Throws ()
+    {
+        var exception = Record.Exception (() => new Label { Width = 10, AutoSize = false });
+        Assert.Null(exception);
+
+        exception = Record.Exception (() => new Label { Height = 10, AutoSize = false });
+        Assert.Null(exception);
+    }
 }

--- a/UnitTests/Views/LabelTests.cs
+++ b/UnitTests/Views/LabelTests.cs
@@ -55,7 +55,7 @@ public class LabelTests
     [Fact]
     public void MouseClick_SetsFocus_OnNextSubview ()
     {
-        var superView = new View () { CanFocus = true, Height = 1, Width = 15};
+        var superView = new View () { CanFocus = true, Height = 1, Width = 15 };
         var focusedView = new View () { CanFocus = true, Width = 1, Height = 1 };
         var label = new Label () { X = 2, Title = "_x" };
         var nextSubview = new View () { CanFocus = true, X = 4, Width = 4, Height = 1 };
@@ -567,14 +567,34 @@ e
     }
 
     [Fact]
-    public void Constructor_Setting_Width_Height_Before_Set_AutoSize_To_False ()
+    public void On_Object_Initializer_Setting_Width_Height_Before_Set_AutoSize_To_False ()
     {
-        var label = new Label { Width = 10, AutoSize = false };
-        Assert.Equal("Absolute(10)", label.Width.ToString());
-        Assert.False(label.AutoSize);
+        // Setting AutoSize to false
+        var label = new Label { Width = 10, Height = 10, AutoSize = false };
+        Assert.Equal ("Absolute(10)", label.Width.ToString ());
+        Assert.Equal ("Absolute(10)", label.Height.ToString ());
+        Assert.False (label.AutoSize);
+        label.BeginInit ();
+        label.EndInit ();
 
-        label = new Label { Height = 10, AutoSize = false };
-        Assert.Equal("Absolute(10)", label.Height.ToString());
-        Assert.False(label.AutoSize);
+        label.AutoSize = true;
+        Assert.Equal ("Absolute(0)", label.Width.ToString ());
+        Assert.Equal ("Absolute(0)", label.Height.ToString ());
+
+        Assert.Throws<InvalidOperationException> (() => label.Width = 10);
+        Assert.Throws<InvalidOperationException> (() => label.Height = 10);
+
+        // Without setting AutoSize to false
+        label = new () { Width = 10, Height = 10 };
+        Assert.Equal ("Absolute(10)", label.Width.ToString ());
+        Assert.Equal ("Absolute(10)", label.Height.ToString ());
+        Assert.True (label.AutoSize);
+        label.BeginInit ();
+        label.EndInit ();
+        Assert.Equal ("Absolute(0)", label.Width.ToString ());
+        Assert.Equal ("Absolute(0)", label.Height.ToString ());
+
+        Assert.Throws<InvalidOperationException> (() => label.Width = 10);
+        Assert.Throws<InvalidOperationException> (() => label.Height = 10);
     }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3324

## Proposed Changes/Todos

- [x] Check for IsInitialized before throwing.
- [x] Add unit test to proof

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
