### PR TITLE
Fixes #3332.  `ClearNeedsDisplay` needs to iterate through sub views

### DIFF
--- a/Terminal.Gui/View/ViewDrawing.cs
+++ b/Terminal.Gui/View/ViewDrawing.cs
@@ -546,10 +546,7 @@ public partial class View
     {
         SubViewNeedsDisplay = true;
 
-        if (_superView is { } && !_superView.SubViewNeedsDisplay)
-        {
-            _superView.SetSubViewNeedsDisplay ();
-        }
+        _superView?.SetSubViewNeedsDisplay ();
     }
 
     /// <summary>Clears <see cref="NeedsDisplay"/> and <see cref="SubViewNeedsDisplay"/>.</summary>

--- a/UICatalog/Scenarios/Clipping.cs
+++ b/UICatalog/Scenarios/Clipping.cs
@@ -32,7 +32,7 @@ public class Clipping : Scenario
         //scrollView.ShowVerticalScrollIndicator = true;
         //scrollView.ShowHorizontalScrollIndicator = true;
 
-        var embedded1 = new Window
+        var embedded1 = new View
         {
             Title = "1",
             X = 3,
@@ -40,22 +40,26 @@ public class Clipping : Scenario
             Width = Dim.Fill (3),
             Height = Dim.Fill (3),
             ColorScheme = Colors.ColorSchemes ["Dialog"],
-            Id = "1"
+            Id = "1",
+            BorderStyle = LineStyle.Rounded,
+            Arrangement = ViewArrangement.Movable
         };
 
-        var embedded2 = new Window
+        var embedded2 = new View
         {
-            Title = "1",
+            Title = "2",
             X = 3,
             Y = 3,
             Width = Dim.Fill (3),
             Height = Dim.Fill (3),
             ColorScheme = Colors.ColorSchemes ["Error"],
-            Id = "2"
+            Id = "2",
+            BorderStyle = LineStyle.Rounded,
+            Arrangement = ViewArrangement.Movable
         };
         embedded1.Add (embedded2);
 
-        var embedded3 = new Window
+        var embedded3 = new View
         {
             Title = "3",
             X = 3,
@@ -63,7 +67,9 @@ public class Clipping : Scenario
             Width = Dim.Fill (3),
             Height = Dim.Fill (3),
             ColorScheme = Colors.ColorSchemes ["TopLevel"],
-            Id = "3"
+            Id = "3",
+            BorderStyle = LineStyle.Rounded,
+            Arrangement = ViewArrangement.Movable
         };
 
         var testButton = new Button { X = 2, Y = 2, Text = "click me" };

--- a/UnitTests/View/NeedsDisplayTests.cs
+++ b/UnitTests/View/NeedsDisplayTests.cs
@@ -1,0 +1,51 @@
+#nullable enable
+using System.Text;
+using Xunit.Abstractions;
+
+namespace Terminal.Gui.ViewTests;
+
+[Trait("Category","Output")]
+public class NeedsDisplayTests (ITestOutputHelper output)
+{
+    [Fact]
+    public void NeedsDisplay_False_If_Width_Height_Zero ()
+    {
+        View view = new () { Width = 0, Height = 0};
+        view.BeginInit();
+        view.EndInit();
+        Assert.False (view.NeedsDisplay);
+        Assert.False (view.SubViewNeedsDisplay);
+    }
+
+
+    [Fact]
+    public void NeedsDisplay_True_Initially_If_Width_Height_Not_Zero ()
+    {
+        View superView = new () { Width = 1, Height = 1};
+        View view1 = new () { Width = 1, Height = 1 };
+        View view2 = new () { Width = 1, Height = 1 };
+
+        superView.Add(view1, view2);
+        superView.BeginInit ();
+        superView.EndInit ();
+
+        Assert.True (superView.NeedsDisplay);
+        Assert.True (superView.SubViewNeedsDisplay);
+        Assert.True (view1.NeedsDisplay);
+        Assert.True (view2.NeedsDisplay);
+
+        superView.Draw ();
+
+        Assert.False (superView.NeedsDisplay);
+        Assert.False (superView.SubViewNeedsDisplay);
+        Assert.False (view1.NeedsDisplay);
+        Assert.False (view2.NeedsDisplay);
+
+        superView.SetNeedsDisplay();
+
+        Assert.True (superView.NeedsDisplay);
+        Assert.True (superView.SubViewNeedsDisplay);
+        Assert.True (view1.NeedsDisplay);
+        Assert.True (view2.NeedsDisplay);
+    }
+}


### PR DESCRIPTION
## Fixes

- Fixes #3332 

## Proposed Changes/Todos

- [x] Figure out root cause: `SubviewNeedsDisplay` on `ContentView` was stuck at `true` preventing drawing of subviews
- [x] Fix root cause: `ClearNeedsDisplay` was not iterating through subviews
- [x] Add unit tests 

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [] I conducted basic QA to assure all features are working
