### PR TITLE
Fixes #3351 (V1). TabIndex with the same setter value but with wrong index return without set the correct value.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -282,7 +282,7 @@ namespace Terminal.Gui {
 				} else if (SuperView?.tabIndexes == null || SuperView?.tabIndexes.Count == 1) {
 					tabIndex = 0;
 					return;
-				} else if (tabIndex == value) {
+				} else if (tabIndex == value && TabIndexes.IndexOf (this) == value) {
 					return;
 				}
 				tabIndex = value > SuperView.tabIndexes.Count - 1 ? SuperView.tabIndexes.Count - 1 : value < 0 ? 0 : value;

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -394,6 +394,32 @@ namespace Terminal.Gui.ViewTests {
 		}
 
 		[Fact]
+		public void TabIndex_Invert_Order_Added_One_By_One_Does_Not_Do_What_Is_Expected ()
+		{
+			var r = new View ();
+			var v1 = new View () { Id = "1", CanFocus = true };
+			r.Add (v1);
+			v1.TabIndex = 2;
+			var v2 = new View () { Id = "2", CanFocus = true };
+			r.Add (v2);
+			v2.TabIndex = 1;
+			var v3 = new View () { Id = "3", CanFocus = true };
+			r.Add (v3);
+			v3.TabIndex = 0;
+
+			Assert.False (r.TabIndexes.IndexOf (v1) == 2);
+			Assert.True (r.TabIndexes.IndexOf (v1) == 1);
+			Assert.False (r.TabIndexes.IndexOf (v2) == 1);
+			Assert.True (r.TabIndexes.IndexOf (v2) == 2);
+			// Only the last is in the expected index
+			Assert.True (r.TabIndexes.IndexOf (v3) == 0);
+
+			Assert.True (r.Subviews.IndexOf (v1) == 0);
+			Assert.True (r.Subviews.IndexOf (v2) == 1);
+			Assert.True (r.Subviews.IndexOf (v3) == 2);
+		}
+
+		[Fact]
 		public void TabIndex_Invert_Order_Mixed ()
 		{
 			var r = new View ();

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -372,6 +372,53 @@ namespace Terminal.Gui.ViewTests {
 		}
 
 		[Fact]
+		public void TabIndex_Invert_Order ()
+		{
+			var r = new View ();
+			var v1 = new View () { Id = "1", CanFocus = true };
+			var v2 = new View () { Id = "2", CanFocus = true };
+			var v3 = new View () { Id = "3", CanFocus = true };
+
+			r.Add (v1, v2, v3);
+
+			v1.TabIndex = 2;
+			v2.TabIndex = 1;
+			v3.TabIndex = 0;
+			Assert.True (r.TabIndexes.IndexOf (v1) == 2);
+			Assert.True (r.TabIndexes.IndexOf (v2) == 1);
+			Assert.True (r.TabIndexes.IndexOf (v3) == 0);
+
+			Assert.True (r.Subviews.IndexOf (v1) == 0);
+			Assert.True (r.Subviews.IndexOf (v2) == 1);
+			Assert.True (r.Subviews.IndexOf (v3) == 2);
+		}
+
+		[Fact]
+		public void TabIndex_Invert_Order_Mixed ()
+		{
+			var r = new View ();
+			var vl1 = new View () { Id = "vl1" };
+			var v1 = new View () { Id = "v1", CanFocus = true };
+			var vl2 = new View () { Id = "vl2" };
+			var v2 = new View () { Id = "v2", CanFocus = true };
+			var vl3 = new View () { Id = "vl3" };
+			var v3 = new View () { Id = "v3", CanFocus = true };
+
+			r.Add (vl1, v1, vl2, v2, vl3, v3);
+
+			v1.TabIndex = 2;
+			v2.TabIndex = 1;
+			v3.TabIndex = 0;
+			Assert.True (r.TabIndexes.IndexOf (v1) == 4);
+			Assert.True (r.TabIndexes.IndexOf (v2) == 2);
+			Assert.True (r.TabIndexes.IndexOf (v3) == 0);
+
+			Assert.True (r.Subviews.IndexOf (v1) == 1);
+			Assert.True (r.Subviews.IndexOf (v2) == 3);
+			Assert.True (r.Subviews.IndexOf (v3) == 5);
+		}
+
+		[Fact]
 		public void TabStop_And_CanFocus_Are_All_True ()
 		{
 			var r = new View ();


### PR DESCRIPTION
## Fixes

- Fixes #3351

## Proposed Changes/Todos

- [x] Check if the index also belong to the view.
- [x] Add unit test to proof

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
