### PR TITLE
Fixes #3374 - `Curses` and `Net` drivers don't generate click events unless mouse has not moved

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -1137,7 +1137,7 @@ internal class NetDriver : ConsoleDriver
                 break;
             case EventType.Mouse:
                 MouseEvent me = ToDriverMouse (inputEvent.MouseEvent);
-                //Debug.WriteLine ($"NetDriver: ({me.X},{me.Y}) - {me.Flags}");
+                Debug.WriteLine ($"NetDriver: ({me.X},{me.Y}) - {me.Flags}");
                 OnMouseEvent (new MouseEventEventArgs (me));
 
                 break;

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1393,18 +1393,20 @@ internal class WindowsDriver : ConsoleDriver
                     break;
                 }
 
+                Debug.WriteLine ($"WindowsDriver: ({me.X},{me.Y}) - {me.Flags}");
+
                 OnMouseEvent (new MouseEventEventArgs (me));
 
                 if (_processButtonClick)
                 {
-                    OnMouseEvent (
-                                  new MouseEventEventArgs (
-                                                           new MouseEvent
-                                                           {
-                                                               X = me.X,
-                                                               Y = me.Y,
-                                                               Flags = ProcessButtonClick (inputEvent.MouseEvent)
-                                                           }));
+                    me = new MouseEvent
+                    {
+                        X = me.X,
+                        Y = me.Y,
+                        Flags = ProcessButtonClick (inputEvent.MouseEvent)
+                    };
+                    Debug.WriteLine ($"WindowsDriver: 2 ({me.X},{me.Y}) - {me.Flags}");
+                    OnMouseEvent (new MouseEventEventArgs (me));
                 }
 
                 break;
@@ -2011,12 +2013,14 @@ internal class WindowsDriver : ConsoleDriver
         //System.Diagnostics.Debug.WriteLine (
         //	$"point.X:{(point is { } ? ((Point)point).X : -1)};point.Y:{(point is { } ? ((Point)point).Y : -1)}");
 
-        return new MouseEvent
+        var me = new MouseEvent
         {
             X = mouseEvent.MousePosition.X,
             Y = mouseEvent.MousePosition.Y,
             Flags = mouseFlag
         };
+
+        return me;
     }
 }
 


### PR DESCRIPTION
## Fixes

- Fixes #3374

## Proposed Changes/Todos

- [x] Add debug spew to further diagnose
- [ ] ???

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
