### PR TITLE
Fixes #3356. SetupFakeDriver isn't disposing Application.Top if Application.Begin was called.

### DIFF
--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -1088,4 +1088,48 @@ public class ApplicationTests
     }
 
     #endregion
+
+    [Fact]
+    [AutoInitShutdown]
+    public void AutoInitShutdown_Dispose_Application_Top ()
+    {
+        // This unit test is for test the SetupFakeDriver_Also_Dispose_Application_Top
+        // unit test. Right-click ApplicationTests on the TestExplorer and Run or Debug
+        // Commenting Application.Top?.Dispose (); on the SetupFakeDriverAttribute some
+        // of ApplicationTests unit tests will fail
+        var view = new View ();
+        var top = new Toplevel ();
+        top.Add (view);
+        Application.Begin (top);
+
+        Assert.NotNull (Application.Top);
+#if DEBUG_IDISPOSABLE
+        Assert.False (Application.Top.WasDisposed);
+#endif
+    }
+
+    [Fact]
+    [SetupFakeDriver]
+    public void SetupFakeDriver_Also_Dispose_Application_Top ()
+    {
+        // This unit test is for test the SetupFakeDriver_Also_Dispose_Application_Top
+        // unit test. Right-click ApplicationTests on the TestExplorer and Run or Debug
+        // Commenting Application.Top?.Dispose (); on the SetupFakeDriverAttribute some
+        // of ApplicationTests unit tests will fail
+        var exception = Record.Exception (
+                                          () =>
+                                          {
+                                              var view = new View ();
+                                              var top = new Toplevel ();
+                                              top.Add (view);
+                                              Application.Begin (top);
+
+                                              Assert.NotNull (Application.Top);
+#if DEBUG_IDISPOSABLE
+                                              Assert.False (Application.Top.WasDisposed);
+#endif
+                                          });
+
+        Assert.Null (exception);
+    }
 }

--- a/UnitTests/TestHelpers.cs
+++ b/UnitTests/TestHelpers.cs
@@ -154,6 +154,9 @@ public class SetupFakeDriverAttribute : BeforeAfterTestAttribute
         // Turn off diagnostic flags in case some test left them on
         View.Diagnostics = ViewDiagnosticFlags.Off;
 
+        // Dispose Application.Top if Application.Begin was called
+        Application.Top?.Dispose ();
+
         Application.Driver = null;
     }
 


### PR DESCRIPTION
## Fixes

- Fixes #3356

## Proposed Changes/Todos

- [x] Add dispose on the After method
- [x] Add unit test to proof

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
