### PR TITLE
Fixes #3342. Why ViewMouse doesn't handle the movable procedure instead of the Adornment?

### DIFF
--- a/Terminal.Gui/Application.cs
+++ b/Terminal.Gui/Application.cs
@@ -179,7 +179,7 @@ public static partial class Application
     ///     <see cref="ConsoleDriver"/> to use. If neither <paramref name="driver"/> or <paramref name="driverName"/> are
     ///     specified the default driver for the platform will be used.
     /// </param>
-    public static void Init (ConsoleDriver driver = null, string driverName = null) { InternalInit (() => new Toplevel (), driver, driverName); }
+    public static void Init (ConsoleDriver driver = null, string driverName = null) { InternalInit (() => new Toplevel { Arrangement = ViewArrangement.Fixed }, driver, driverName); }
 
     internal static bool _initialized;
     internal static int _mainThreadId = -1;

--- a/Terminal.Gui/View/Adornment/Adornment.cs
+++ b/Terminal.Gui/View/Adornment/Adornment.cs
@@ -259,7 +259,7 @@ public class Adornment : View
 
         if (!Parent.CanFocus || !Parent.Arrangement.HasFlag (ViewArrangement.Movable))
         {
-            return true;
+            return false;
         }
 
         // BUGBUG: See https://github.com/gui-cs/Terminal.Gui/issues/3312
@@ -270,7 +270,8 @@ public class Adornment : View
 
             // Only start grabbing if the user clicks in the Thickness area
             // Adornment.Contains takes Parent SuperView=relative coords.
-            if (Contains (mouseEvent.X + Parent.Frame.X + Frame.X, mouseEvent.Y+ Parent.Frame.Y + Frame.Y))
+            if (mouseEvent.View is Adornment && Contains (mouseEvent.X + Parent.Frame.X + Frame.X, mouseEvent.Y + Parent.Frame.Y + Frame.Y)
+                || (mouseEvent.View == Parent && IsParentLocationOnTheBoundaries(Parent.Frame,  mouseEvent.X + Parent.Frame.X + Parent.GetBoundsOffset().X, mouseEvent.Y + Parent.Frame.Y + Parent.GetBoundsOffset().Y)))
             {
                 // Set the start grab point to the Frame coords
                 _startGrabPoint = new (mouseEvent.X + Frame.X, mouseEvent.Y + Frame.Y);
@@ -319,6 +320,21 @@ public class Adornment : View
         {
             _dragPosition = null;
             Application.UngrabMouse ();
+        }
+
+        return false;
+    }
+
+    private static bool IsParentLocationOnTheBoundaries (Rectangle rect, int x, int y)
+    {
+        if (x == rect.Left || x == rect.Right - 1)
+        {
+            return y >= rect.Top && y <= rect.Bottom;
+        }
+
+        if (y == rect.Top || y == rect.Bottom - 1)
+        {
+            return x >= rect.Left && x <= rect.Right;
         }
 
         return false;

--- a/Terminal.Gui/View/Adornment/Padding.cs
+++ b/Terminal.Gui/View/Adornment/Padding.cs
@@ -39,30 +39,29 @@ public class Padding : Adornment
         }
     }
 
-    /// <summary>Called when a mouse event occurs within the Padding.</summary>
-    /// <remarks>
-    /// <para>
-    /// The coordinates are relative to <see cref="View.Bounds"/>.
-    /// </para>
-    /// <para>
-    /// A mouse click on the Padding will cause the Parent to focus.
-    /// </para>
-    /// </remarks>
-    /// <param name="mouseEvent"></param>
-    /// <returns><see langword="true"/>, if the event was handled, <see langword="false"/> otherwise.</returns>
-    protected internal override bool OnMouseEvent (MouseEvent mouseEvent)
-    {
-        if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Clicked))
-        {
-            if (Parent.CanFocus && !Parent.HasFocus)
-            {
-                Parent.SetFocus ();
-                Parent.SetNeedsDisplay ();
-                return true;
-            }
-        }
+    ///// <summary>Called when a mouse event occurs within the Padding.</summary>
+    ///// <remarks>
+    ///// <para>
+    ///// The coordinates are relative to <see cref="View.Bounds"/>.
+    ///// </para>
+    ///// <para>
+    ///// A mouse click on the Padding will cause the Parent to focus.
+    ///// </para>
+    ///// </remarks>
+    ///// <param name="mouseEvent"></param>
+    ///// <returns><see langword="true"/>, if the event was handled, <see langword="false"/> otherwise.</returns>
+    //protected internal override bool OnMouseEvent (MouseEvent mouseEvent)
+    //{
+    //    if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Clicked))
+    //    {
+    //        if (Parent.CanFocus && !Parent.HasFocus)
+    //        {
+    //            Parent.SetFocus ();
+    //            Parent.SetNeedsDisplay ();
+    //            return true;
+    //        }
+    //    }
 
-        return false;
-    }
-
+    //    return false;
+    //}
 }

--- a/Terminal.Gui/View/ViewMouse.cs
+++ b/Terminal.Gui/View/ViewMouse.cs
@@ -133,7 +133,12 @@ public partial class View
 
         MouseEvent?.Invoke (this, args);
 
-        return args.Handled == true;
+        if (args.Handled)
+        {
+            return true;
+        }
+
+        return Margin?.OnMouseEvent (mouseEvent) == true;
     }
 
     /// <summary>Invokes the MouseClick event.</summary>

--- a/UICatalog/Scenarios/BackgroundWorkerCollection.cs
+++ b/UICatalog/Scenarios/BackgroundWorkerCollection.cs
@@ -27,6 +27,8 @@ public class BackgroundWorkerCollection : Scenario
 
             IsOverlappedContainer = true;
 
+            Arrangement = ViewArrangement.Fixed;
+
             _workerApp = new WorkerApp { Visible = false };
 
             _menu = new MenuBar
@@ -328,15 +330,15 @@ public class BackgroundWorkerCollection : Scenario
 
             ColorScheme = Colors.ColorSchemes ["Base"];
 
-            var label = new Label { X = Pos.Center (), Y = 0, Text = "Worker collection Log" };
+            var label = new Label { X = Pos.Center (), Y = 1, Text = "Worker collection Log" };
             Add (label);
 
             _listLog = new ListView
             {
-                X = 0,
+                X = 1,
                 Y = Pos.Bottom (label),
-                Width = Dim.Fill (),
-                Height = Dim.Fill (),
+                Width = Dim.Fill (1),
+                Height = Dim.Fill (1),
                 Source = new ListWrapper (_log)
             };
             Add (_listLog);

--- a/UnitTests/View/MouseTests.cs
+++ b/UnitTests/View/MouseTests.cs
@@ -37,20 +37,21 @@ public class MouseTests (ITestOutputHelper output)
     // Test drag to move
     [Theory]
     [InlineData (0, 0, 0, 0, false)]
-    [InlineData (0, 0, 0, 4, false)]
+    [InlineData (0, 0, 0, 4, true)]
     [InlineData (1, 0, 0, 4, true)]
     [InlineData (0, 1, 0, 4, true)]
-    [InlineData (0, 0, 1, 4, false)]
+    [InlineData (0, 0, 1, 4, true)]
 
     [InlineData (1, 1, 0, 3, false)]
     [InlineData (1, 1, 0, 4, true)]
     [InlineData (1, 1, 0, 5, true)]
     [InlineData (1, 1, 0, 6, false)]
 
-
     [InlineData (1, 1, 0, 11, false)]
     [InlineData (1, 1, 0, 12, true)]
+    [InlineData (0, 0, 0, 13, true)]
     [InlineData (1, 1, 0, 13, true)]
+    [InlineData (0, 0, 1, 13, true)]
     [InlineData (1, 1, 0, 14, false)]
     [AutoInitShutdown]
     public void ButtonPressed_In_Margin_Or_Border_Starts_Drag (int marginThickness, int borderThickness, int paddingThickness, int xy, bool expectedMoved)
@@ -73,10 +74,22 @@ public class MouseTests (ITestOutputHelper output)
         Assert.Equal (new Point (4, 4), testView.Frame.Location);
         Application.OnMouseEvent (new (new () { X = xy, Y = xy, Flags = MouseFlags.Button1Pressed }));
 
-        Assert.False (Application.MouseGrabView is { } && (Application.MouseGrabView != testView.Margin && Application.MouseGrabView != testView.Border));
+        if (expectedMoved)
+        {
+            Assert.False (Application.MouseGrabView is { } && (Application.MouseGrabView != testView.Margin && Application.MouseGrabView != testView.Border && Application.MouseGrabView != testView.Padding));
+        }
+        else
+        {
+            Assert.Null (Application.MouseGrabView);
+        }
 
         Application.OnMouseEvent (new (new () { X = xy + 1, Y = xy + 1, Flags = MouseFlags.Button1Pressed | MouseFlags.ReportMousePosition }));
 
         Assert.Equal (expectedMoved, new Point (5, 5) == testView.Frame.Location);
+
+        if (!expectedMoved)
+        {
+            Assert.Equal (new Point (4, 4), testView.Frame.Location);
+        }
     }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3342

## Proposed Changes/Todos

- [ ] View mouse also work without adornments.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working


https://github.com/gui-cs/Terminal.Gui/assets/13117724/7b5b123c-fb5e-4d62-8788-8e1b5c6bf5fa

