### PR TITLE
Fixes #3333. Application.UnGrabbedMouse event doesn't allow grab another view after exit.

### DIFF
--- a/Terminal.Gui/Application.cs
+++ b/Terminal.Gui/Application.cs
@@ -1305,8 +1305,9 @@ public static partial class Application
 
         if (!OnUnGrabbingMouse (MouseGrabView))
         {
-            OnUnGrabbedMouse (MouseGrabView);
+            var view = MouseGrabView;
             MouseGrabView = null;
+            OnUnGrabbedMouse (view);
         }
     }
 

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -149,6 +149,8 @@ public class ScrollView : View
                 if (supView == _contentView)
                 {
                     Application.GrabMouse (this);
+
+                    break;
                 }
 
                 supView = supView.SuperView;

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -78,6 +78,8 @@ public class ScrollView : View
         _contentView.MouseEnter += View_MouseEnter;
         _contentView.MouseLeave += View_MouseLeave;
 
+        Application.UnGrabbedMouse += Application_UnGrabbedMouse;
+
         // Things this view knows how to do
         AddCommand (Command.ScrollUp, () => ScrollUp (1));
         AddCommand (Command.ScrollDown, () => ScrollDown (1));
@@ -132,6 +134,16 @@ public class ScrollView : View
                            _vertical.ChangedPosition += delegate { ContentOffset = new Point (ContentOffset.X, _vertical.Position); };
                            _horizontal.ChangedPosition += delegate { ContentOffset = new Point (_horizontal.Position, ContentOffset.Y); };
                        };
+    }
+
+    private void Application_UnGrabbedMouse (object sender, ViewEventArgs e)
+    {
+        var parent = e.View is Adornment adornment ? adornment.Parent : e.View;
+
+        if (parent is { } && _contentView.Subviews.Contains (parent))
+        {
+            Application.GrabMouse (this);
+        }
     }
 
     /// <summary>If true the vertical/horizontal scroll bars won't be showed if it's not needed.</summary>
@@ -535,6 +547,8 @@ public class ScrollView : View
             // It was not added to SuperView, so it won't get disposed automatically
             _horizontal?.Dispose ();
         }
+
+        Application.UnGrabbedMouse -= Application_UnGrabbedMouse;
 
         base.Dispose (disposing);
     }

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -140,9 +140,19 @@ public class ScrollView : View
     {
         var parent = e.View is Adornment adornment ? adornment.Parent : e.View;
 
-        if (parent is { } && _contentView.Subviews.Contains (parent))
+        if (parent is { })
         {
-            Application.GrabMouse (this);
+            var supView = parent.SuperView;
+
+            while (supView is { })
+            {
+                if (supView == _contentView)
+                {
+                    Application.GrabMouse (this);
+                }
+
+                supView = supView.SuperView;
+            }
         }
     }
 
@@ -733,7 +743,7 @@ public class ScrollView : View
 
     private void View_MouseLeave (object sender, MouseEventEventArgs e)
     {
-        if (Application.MouseGrabView is { } && Application.MouseGrabView != _vertical && Application.MouseGrabView != _horizontal)
+        if (Application.MouseGrabView is { } && Application.MouseGrabView != this && Application.MouseGrabView != _vertical && Application.MouseGrabView != _horizontal)
         {
             Application.UngrabMouse ();
         }

--- a/UnitTests/Application/MouseTests.cs
+++ b/UnitTests/Application/MouseTests.cs
@@ -316,8 +316,9 @@ public class MouseTests
         View grabView = null;
         var count = 0;
 
-        var view1 = new View ();
-        var view2 = new View ();
+        var view1 = new View { Id = "view1" };
+        var view2 = new View { Id = "view2" };
+        var view3 = new View { Id = "view3" };
 
         Application.GrabbedMouse += Application_GrabbedMouse;
         Application.UnGrabbedMouse += Application_UnGrabbedMouse;
@@ -343,6 +344,8 @@ public class MouseTests
         Application.UngrabMouse ();
         Assert.Equal (2, count);
         Assert.Equal (grabView, view2);
+        Assert.Equal (view3, Application.MouseGrabView);
+        Application.UngrabMouse ();
         Assert.Null (Application.MouseGrabView);
 
         void Application_GrabbedMouse (object sender, ViewEventArgs e)
@@ -375,6 +378,12 @@ public class MouseTests
             }
 
             count++;
+
+            if (count > 1)
+            {
+                // It's possible to grab another view after the previous was ungrabbed
+                Application.GrabMouse (view3);
+            }
 
             Application.UnGrabbedMouse -= Application_UnGrabbedMouse;
         }

--- a/UnitTests/Views/ToplevelTests.cs
+++ b/UnitTests/Views/ToplevelTests.cs
@@ -1366,7 +1366,6 @@ public class ToplevelTests
         Assert.Equal (new (0, 0, 10, 5), view._needsDisplayRect);
     }
 
-    // BUGBUG: Broke this test with #2483 - @bdisp I need your help figuring out why
     [Fact]
     [AutoInitShutdown]
     public void Toplevel_Inside_ScrollView_MouseGrabView ()
@@ -1471,44 +1470,44 @@ public class ToplevelTests
         Assert.Equal (win.Border, Application.MouseGrabView);
         top.SetNeedsLayout ();
         top.LayoutSubviews ();
-        // BUGBUG: tig broke this in #3273
-   //     Assert.Equal (new Rectangle (2, 2, 195, 95), win.Frame);
-   //     Application.Refresh ();
+        Assert.Equal (new Rectangle (2, 2, 195, 95), win.Frame);
+        Application.Refresh ();
 
-   //     TestHelpers.AssertDriverContentsWithFrameAre (
-   //                                                   @"
-   //                                       ▲
-   //                                       ┬
-   //  ┌────────────────────────────────────│
-   //  │                                    ┴
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ░
-   //  │                                    ▼
-   //◄├──────┤░░░░░░░░░░░░░░░░░░░░░░░░░░░░░► ",
-   //                                                   _output
-   //                                                  );
+        TestHelpers.AssertDriverContentsWithFrameAre (
+                                                      @"
+                                          ▲
+                                          ┬
+     ┌────────────────────────────────────│
+     │                                    ┴
+     │                                    ░
+     │                                    ░
+     │                                    ░
+     │                                    ░
+     │                                    ░
+     │                                    ░
+     │                                    ░
+     │                                    ░
+     │                                    ░
+     │                                    ░
+     │                                    ▼
+   ◄├──────┤░░░░░░░░░░░░░░░░░░░░░░░░░░░░░► ",
+                                                      _output
+                                                     );
 
-   //     Application.OnMouseEvent (
-   //                               new MouseEventEventArgs (
-   //                                                        new MouseEvent { X = 5, Y = 5, Flags = MouseFlags.Button1Released }
-   //                                                       )
-   //                              );
-   //     Assert.Null (Application.MouseGrabView);
+        Application.OnMouseEvent (
+                                  new MouseEventEventArgs (
+                                                           new MouseEvent { X = 5, Y = 5, Flags = MouseFlags.Button1Released }
+                                                          )
+                                 );
+        // ScrollView always grab the mouse when the container's subview OnMouseEnter don't want grab the mouse
+        Assert.Equal (scrollView, Application.MouseGrabView);
 
-   //     Application.OnMouseEvent (
-   //                               new MouseEventEventArgs (
-   //                                                        new MouseEvent { X = 4, Y = 4, Flags = MouseFlags.ReportMousePosition }
-   //                                                       )
-   //                              );
-   //     Assert.Equal (scrollView, Application.MouseGrabView);
+        Application.OnMouseEvent (
+                                  new MouseEventEventArgs (
+                                                           new MouseEvent { X = 4, Y = 4, Flags = MouseFlags.ReportMousePosition }
+                                                          )
+                                 );
+        Assert.Equal (scrollView, Application.MouseGrabView);
     }
 
     [Fact]


### PR DESCRIPTION
## Fixes

- Fixes #3333

## Proposed Changes/Todos

- [x] Sets MouseGrabView to null before call the event
- [x] Change unit test to proof
- [x] ScrollView now grab the mouse if any view want to grab it

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
