### PR TITLE
Fixes #3340. Mouse ButtonShift doesn't work anymore on Windows Terminal.

### DIFF
--- a/Terminal.Gui/Input/Mouse.cs
+++ b/Terminal.Gui/Input/Mouse.cs
@@ -88,11 +88,11 @@ public enum MouseFlags
     /// <summary>Vertical button wheeled down.</summary>
     WheeledDown = 0x20000000,
 
-    /// <summary>Vertical button wheeled up while pressing ButtonShift.</summary>
-    WheeledLeft = ButtonShift | WheeledUp,
+    /// <summary>Vertical button wheeled up while pressing ButtonCtrl.</summary>
+    WheeledLeft = ButtonCtrl | WheeledUp,
 
-    /// <summary>Vertical button wheeled down while pressing ButtonShift.</summary>
-    WheeledRight = ButtonShift | WheeledDown,
+    /// <summary>Vertical button wheeled down while pressing ButtonCtrl.</summary>
+    WheeledRight = ButtonCtrl | WheeledDown,
 
     /// <summary>Mask that captures all the events.</summary>
     AllEvents = 0x7ffffff

--- a/UnitTests/View/MouseTests.cs
+++ b/UnitTests/View/MouseTests.cs
@@ -79,4 +79,17 @@ public class MouseTests (ITestOutputHelper output)
 
         Assert.Equal (expectedMoved, new Point (5, 5) == testView.Frame.Location);
     }
+
+    [Theory]
+    [InlineData (MouseFlags.WheeledUp | MouseFlags.ButtonCtrl, MouseFlags.WheeledLeft)]
+    [InlineData (MouseFlags.WheeledDown | MouseFlags.ButtonCtrl, MouseFlags.WheeledRight)]
+    public void WheeledLeft_WheeledRight (MouseFlags mouseFlags, MouseFlags expectedMouseFlagsFromEvent)
+    {
+        MouseFlags mouseFlagsFromEvent = MouseFlags.None;
+        var view = new View ();
+        view.MouseEvent += (s, e) => mouseFlagsFromEvent = e.MouseEvent.Flags;
+
+        view.OnMouseEvent (new MouseEvent () { Flags = mouseFlags });
+        Assert.Equal (mouseFlagsFromEvent, expectedMouseFlagsFromEvent);
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3340

## Proposed Changes/Todos

- [x] Change to the ButtonCtrl instead of the ButtonShift
- [x] Add unit test to proof

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

##Screenshots

https://github.com/gui-cs/Terminal.Gui/assets/13117724/74905d7f-3ce9-41b3-a317-37668e4435e8

The reason why ButtonShift doesn't work anymore on Windows Terminal is because it needed to use that button to disable the mouse from the CLI and use in the terminal to selecting text and it ignores the Win32 API that enable the CLI using that resources. But unfortunately I seeing even more theses procedures which make me question "Should I pay for a system that brakes certain features the users used and now they can't"