### PR TITLE
Fixes #3338. `Application.Run/End` -> Callers must dispose Toplevel

### DIFF
--- a/Terminal.Gui/FileServices/DefaultFileOperations.cs
+++ b/Terminal.Gui/FileServices/DefaultFileOperations.cs
@@ -162,6 +162,7 @@ public class DefaultFileOperations : IFileOperations
         dlg.AddButton (btnCancel);
 
         Application.Run (dlg);
+        dlg.Dispose ();
 
         result = tf.Text;
 

--- a/Terminal.Gui/Views/MessageBox.cs
+++ b/Terminal.Gui/Views/MessageBox.cs
@@ -468,6 +468,7 @@ public static class MessageBox
 
         // Run the modal; do not shutdown the mainloop driver when done
         Application.Run (d);
+        d.Dispose ();
 
         return Clicked;
     }

--- a/UICatalog/KeyBindingsDialog.cs
+++ b/UICatalog/KeyBindingsDialog.cs
@@ -82,6 +82,7 @@ internal class KeyBindingsDialog : Dialog
                            Application.RequestStop ();
                        };
         Application.Run (dlg);
+        dlg.Dispose ();
 
         if (key.HasValue)
         {

--- a/UICatalog/Scenarios/Adornments.cs
+++ b/UICatalog/Scenarios/Adornments.cs
@@ -120,6 +120,8 @@ public class Adornments : Scenario
         Application.Top.Closed += (s, e) => View.Diagnostics = _diagnosticFlags;
 
         Application.Run (editor);
+        editor.Dispose ();
+
         Application.Shutdown ();
     }
 

--- a/UICatalog/Scenarios/BackgroundWorkerCollection.cs
+++ b/UICatalog/Scenarios/BackgroundWorkerCollection.cs
@@ -13,12 +13,16 @@ namespace UICatalog.Scenarios;
 [ScenarioCategory ("Controls")]
 public class BackgroundWorkerCollection : Scenario
 {
-    public override void Run () { Application.Run<OverlappedMain> (); }
+    public override void Run ()
+    {
+        Application.Run<OverlappedMain> ();
+        Application.Top.Dispose ();
+    }
 
     private class OverlappedMain : Toplevel
     {
         private readonly MenuBar _menu;
-        private readonly WorkerApp _workerApp;
+        private WorkerApp _workerApp;
         private bool _canOpenWorkerApp;
 
         public OverlappedMain ()
@@ -93,8 +97,6 @@ public class BackgroundWorkerCollection : Scenario
             Activate += OverlappedMain_Activate;
             Deactivate += OverlappedMain_Deactivate;
 
-            Closed += OverlappedMain_Closed;
-
             Application.Iteration += (s, a) =>
                                      {
                                          if (_canOpenWorkerApp && !_workerApp.Running && Application.OverlappedTop.Running)
@@ -165,15 +167,15 @@ public class BackgroundWorkerCollection : Scenario
             return new MenuBarItem ("_Window", new List<MenuItem []> { menuItems.ToArray () });
         }
 
-        private void OverlappedMain_Activate (object sender, ToplevelEventArgs top) { _workerApp.WriteLog ($"{top.Toplevel.Data} activate."); }
-
-        private void OverlappedMain_Closed (object sender, ToplevelEventArgs e)
+        private void OverlappedMain_Activate (object sender, ToplevelEventArgs top)
         {
-            _workerApp.Dispose ();
-            Dispose ();
+            _workerApp?.WriteLog ($"{top.Toplevel.Data} activate.");
         }
 
-        private void OverlappedMain_Deactivate (object sender, ToplevelEventArgs top) { _workerApp.WriteLog ($"{top.Toplevel.Data} deactivate."); }
+        private void OverlappedMain_Deactivate (object sender, ToplevelEventArgs top)
+        {
+            _workerApp?.WriteLog ($"{top.Toplevel.Data} deactivate.");
+        }
         private void Quit () { RequestStop (); }
 
         private MenuBarItem View ()
@@ -207,6 +209,15 @@ public class BackgroundWorkerCollection : Scenario
                                     "_View",
                                     new List<MenuItem []> { menuItems.Count == 0 ? new MenuItem [] { } : menuItems.ToArray () }
                                    );
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose (bool disposing)
+        {
+            _workerApp?.Dispose ();
+            _workerApp = null;
+
+            base.Dispose (disposing);
         }
     }
 
@@ -299,7 +310,6 @@ public class BackgroundWorkerCollection : Scenario
 
         public Staging Staging { get; private set; }
         public event Action<StagingUIController> ReportClosed;
-        public void Run () { Application.Run (this); }
 
         private void OnReportClosed (object sender, EventArgs e)
         {
@@ -447,7 +457,8 @@ public class BackgroundWorkerCollection : Scenario
                                                  _stagingsUi.Add (stagingUI);
                                                  _stagingWorkers.Remove (staging);
 
-                                                 stagingUI.Run ();
+                                                 Application.Run (stagingUI);
+                                                 stagingUI.Dispose ();
                                              }
                                          };
 
@@ -465,8 +476,8 @@ public class BackgroundWorkerCollection : Scenario
 
                 _stagingWorkers.Add (staging, worker);
                 worker.RunWorkerAsync ();
-                stagingUI.Dispose ();
             }
+            stagingUI.Dispose ();
         }
 
         public void WriteLog (string msg)

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -898,6 +898,7 @@ internal class CharMap : ScrollView
                                    (s as Dialog)?.RequestStop ();
                                };
         Application.Run (waitIndicator);
+        waitIndicator.Dispose ();
 
         if (!string.IsNullOrEmpty (decResponse))
         {
@@ -1011,6 +1012,7 @@ internal class CharMap : ScrollView
             dlg.Add (json);
 
             Application.Run (dlg);
+            dlg.Dispose ();
         }
         else
         {

--- a/UICatalog/Scenarios/CsvEditor.cs
+++ b/UICatalog/Scenarios/CsvEditor.cs
@@ -316,6 +316,7 @@ public class CsvEditor : Scenario
         tf.SetFocus ();
 
         Application.Run (d);
+        d.Dispose ();
 
         enteredText = okPressed ? tf.Text : null;
 
@@ -455,6 +456,7 @@ public class CsvEditor : Scenario
         {
             Open (ofd.Path);
         }
+        ofd.Dispose ();
     }
 
     private void Open (string filename)

--- a/UICatalog/Scenarios/Dialogs.cs
+++ b/UICatalog/Scenarios/Dialogs.cs
@@ -192,6 +192,7 @@ public class Dialogs : Scenario
                                                                        buttonPressedLabel
                                                                       );
                                         Application.Run (dlg);
+                                        dlg.Dispose ();
                                     };
 
         Win.Add (showDialogButton);

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -417,9 +417,9 @@ public class DynamicMenuBar : Scenario
                 EditMenuBarItem (_menuItem);
             }
 
-            var _btnOk = new Button { IsDefault = true, Text = "Ok" };
+            var btnOk = new Button { IsDefault = true, Text = "Ok" };
 
-            _btnOk.Accept += (s, e) =>
+            btnOk.Accept += (s, e) =>
                               {
                                   if (string.IsNullOrEmpty (TextTitle.Text))
                                   {
@@ -431,21 +431,22 @@ public class DynamicMenuBar : Scenario
                                       Application.RequestStop ();
                                   }
                               };
-            var _btnCancel = new Button { Text = "Cancel" };
+            var btnCancel = new Button { Text = "Cancel" };
 
-            _btnCancel.Accept += (s, e) =>
+            btnCancel.Accept += (s, e) =>
                                   {
                                       TextTitle.Text = string.Empty;
                                       Application.RequestStop ();
                                   };
-            var _dialog = new Dialog { Title = "Enter the menu details.", Buttons = [_btnOk, _btnCancel] };
+            var dialog = new Dialog { Title = "Enter the menu details.", Buttons = [btnOk, btnCancel] };
 
             Width = Dim.Fill ();
             Height = Dim.Fill () - 1;
-            _dialog.Add (this);
+            dialog.Add (this);
             TextTitle.SetFocus ();
             TextTitle.CursorPosition = TextTitle.Text.Length;
-            Application.Run (_dialog);
+            Application.Run (dialog);
+            dialog.Dispose ();
 
             if (valid)
             {

--- a/UICatalog/Scenarios/DynamicStatusBar.cs
+++ b/UICatalog/Scenarios/DynamicStatusBar.cs
@@ -253,9 +253,9 @@ public class DynamicStatusBar : Scenario
                 EditStatusItem (_statusItem);
             }
 
-            var _btnOk = new Button { IsDefault = true, Text = "OK" };
+            var btnOk = new Button { IsDefault = true, Text = "OK" };
 
-            _btnOk.Accept += (s, e) =>
+            btnOk.Accept += (s, e) =>
                               {
                                   if (string.IsNullOrEmpty (TextTitle.Text))
                                   {
@@ -275,21 +275,22 @@ public class DynamicStatusBar : Scenario
                                       Application.RequestStop ();
                                   }
                               };
-            var _btnCancel = new Button { Text = "Cancel" };
+            var btnCancel = new Button { Text = "Cancel" };
 
-            _btnCancel.Accept += (s, e) =>
+            btnCancel.Accept += (s, e) =>
                                   {
                                       TextTitle.Text = string.Empty;
                                       Application.RequestStop ();
                                   };
-            var _dialog = new Dialog { Title = "Enter the menu details.", Buttons = [_btnOk, _btnCancel] };
+            var dialog = new Dialog { Title = "Enter the menu details.", Buttons = [btnOk, btnCancel] };
 
             Width = Dim.Fill ();
             Height = Dim.Fill () - 1;
-            _dialog.Add (this);
+            dialog.Add (this);
             TextTitle.SetFocus ();
             TextTitle.CursorPosition = TextTitle.Text.Length;
-            Application.Run (_dialog);
+            Application.Run (dialog);
+            dialog.Dispose ();
 
             return valid
                        ? new DynamicStatusItem

--- a/UICatalog/Scenarios/Editor.cs
+++ b/UICatalog/Scenarios/Editor.cs
@@ -1061,6 +1061,7 @@ public class Editor : Scenario
             _fileName = d.FilePaths [0];
             LoadFile ();
         }
+        d.Dispose ();
     }
 
     private void Paste ()
@@ -1259,12 +1260,16 @@ public class Editor : Scenario
         };
         var sd = new SaveDialog { Title = "Save file", AllowedTypes = aTypes };
 
-        sd.Path = Path.Combine (sd.FileName, Win.Title);
+        sd.Path = Win.Title;
         Application.Run (sd);
+        bool canceled = sd.Canceled;
+        string path = sd.Path;
+        string fileName = sd.FileName;
+        sd.Dispose ();
 
-        if (!sd.Canceled)
+        if (!canceled)
         {
-            if (File.Exists (sd.Path))
+            if (File.Exists (path))
             {
                 if (MessageBox.Query (
                                       "Save File",
@@ -1274,7 +1279,7 @@ public class Editor : Scenario
                                      )
                     == 1)
                 {
-                    return SaveFile (sd.FileName, sd.Path);
+                    return SaveFile (fileName, path);
                 }
 
                 _saved = false;
@@ -1282,7 +1287,7 @@ public class Editor : Scenario
                 return _saved;
             }
 
-            return SaveFile (sd.FileName, sd.Path);
+            return SaveFile (fileName, path);
         }
 
         _saved = false;

--- a/UICatalog/Scenarios/FileDialogExamples.cs
+++ b/UICatalog/Scenarios/FileDialogExamples.cs
@@ -228,6 +228,8 @@ public class FileDialogExamples : Scenario
                               "Ok"
                              );
         }
+
+        fd.Dispose ();
     }
 
     private void SetupHandler (Button btn)

--- a/UICatalog/Scenarios/HexEditor.cs
+++ b/UICatalog/Scenarios/HexEditor.cs
@@ -203,6 +203,7 @@ public class HexEditor : Scenario
             _hexView.Source = LoadFile ();
             _hexView.DisplayStart = 0;
         }
+        d.Dispose ();
     }
 
     private void Paste () { MessageBox.ErrorQuery ("Not Implemented", "Functionality not yet implemented.", "Ok"); }

--- a/UICatalog/Scenarios/Images.cs
+++ b/UICatalog/Scenarios/Images.cs
@@ -66,10 +66,13 @@ public class Images : Scenario
 
                                     if (ofd.Canceled)
                                     {
+                                        ofd.Dispose ();
                                         return;
                                     }
 
                                     string path = ofd.FilePaths [0];
+
+                                    ofd.Dispose ();
 
                                     if (string.IsNullOrWhiteSpace (path))
                                     {

--- a/UICatalog/Scenarios/InteractiveTree.cs
+++ b/UICatalog/Scenarios/InteractiveTree.cs
@@ -103,6 +103,7 @@ public class InteractiveTree : Scenario
         tf.SetFocus ();
 
         Application.Run (d);
+        d.Dispose ();
 
         enteredText = okPressed ? tf.Text : null;
 

--- a/UICatalog/Scenarios/ListColumns.cs
+++ b/UICatalog/Scenarios/ListColumns.cs
@@ -294,6 +294,7 @@ public class ListColumns : Scenario
         tf.SetFocus ();
 
         Application.Run (d);
+        d.Dispose ();
 
         if (accepted)
         {

--- a/UICatalog/Scenarios/Localization.cs
+++ b/UICatalog/Scenarios/Localization.cs
@@ -200,6 +200,7 @@ public class Localization : Scenario
         }
 
         Application.Run (dialog);
+        dialog.Dispose ();
     }
 
     public void ShowWizard ()
@@ -209,6 +210,7 @@ public class Localization : Scenario
         wizard.AddStep (new WizardStep { HelpText = "Wizard step 2", NextButtonText = ">>> (_N)" });
         wizard.AddStep (new WizardStep { HelpText = "Wizard last step" });
         Application.Run (wizard);
+        wizard.Dispose ();
     }
 
     private void LanguageComboBox_SelectChanged (object sender, ListViewItemEventArgs e)

--- a/UICatalog/Scenarios/MultiColouredTable.cs
+++ b/UICatalog/Scenarios/MultiColouredTable.cs
@@ -117,6 +117,7 @@ public class MultiColouredTable : Scenario
         tf.SetFocus ();
 
         Application.Run (d);
+        d.Dispose ();
 
         enteredText = okPressed ? tf.Text : null;
 

--- a/UICatalog/Scenarios/Notepad.cs
+++ b/UICatalog/Scenarios/Notepad.cs
@@ -56,11 +56,13 @@ public class Notepad : Scenario
 
         if (string.IsNullOrWhiteSpace (fd.Path))
         {
+            fd.Dispose ();
             return false;
         }
 
         if (fd.Canceled)
         {
+            fd.Dispose ();
             return false;
         }
 
@@ -68,6 +70,7 @@ public class Notepad : Scenario
         tab.Text = fd.FileName;
         tab.Save ();
 
+        fd.Dispose ();
         return true;
     }
 
@@ -248,19 +251,23 @@ public class Notepad : Scenario
 
         Application.Run (open);
 
-        if (!open.Canceled)
+        bool canceled = open.Canceled;
+
+        if (!canceled)
         {
             foreach (string path in open.FilePaths)
             {
                 if (string.IsNullOrEmpty (path) || !File.Exists (path))
                 {
-                    return;
+                    break;
                 }
 
                 // TODO should open in focused TabView
                 Open (new FileInfo (path), Path.GetFileName (path));
             }
         }
+
+        open.Dispose ();
     }
 
     /// <summary>Creates a new tab with initial text</summary>

--- a/UICatalog/Scenarios/ProgressBarStyles.cs
+++ b/UICatalog/Scenarios/ProgressBarStyles.cs
@@ -78,6 +78,7 @@ public class ProgressBarStyles : Scenario
             dialog.Add (colorPicker);
             colorPicker.ColorChanged += (s, e) => { dialog.RequestStop (); };
             Application.Run (dialog);
+            dialog.Dispose ();
 
             ColorName retColor = colorPicker.SelectedColor;
             colorPicker.Dispose ();
@@ -294,6 +295,7 @@ public class ProgressBarStyles : Scenario
         }
 
         Application.Run (editor);
+        editor.Dispose ();
         Application.Shutdown ();
     }
 

--- a/UICatalog/Scenarios/SingleBackgroundWorker.cs
+++ b/UICatalog/Scenarios/SingleBackgroundWorker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading;
 using Terminal.Gui;
 
@@ -77,9 +78,9 @@ public class SingleBackgroundWorker : Scenario
                                           );
             Add (statusBar);
 
-            var top = new Toplevel ();
+            var workerLogTop = new Toplevel () { Title = "Worker Log Top"};
 
-            top.Add (
+            workerLogTop.Add (
                      new Label { X = Pos.Center (), Y = 0, Text = "Worker Log" }
                     );
 
@@ -91,8 +92,9 @@ public class SingleBackgroundWorker : Scenario
                 Height = Dim.Fill (),
                 Source = new ListWrapper (_log)
             };
-            top.Add (_listLog);
-            Add (top);
+            workerLogTop.Add (_listLog);
+            Add (workerLogTop);
+            Title = "MainApp";
         }
 
         private void RunWorker ()
@@ -194,23 +196,30 @@ public class SingleBackgroundWorker : Scenario
                                                   var builderUI =
                                                       new StagingUIController (_startStaging, e.Result as List<string>);
                                                   builderUI.Load ();
+                                                  builderUI.Dispose ();
+
                                               }
 
                                               _worker = null;
                                           };
             _worker.RunWorkerAsync ();
             Application.Run (md);
+            md.Dispose ();
         }
     }
 
     public class StagingUIController : Window
     {
-        private readonly Toplevel _top;
+        private Toplevel _top;
 
         public StagingUIController (DateTime? start, List<string> list)
         {
             Rectangle frame = Application.Top.Frame;
-            _top = new Toplevel { X = frame.X, Y = frame.Y, Width = frame.Width, Height = frame.Height };
+            _top = new Toplevel
+            {
+                Title = "_top", 
+                X = frame.X, Y = frame.Y, Width = frame.Width, Height = frame.Height
+            };
 
             _top.KeyDown += (s, e) =>
                             {
@@ -299,6 +308,18 @@ public class SingleBackgroundWorker : Scenario
             _top.Add (this);
         }
 
-        public void Load () { Application.Run (_top); }
+        public void Load () {
+            Application.Run (_top);
+            _top.Dispose ();
+            _top = null;
+        }
+
+        ///// <inheritdoc />
+        //protected override void Dispose (bool disposing)
+        //{
+        //    _top?.Dispose ();
+        //    _top = null;
+        //    base.Dispose (disposing);
+        //}
     }
 }

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -886,6 +886,7 @@ public class TableEditor : Scenario
         tf.SetFocus ();
 
         Application.Run (d);
+        d.Dispose ();
 
         if (okPressed)
         {
@@ -1085,6 +1086,7 @@ public class TableEditor : Scenario
         tf.SetFocus ();
 
         Application.Run (d);
+        d.Dispose ();
 
         if (accepted)
         {

--- a/UICatalog/Scenarios/Wizards.cs
+++ b/UICatalog/Scenarios/Wizards.cs
@@ -349,6 +349,7 @@ public class Wizards : Scenario
                                                                                     };
 
                                             Application.Run (wizard);
+                                            wizard.Dispose ();
                                         }
                                         catch (FormatException)
                                         {

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -992,6 +992,7 @@ internal class UICatalogApp
                            {
                                var dlg = new KeyBindingsDialog ();
                                Application.Run (dlg);
+                               dlg.Dispose ();
                            };
 
             menuItems.Add (null!);

--- a/UnitTests/Dialogs/DialogTests.cs
+++ b/UnitTests/Dialogs/DialogTests.cs
@@ -1331,4 +1331,33 @@ public class DialogTests
 
         return (Begin (dlg), dlg);
     }
+
+    [Fact]
+    [SetupFakeDriver]
+    [TestRespondersDisposed]
+    public void Run_Does_Not_Dispose_Dialog ()
+    {
+        Init ();
+        Dialog dlg = new ();
+
+        dlg.Ready += Dlg_Ready;
+
+        Run (dlg);
+
+#if DEBUG_IDISPOSABLE
+        Assert.False (dlg.WasDisposed);
+#endif
+
+        dlg.Dispose ();
+
+        Shutdown();
+
+        return;
+
+        void Dlg_Ready (object sender, EventArgs e)
+        {
+            RequestStop ();
+        }
+    }
+
 }


### PR DESCRIPTION
Caused by #3300

## Fixes

- Fixes #3338 

## Proposed Changes/Todos

- [x] Find and fix all occurances of code not cleaning up the Toplevel used for `Run`

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
