### PR TITLE
Fixes #3362. SetRelativeLayout doesn't handled with positive/negative location offset.

### DIFF
--- a/Terminal.Gui/View/Layout/ViewLayout.cs
+++ b/Terminal.Gui/View/Layout/ViewLayout.cs
@@ -1194,6 +1194,15 @@ public partial class View
                                              0
                                             );
 
+                    if (dim is Dim.DimFill || pos is Pos.PosFunc)
+                    {
+                        newDimension = Math.Max (Math.Min (newDimension, superviewDimension - newLocation + superviewLocation), 0);
+                    }
+
+                    if (pos is Pos.PosFunc)
+                    {
+                        newLocation = Math.Max (newLocation, superviewLocation);
+                    }
                     break;
             }
 

--- a/Terminal.Gui/View/Layout/ViewLayout.cs
+++ b/Terminal.Gui/View/Layout/ViewLayout.cs
@@ -925,7 +925,7 @@ public partial class View
 
         foreach (View v in ordered)
         {
-            LayoutSubview (v, new (GetBoundsOffset (), Bounds.Size));
+            LayoutSubview (v, new (Point.Empty, Bounds.Size));
         }
 
         // If the 'to' is rooted to 'from' and the layoutstyle is Computed it's a special-case.
@@ -1116,6 +1116,7 @@ public partial class View
 
             int newDimension, newLocation;
             int superviewDimension = width ? superviewBounds.Width : superviewBounds.Height;
+            int superviewLocation = width ? superviewBounds.X : superviewBounds.Y;
 
             // Determine new location
             switch (pos)
@@ -1124,7 +1125,7 @@ public partial class View
                     // For Center, the dimension is dependent on location, but we need to force getting the dimension first
                     // using a location of 0
                     newDimension = Math.Max (GetNewDimension (dim, 0, superviewDimension, autosizeDimension), 0);
-                    newLocation = posCenter.Anchor (superviewDimension - newDimension);
+                    newLocation = posCenter.Anchor (superviewDimension - newDimension) + superviewLocation;
 
                     newDimension = Math.Max (
                                              GetNewDimension (dim, newLocation, superviewDimension, autosizeDimension),
@@ -1175,7 +1176,7 @@ public partial class View
                 case Pos.PosFunc:
                 case Pos.PosView:
                 default:
-                    newLocation = pos?.Anchor (superviewDimension) ?? 0;
+                    newLocation = (pos?.Anchor (superviewDimension) ?? 0) + superviewLocation;
 
                     newDimension = Math.Max (
                                              GetNewDimension (dim, newLocation, superviewDimension, autosizeDimension),
@@ -1202,15 +1203,15 @@ public partial class View
             // the view LayoutStyle.Absolute.
             _frame = r;
 
-            if (_x is Pos.PosAbsolute)
-            {
-                _x = Frame.X;
-            }
+            //if (_x is Pos.PosAbsolute)
+            //{
+            //    _x = Frame.X;
+            //}
 
-            if (_y is Pos.PosAbsolute)
-            {
-                _y = Frame.Y;
-            }
+            //if (_y is Pos.PosAbsolute)
+            //{
+            //    _y = Frame.Y;
+            //}
 
             if (_width is Dim.DimAbsolute)
             {

--- a/Terminal.Gui/View/Layout/ViewLayout.cs
+++ b/Terminal.Gui/View/Layout/ViewLayout.cs
@@ -1056,7 +1056,8 @@ public partial class View
             Rectangle superviewBounds,
             Pos pos,
             Dim dim,
-            int autosizeDimension
+            int autosizeDimension,
+            bool useSuperviewBoundsLocation = true
         )
         {
             // Gets the new dimension (width or height, dependent on `width`) of the given Dim given:
@@ -1116,7 +1117,7 @@ public partial class View
 
             int newDimension, newLocation;
             int superviewDimension = width ? superviewBounds.Width : superviewBounds.Height;
-            int superviewLocation = width ? superviewBounds.X : superviewBounds.Y;
+            int superviewLocation = useSuperviewBoundsLocation ? width ? superviewBounds.X : superviewBounds.Y : 0;
 
             // Determine new location
             switch (pos)
@@ -1151,7 +1152,8 @@ public partial class View
                                                                         superviewBounds,
                                                                         combine._right,
                                                                         dim,
-                                                                        autosizeDimension
+                                                                        autosizeDimension,
+                                                                        false
                                                                        );
 
                     if (combine._add)
@@ -1170,11 +1172,20 @@ public partial class View
 
                     break;
 
+                case Pos.PosView:
+                    newLocation = (pos?.Anchor (superviewDimension) ?? 0);
+
+                    newDimension = Math.Max (
+                                             GetNewDimension (dim, newLocation, superviewDimension, autosizeDimension),
+                                             0
+                                            );
+
+                    break;
+
                 case Pos.PosAnchorEnd:
                 case Pos.PosAbsolute:
                 case Pos.PosFactor:
                 case Pos.PosFunc:
-                case Pos.PosView:
                 default:
                     newLocation = (pos?.Anchor (superviewDimension) ?? 0) + superviewLocation;
 

--- a/UnitTests/View/Layout/SetRelativeLayoutTests.cs
+++ b/UnitTests/View/Layout/SetRelativeLayoutTests.cs
@@ -557,4 +557,47 @@ public class SetRelativeLayoutTests
         Assert.Equal (3, view.Frame.Width);
         Assert.Equal (3, view.Frame.Height);
     }
+
+    [Theory]
+    [InlineData (0, 0, 7, 7, 3, 3)]
+    [InlineData (-1, -1, 6, 6, 3, 3)]
+    [InlineData (1, 1, 8, 8, 2, 2)]
+    [InlineData (3, 3, 10, 10, 0, 0)]
+    [InlineData (-3, -3, 4, 4, 3, 3)]
+    [InlineData (-20, -20, -13, -13, 3, 3)]
+    public void AnchorEnd_X_Same_As_Y_DimFill_Width_Same_As_Height (int x, int y, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view = new View { X = Pos.AnchorEnd (3), Y = Pos.AnchorEnd (3), Width = Dim.Fill (), Height = Dim.Fill () };
+        view.BeginInit ();
+        view.EndInit ();
+        view.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view.Frame.X);
+        Assert.Equal (expectedY, view.Frame.Y);
+        Assert.Equal (expectedWidth, view.Frame.Width);
+        Assert.Equal (expectedHeight, view.Frame.Height);
+    }
+
+    [Theory]
+    [InlineData (0, 0, 4, 4, 1, 1)]
+    [InlineData (3, 3, 4, 4, 1, 1)]
+    [InlineData (-3, -3, 4, 4, 1, 1)]
+    [InlineData (11, 11, 11, 11, 1, 1)]
+    [InlineData (5, 5, 5, 5, 1, 1)]
+    [InlineData (-5, -5, 4, 4, 1, 1)]
+    [InlineData (-6, -6, 4, 4, 0, 0)]
+    public void PosFunc_X_Same_As_Y_And_Width_Same_As_Height (int x, int y, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view = new View { X = Pos.Function (() => 4 + -x), Y = Pos.Function (() => 4 + -y), Width = 1, Height = 1 };
+        view.BeginInit ();
+        view.EndInit ();
+        view.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view.Frame.X);
+        Assert.Equal (expectedY, view.Frame.Y);
+        Assert.Equal (expectedWidth, view.Frame.Width);
+        Assert.Equal (expectedHeight, view.Frame.Height);
+    }
 }

--- a/UnitTests/View/Layout/SetRelativeLayoutTests.cs
+++ b/UnitTests/View/Layout/SetRelativeLayoutTests.cs
@@ -469,8 +469,8 @@ public class SetRelativeLayoutTests
 
     [Theory]
     [InlineData (0, 0, 4, 4)]
-    [InlineData (-1, -1, 2, 2)]
-    [InlineData (1, 1, 6, 6)]
+    [InlineData (-1, -1, 3, 3)]
+    [InlineData (1, 1, 5, 5)]
     public void Combine_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
     {
         var screen = new Rectangle (x, y, 10, 10);
@@ -523,8 +523,8 @@ public class SetRelativeLayoutTests
 
     [Theory]
     [InlineData (0, 0, 4, 4)]
-    [InlineData (-1, -1, 3, 3)]
-    [InlineData (1, 1, 5, 5)]
+    [InlineData (-1, -1, 4, 4)]
+    [InlineData (1, 1, 4, 4)]
     public void PosView_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
     {
         var screen = new Rectangle (x, y, 10, 10);

--- a/UnitTests/View/Layout/SetRelativeLayoutTests.cs
+++ b/UnitTests/View/Layout/SetRelativeLayoutTests.cs
@@ -430,4 +430,131 @@ public class SetRelativeLayoutTests
         Assert.Equal (26, tf.Frame.Width);
         Assert.Equal (1, tf.Frame.Height);
     }
+
+    [Theory]
+    [InlineData (0, 0, 10, 10)]
+    [InlineData (-1, -1, 9, 9)]
+    [InlineData (1, 1, 11, 11)]
+    public void AnchorEnd_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view = new View { X = Pos.AnchorEnd (), Y = Pos.AnchorEnd (), Width = 3, Height = 3 };
+        view.BeginInit ();
+        view.EndInit ();
+        view.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view.Frame.X);
+        Assert.Equal (expectedY, view.Frame.Y);
+        Assert.Equal (3, view.Frame.Width);
+        Assert.Equal (3, view.Frame.Height);
+    }
+
+    [Theory]
+    [InlineData (0, 0, 3, 3)]
+    [InlineData (-1, -1, 2, 2)]
+    [InlineData (1, 1, 4, 4)]
+    public void Center_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view = new View { X = Pos.Center (), Y = Pos.Center (), Width = 3, Height = 3 };
+        view.BeginInit ();
+        view.EndInit ();
+        view.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view.Frame.X);
+        Assert.Equal (expectedY, view.Frame.Y);
+        Assert.Equal (3, view.Frame.Width);
+        Assert.Equal (3, view.Frame.Height);
+    }
+
+    [Theory]
+    [InlineData (0, 0, 4, 4)]
+    [InlineData (-1, -1, 2, 2)]
+    [InlineData (1, 1, 6, 6)]
+    public void Combine_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view = new View { X = Pos.Center () + 1, Y = Pos.Center () + 1, Width = 3, Height = 3 };
+        view.BeginInit ();
+        view.EndInit ();
+        view.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view.Frame.X);
+        Assert.Equal (expectedY, view.Frame.Y);
+        Assert.Equal (3, view.Frame.Width);
+        Assert.Equal (3, view.Frame.Height);
+    }
+
+    [Theory]
+    [InlineData (0, 0, 3, 3)]
+    [InlineData (-1, -1, 2, 2)]
+    [InlineData (1, 1, 4, 4)]
+    public void Absolute_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view = new View { X = 3, Y = 3, Width = 3, Height = 3 };
+        view.BeginInit ();
+        view.EndInit ();
+        view.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view.Frame.X);
+        Assert.Equal (expectedY, view.Frame.Y);
+        Assert.Equal (3, view.Frame.Width);
+        Assert.Equal (3, view.Frame.Height);
+    }
+
+    [Theory]
+    [InlineData (0, 0, 5, 5)]
+    [InlineData (-1, -1, 4, 4)]
+    [InlineData (1, 1, 6, 6)]
+    public void Factor_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view = new View { X = Pos.Percent (50), Y = Pos.Percent (50), Width = 3, Height = 3 };
+        view.BeginInit ();
+        view.EndInit ();
+        view.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view.Frame.X);
+        Assert.Equal (expectedY, view.Frame.Y);
+        Assert.Equal (3, view.Frame.Width);
+        Assert.Equal (3, view.Frame.Height);
+    }
+
+    [Theory]
+    [InlineData (0, 0, 4, 4)]
+    [InlineData (-1, -1, 3, 3)]
+    [InlineData (1, 1, 5, 5)]
+    public void PosView_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view1 = new View { X = 3, Y = 3, Width = 1, Height = 1 };
+        var view2 = new View { X = Pos.Right (view1), Y = Pos.Bottom (view1), Width = 3, Height = 3 };
+        view2.BeginInit ();
+        view2.EndInit ();
+        view2.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view2.Frame.X);
+        Assert.Equal (expectedY, view2.Frame.Y);
+        Assert.Equal (3, view2.Frame.Width);
+        Assert.Equal (3, view2.Frame.Height);
+    }
+
+    [Theory]
+    [InlineData (0, 0, 4, 4)]
+    [InlineData (-1, -1, 3, 3)]
+    [InlineData (1, 1, 5, 5)]
+    public void PosFunc_X_Same_As_Y (int x, int y, int expectedX, int expectedY)
+    {
+        var screen = new Rectangle (x, y, 10, 10);
+        var view = new View { X = Pos.Function (() => 4), Y = Pos.Function (() => 4), Width = 3, Height = 3 };
+        view.BeginInit ();
+        view.EndInit ();
+        view.SetRelativeLayout (screen);
+
+        Assert.Equal (expectedX, view.Frame.X);
+        Assert.Equal (expectedY, view.Frame.Y);
+        Assert.Equal (3, view.Frame.Width);
+        Assert.Equal (3, view.Frame.Height);
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3362

## Proposed Changes/Todos

- [x] Add location handle in the SetRelativeLayout.
- [x] X and Y cannot be changed on the SetRelativeLayout because they will used to pass always the correct location. Only the Frame is changed.
- [x] Add unit tests to proof.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
