### PR TITLE
Make terminal gui internal methods visible to TGD

### DIFF
--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -65,6 +65,7 @@
   <!-- =================================================================== -->
   <ItemGroup>
     <InternalsVisibleTo Include="UnitTests" />
+    <InternalsVisibleTo Include="TerminalGuiDesigner" />
   </ItemGroup>
   <!-- =================================================================== -->
   <!-- API Documentation -->


### PR DESCRIPTION
## Proposed Changes/Todos

Makes internal methods visible to TGD e.g. `FindDeepestView`

There are many cases where TGD is using reflection to call inaccessible members e.g. Pos types.  This was fine during v1 where things were relativly stable but v2 changes constantly.  Directly referencing the methods will make it much easier to handle upgrades as v2 continues development.
