### PR TITLE
Fixes #3347. NetDriver throws System.OperationCanceledException: 'The operation was canceled.'

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -374,11 +374,11 @@ internal class NetEvents : IDisposable
                 return;
             }
 
-            _winChange.Wait (_inputReadyCancellationTokenSource.Token);
-            _winChange.Reset ();
-
             try
             {
+                _winChange.Wait (_inputReadyCancellationTokenSource.Token);
+                _winChange.Reset ();
+
                 RequestWindowSize (_inputReadyCancellationTokenSource.Token);
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
## Fixes

- Fixes #3347

## Proposed Changes/Todos

- [x] Moved the statement into the try keyword.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
