### PR TITLE
Fixes #3326. Menu is responding even outside the limits, not moving to the view that has the mouse.

### DIFF
--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -714,7 +714,7 @@ internal sealed class Menu : View
 
     private void Application_RootMouseEvent (object sender, MouseEventEventArgs a)
     {
-        if (a.MouseEvent.View is MenuBar)
+        if (a.MouseEvent.View is { } and (MenuBar or not Menu))
         {
             return;
         }
@@ -724,17 +724,19 @@ internal sealed class Menu : View
             throw new InvalidOperationException ("This shouldn't running on a invisible menu!");
         }
 
-        Point boundsPoint = ScreenToBounds (a.MouseEvent.X, a.MouseEvent.Y);
+        View view = a.MouseEvent.View ?? this;
+
+        Point boundsPoint = view.ScreenToBounds (a.MouseEvent.X, a.MouseEvent.Y);
         var me = new MouseEvent
         {
             X = boundsPoint.X,
             Y = boundsPoint.Y,
             Flags = a.MouseEvent.Flags,
             ScreenPosition = new (a.MouseEvent.X, a.MouseEvent.Y),
-            View = this
+            View = view
         };
 
-        if (OnMouseEvent (me) || a.MouseEvent.Flags == MouseFlags.Button1Pressed || a.MouseEvent.Flags == MouseFlags.Button1Released)
+        if (view.OnMouseEvent (me) || a.MouseEvent.Flags == MouseFlags.Button1Pressed || a.MouseEvent.Flags == MouseFlags.Button1Released)
         {
             a.MouseEvent.Handled = true;
         }

--- a/UnitTests/Views/ContextMenuTests.cs
+++ b/UnitTests/Views/ContextMenuTests.cs
@@ -1306,9 +1306,10 @@ public class ContextMenuTests
                                                       _output
                                                      );
 
+        // X=5 is the border and so need to use at least one more
         Application.OnMouseEvent (
                                   new MouseEventEventArgs (
-                                                           new MouseEvent { X = 5, Y = 13, Flags = MouseFlags.Button1Clicked }
+                                                           new MouseEvent { X = 6, Y = 13, Flags = MouseFlags.Button1Clicked }
                                                           )
                                  );
 
@@ -1330,7 +1331,7 @@ public class ContextMenuTests
 
         Application.OnMouseEvent (
                                   new MouseEventEventArgs (
-                                                           new MouseEvent { X = 5, Y = 12, Flags = MouseFlags.Button1Clicked }
+                                                           new MouseEvent { X = 6, Y = 12, Flags = MouseFlags.Button1Clicked }
                                                           )
                                  );
 
@@ -1345,6 +1346,124 @@ public class ContextMenuTests
      │ Two   ►│
      │ Three  │
      └────────┘",
+                                                      _output
+                                                     );
+
+        Application.End (rs);
+    }
+
+        [Fact]
+    [AutoInitShutdown]
+    public void UseSubMenusSingleFrame_False_By_Mouse ()
+    {
+        var cm = new ContextMenu
+        {
+            Position = new Point (5, 10),
+            MenuItems = new MenuBarItem (
+                                         "Numbers",
+                                         [
+                                             new MenuItem ("One", "", null),
+                                             new MenuBarItem (
+                                                              "Two",
+                                                              [
+                                                                  new MenuItem (
+                                                                                "Two-Menu 1",
+                                                                                "",
+                                                                                null
+                                                                               ),
+                                                                  new MenuItem ("Two-Menu 2", "", null)
+                                                              ]
+                                                             ),
+                                             new MenuBarItem ("Three",
+                                                              [
+                                                                  new MenuItem (
+                                                                                "Three-Menu 1",
+                                                                                "",
+                                                                                null
+                                                                               ),
+                                                                  new MenuItem ("Three-Menu 2", "", null)
+                                                              ]
+                                                             )
+                                         ]
+                                        )
+        };
+
+        cm.Show ();
+        RunState rs = Application.Begin (Application.Top);
+
+        Assert.Equal (new Rectangle (5, 11, 10, 5), Application.Top.Subviews [0].Frame);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (
+                                                      @"
+     ┌────────┐
+     │ One    │
+     │ Two   ►│
+     │ Three ►│
+     └────────┘",
+                                                      _output
+                                                     );
+
+        Application.OnMouseEvent (
+                                  new MouseEventEventArgs (
+                                                           new MouseEvent { X = 6, Y = 13, Flags = MouseFlags.ReportMousePosition }
+                                                          )
+                                 );
+
+        var firstIteration = false;
+        Application.RunIteration (ref rs, ref firstIteration);
+        Assert.Equal (new Rectangle (5, 11, 10, 5), Application.Top.Subviews [0].Frame);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (
+                                                      @"
+     ┌────────┐               
+     │ One    │               
+     │ Two   ►│┌─────────────┐
+     │ Three ►││ Two-Menu 1  │
+     └────────┘│ Two-Menu 2  │
+               └─────────────┘",
+                                                      _output
+                                                     );
+
+        Application.OnMouseEvent (
+                                  new MouseEventEventArgs (
+                                                           new MouseEvent { X = 6, Y = 14, Flags = MouseFlags.ReportMousePosition }
+                                                          )
+                                 );
+
+        firstIteration = false;
+        Application.RunIteration (ref rs, ref firstIteration);
+        Assert.Equal (new Rectangle (5, 11, 10, 5), Application.Top.Subviews [0].Frame);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (
+                                                      @"
+     ┌────────┐                 
+     │ One    │                 
+     │ Two   ►│                 
+     │ Three ►│┌───────────────┐
+     └────────┘│ Three-Menu 1  │
+               │ Three-Menu 2  │
+               └───────────────┘",
+                                                      _output
+                                                     );
+
+        Application.OnMouseEvent (
+                                  new MouseEventEventArgs (
+                                                           new MouseEvent { X = 6, Y = 13, Flags = MouseFlags.ReportMousePosition }
+                                                          )
+                                 );
+
+        firstIteration = false;
+        Application.RunIteration (ref rs, ref firstIteration);
+        Assert.Equal (new Rectangle (5, 11, 10, 5), Application.Top.Subviews [0].Frame);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (
+                                                      @"
+     ┌────────┐               
+     │ One    │               
+     │ Two   ►│┌─────────────┐
+     │ Three ►││ Two-Menu 1  │
+     └────────┘│ Two-Menu 2  │
+               └─────────────┘",
                                                       _output
                                                      );
 

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -3661,7 +3661,7 @@ Edit
 
     [Fact]
     [AutoInitShutdown]
-    public void Click_Another_View_Close_A_Open_Menu ()
+    public void Click_Another_View_Close_An_Open_Menu ()
     {
         var menu = new MenuBar
         {

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -3658,4 +3658,26 @@ Edit
             Add (menu);
         }
     }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void Click_Another_View_Close_A_Open_Menu ()
+    {
+        var menu = new MenuBar
+        {
+            Menus =
+            [
+                new MenuBarItem ("File", new MenuItem [] { new ("New", "", null) })
+            ]
+        };
+
+        var btnClicked = false;
+        var btn = new Button { Y = 4, Text = "Test" };
+        btn.Accept += (s, e) => btnClicked = true;
+        Application.Top.Add (menu, btn);
+        Application.Begin (Application.Top);
+
+        Application.OnMouseEvent (new (new () { X = 0, Y = 4, Flags = MouseFlags.Button1Clicked }));
+        Assert.True (btnClicked);
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3326

## Proposed Changes/Todos

- [x] Ensure the Menu use the correct view passed on the event
- [x] Add more unit tests to Menu and ContextMenu to proof

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
