### PR TITLE
Fixes #3351. TabIndex with the same setter value but with wrong index return without set the correct value.

### DIFF
--- a/Terminal.Gui/View/ViewKeyboard.cs
+++ b/Terminal.Gui/View/ViewKeyboard.cs
@@ -267,7 +267,7 @@ public partial class View
                 return;
             }
 
-            if (_tabIndex == value)
+            if (_tabIndex == value && TabIndexes.IndexOf (this) == value)
             {
                 return;
             }

--- a/UnitTests/View/NavigationTests.cs
+++ b/UnitTests/View/NavigationTests.cs
@@ -1303,13 +1303,39 @@ public class NavigationTests
         v1.TabIndex = 2;
         v2.TabIndex = 1;
         v3.TabIndex = 0;
-        Assert.True (r.TabIndexes.IndexOf (v1) == 2);
-        Assert.True (r.TabIndexes.IndexOf (v2) == 1);
-        Assert.True (r.TabIndexes.IndexOf (v3) == 0);
+        Assert.Equal (2, r.TabIndexes.IndexOf (v1));
+        Assert.Equal (1, r.TabIndexes.IndexOf (v2));
+        Assert.Equal (0, r.TabIndexes.IndexOf (v3));
 
-        Assert.True (r.Subviews.IndexOf (v1) == 0);
-        Assert.True (r.Subviews.IndexOf (v2) == 1);
-        Assert.True (r.Subviews.IndexOf (v3) == 2);
+        Assert.Equal (0, r.Subviews.IndexOf (v1));
+        Assert.Equal (1, r.Subviews.IndexOf (v2));
+        Assert.Equal (2, r.Subviews.IndexOf (v3));
+    }
+
+    [Fact]
+    public void TabIndex_Invert_Order_Added_One_By_One_Does_Not_Do_What_Is_Expected ()
+    {
+        var r = new View ();
+        var v1 = new View () { Id = "1", CanFocus = true };
+        r.Add (v1);
+        v1.TabIndex = 2;
+        var v2 = new View () { Id = "2", CanFocus = true };
+        r.Add (v2);
+        v2.TabIndex = 1;
+        var v3 = new View () { Id = "3", CanFocus = true };
+        r.Add (v3);
+        v3.TabIndex = 0;
+
+        Assert.NotEqual (2, r.TabIndexes.IndexOf (v1));
+        Assert.Equal (1, r.TabIndexes.IndexOf (v1));
+        Assert.NotEqual (1, r.TabIndexes.IndexOf (v2));
+        Assert.Equal (2, r.TabIndexes.IndexOf (v2));
+        // Only the last is in the expected index
+        Assert.Equal (0, r.TabIndexes.IndexOf (v3));
+
+        Assert.Equal (0, r.Subviews.IndexOf (v1));
+        Assert.Equal (1, r.Subviews.IndexOf (v2));
+        Assert.Equal (2, r.Subviews.IndexOf (v3));
     }
 
     [Fact]
@@ -1328,13 +1354,13 @@ public class NavigationTests
         v1.TabIndex = 2;
         v2.TabIndex = 1;
         v3.TabIndex = 0;
-        Assert.True (r.TabIndexes.IndexOf (v1) == 4);
-        Assert.True (r.TabIndexes.IndexOf (v2) == 2);
-        Assert.True (r.TabIndexes.IndexOf (v3) == 0);
+        Assert.Equal (4, r.TabIndexes.IndexOf (v1));
+        Assert.Equal (2, r.TabIndexes.IndexOf (v2));
+        Assert.Equal (0, r.TabIndexes.IndexOf (v3));
 
-        Assert.True (r.Subviews.IndexOf (v1) == 1);
-        Assert.True (r.Subviews.IndexOf (v2) == 3);
-        Assert.True (r.Subviews.IndexOf (v3) == 5);
+        Assert.Equal (1, r.Subviews.IndexOf (v1));
+        Assert.Equal (3, r.Subviews.IndexOf (v2));
+        Assert.Equal (5, r.Subviews.IndexOf (v3));
     }
 
     [Fact]

--- a/UnitTests/View/NavigationTests.cs
+++ b/UnitTests/View/NavigationTests.cs
@@ -1303,39 +1303,13 @@ public class NavigationTests
         v1.TabIndex = 2;
         v2.TabIndex = 1;
         v3.TabIndex = 0;
-        Assert.Equal (2, r.TabIndexes.IndexOf (v1));
-        Assert.Equal (1, r.TabIndexes.IndexOf (v2));
-        Assert.Equal (0, r.TabIndexes.IndexOf (v3));
+        Assert.True (r.TabIndexes.IndexOf (v1) == 2);
+        Assert.True (r.TabIndexes.IndexOf (v2) == 1);
+        Assert.True (r.TabIndexes.IndexOf (v3) == 0);
 
-        Assert.Equal (0, r.Subviews.IndexOf (v1));
-        Assert.Equal (1, r.Subviews.IndexOf (v2));
-        Assert.Equal (2, r.Subviews.IndexOf (v3));
-    }
-
-    [Fact]
-    public void TabIndex_Invert_Order_Added_One_By_One_Does_Not_Do_What_Is_Expected ()
-    {
-        var r = new View ();
-        var v1 = new View () { Id = "1", CanFocus = true };
-        r.Add (v1);
-        v1.TabIndex = 2;
-        var v2 = new View () { Id = "2", CanFocus = true };
-        r.Add (v2);
-        v2.TabIndex = 1;
-        var v3 = new View () { Id = "3", CanFocus = true };
-        r.Add (v3);
-        v3.TabIndex = 0;
-
-        Assert.NotEqual (2, r.TabIndexes.IndexOf (v1));
-        Assert.Equal (1, r.TabIndexes.IndexOf (v1));
-        Assert.NotEqual (1, r.TabIndexes.IndexOf (v2));
-        Assert.Equal (2, r.TabIndexes.IndexOf (v2));
-        // Only the last is in the expected index
-        Assert.Equal (0, r.TabIndexes.IndexOf (v3));
-
-        Assert.Equal (0, r.Subviews.IndexOf (v1));
-        Assert.Equal (1, r.Subviews.IndexOf (v2));
-        Assert.Equal (2, r.Subviews.IndexOf (v3));
+        Assert.True (r.Subviews.IndexOf (v1) == 0);
+        Assert.True (r.Subviews.IndexOf (v2) == 1);
+        Assert.True (r.Subviews.IndexOf (v3) == 2);
     }
 
     [Fact]
@@ -1354,13 +1328,13 @@ public class NavigationTests
         v1.TabIndex = 2;
         v2.TabIndex = 1;
         v3.TabIndex = 0;
-        Assert.Equal (4, r.TabIndexes.IndexOf (v1));
-        Assert.Equal (2, r.TabIndexes.IndexOf (v2));
-        Assert.Equal (0, r.TabIndexes.IndexOf (v3));
+        Assert.True (r.TabIndexes.IndexOf (v1) == 4);
+        Assert.True (r.TabIndexes.IndexOf (v2) == 2);
+        Assert.True (r.TabIndexes.IndexOf (v3) == 0);
 
-        Assert.Equal (1, r.Subviews.IndexOf (v1));
-        Assert.Equal (3, r.Subviews.IndexOf (v2));
-        Assert.Equal (5, r.Subviews.IndexOf (v3));
+        Assert.True (r.Subviews.IndexOf (v1) == 1);
+        Assert.True (r.Subviews.IndexOf (v2) == 3);
+        Assert.True (r.Subviews.IndexOf (v3) == 5);
     }
 
     [Fact]

--- a/UnitTests/View/NavigationTests.cs
+++ b/UnitTests/View/NavigationTests.cs
@@ -1291,6 +1291,53 @@ public class NavigationTests
     }
 
     [Fact]
+    public void TabIndex_Invert_Order ()
+    {
+        var r = new View ();
+        var v1 = new View () { Id = "1", CanFocus = true };
+        var v2 = new View () { Id = "2", CanFocus = true };
+        var v3 = new View () { Id = "3", CanFocus = true };
+
+        r.Add (v1, v2, v3);
+
+        v1.TabIndex = 2;
+        v2.TabIndex = 1;
+        v3.TabIndex = 0;
+        Assert.True (r.TabIndexes.IndexOf (v1) == 2);
+        Assert.True (r.TabIndexes.IndexOf (v2) == 1);
+        Assert.True (r.TabIndexes.IndexOf (v3) == 0);
+
+        Assert.True (r.Subviews.IndexOf (v1) == 0);
+        Assert.True (r.Subviews.IndexOf (v2) == 1);
+        Assert.True (r.Subviews.IndexOf (v3) == 2);
+    }
+
+    [Fact]
+    public void TabIndex_Invert_Order_Mixed ()
+    {
+        var r = new View ();
+        var vl1 = new View () { Id = "vl1" };
+        var v1 = new View () { Id = "v1", CanFocus = true };
+        var vl2 = new View () { Id = "vl2" };
+        var v2 = new View () { Id = "v2", CanFocus = true };
+        var vl3 = new View () { Id = "vl3" };
+        var v3 = new View () { Id = "v3", CanFocus = true };
+
+        r.Add (vl1, v1, vl2, v2, vl3, v3);
+
+        v1.TabIndex = 2;
+        v2.TabIndex = 1;
+        v3.TabIndex = 0;
+        Assert.True (r.TabIndexes.IndexOf (v1) == 4);
+        Assert.True (r.TabIndexes.IndexOf (v2) == 2);
+        Assert.True (r.TabIndexes.IndexOf (v3) == 0);
+
+        Assert.True (r.Subviews.IndexOf (v1) == 1);
+        Assert.True (r.Subviews.IndexOf (v2) == 3);
+        Assert.True (r.Subviews.IndexOf (v3) == 5);
+    }
+
+    [Fact]
     public void TabStop_All_False_And_All_True_And_Changing_TabStop_Later ()
     {
         var r = new View ();

--- a/UnitTests/View/NavigationTests.cs
+++ b/UnitTests/View/NavigationTests.cs
@@ -1313,6 +1313,32 @@ public class NavigationTests
     }
 
     [Fact]
+    public void TabIndex_Invert_Order_Added_One_By_One_Does_Not_Do_What_Is_Expected ()
+    {
+        var r = new View ();
+        var v1 = new View () { Id = "1", CanFocus = true };
+        r.Add (v1);
+        v1.TabIndex = 2;
+        var v2 = new View () { Id = "2", CanFocus = true };
+        r.Add (v2);
+        v2.TabIndex = 1;
+        var v3 = new View () { Id = "3", CanFocus = true };
+        r.Add (v3);
+        v3.TabIndex = 0;
+
+        Assert.False (r.TabIndexes.IndexOf (v1) == 2);
+        Assert.True (r.TabIndexes.IndexOf (v1) == 1);
+        Assert.False (r.TabIndexes.IndexOf (v2) == 1);
+        Assert.True (r.TabIndexes.IndexOf (v2) == 2);
+        // Only the last is in the expected index
+        Assert.True (r.TabIndexes.IndexOf (v3) == 0);
+
+        Assert.True (r.Subviews.IndexOf (v1) == 0);
+        Assert.True (r.Subviews.IndexOf (v2) == 1);
+        Assert.True (r.Subviews.IndexOf (v3) == 2);
+    }
+
+    [Fact]
     public void TabIndex_Invert_Order_Mixed ()
     {
         var r = new View ();


### PR DESCRIPTION
## Fixes

- Fixes #3351

## Proposed Changes/Todos

- [x] Check if the index also belong to the view.
- [x] Add unit test to proof

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
