### PR TITLE
Fixes #3381. `WindowsDriver` spurious ButtonPressed mouse events

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -472,6 +472,7 @@ internal class WindowsConsole
     [Flags]
     public enum ButtonState
     {
+        NoButtonPressed = 0,
         Button1Pressed = 1,
         Button2Pressed = 4,
         Button3Pressed = 8,
@@ -482,6 +483,7 @@ internal class WindowsConsole
     [Flags]
     public enum ControlKeyState
     {
+        NoControlKeyPressed = 0,
         RightAltPressed = 1,
         LeftAltPressed = 2,
         RightControlPressed = 4,
@@ -496,6 +498,7 @@ internal class WindowsConsole
     [Flags]
     public enum EventFlags
     {
+        NoEvent = 0,
         MouseMoved = 1,
         DoubleClick = 2,
         MouseWheeled = 4,
@@ -517,7 +520,7 @@ internal class WindowsConsole
         [FieldOffset (12)]
         public EventFlags EventFlags;
 
-        public readonly override string ToString () { return $"[Mouse({MousePosition},{ButtonState},{ControlKeyState},{EventFlags}"; }
+        public readonly override string ToString () { return $"[Mouse{MousePosition},{ButtonState},{ControlKeyState},{EventFlags}]"; }
     }
 
     public struct WindowBufferSizeRecord
@@ -1388,7 +1391,7 @@ internal class WindowsDriver : ConsoleDriver
             case WindowsConsole.EventType.Mouse:
                 MouseEvent me = ToDriverMouse (inputEvent.MouseEvent);
 
-                if (me is null)
+               if (me is null || me.Flags == MouseFlags.None)
                 {
                     break;
                 }
@@ -1774,8 +1777,8 @@ internal class WindowsDriver : ConsoleDriver
     {
         var mouseFlag = MouseFlags.AllEvents;
 
-        //System.Diagnostics.Debug.WriteLine (
-        //	$"X:{mouseEvent.MousePosition.X};Y:{mouseEvent.MousePosition.Y};ButtonState:{mouseEvent.ButtonState};EventFlags:{mouseEvent.EventFlags}");
+        Debug.WriteLine ($"ToDriverMouse: {mouseEvent}");
+        	//$"X:{mouseEvent.MousePosition.X};Y:{mouseEvent.MousePosition.Y};ButtonState:{mouseEvent.ButtonState};EventFlags:{mouseEvent.EventFlags}");
 
         if (_isButtonDoubleClicked || _isOneFingerDoubleClicked)
         {
@@ -2003,7 +2006,7 @@ internal class WindowsDriver : ConsoleDriver
         else if (mouseEvent is { ButtonState: 0, EventFlags: 0 })
         {
             // This happens on a double or triple click event.
-            mouseFlag = 0;
+            mouseFlag = MouseFlags.None;
         }
 
         mouseFlag = SetControlKeyStates (mouseEvent, mouseFlag);
@@ -2129,7 +2132,16 @@ internal class WindowsMainLoop : IMainLoopDriver
     void IMainLoopDriver.TearDown ()
     {
         // Eat any outstanding events
-        //var r = _winConsole.ReadConsoleInput ();
+        var records = _winConsole.ReadConsoleInput ();
+
+        if (records != null)
+        {
+            foreach (var rec in records)
+            {
+                Debug.WriteLine ($"Teardown: {rec.ToString ()}");
+                Debug.Assert (rec is not { EventType: WindowsConsole.EventType.Mouse, MouseEvent.ButtonState: WindowsConsole.ButtonState.Button1Pressed });
+            }
+        }
 
         _inputHandlerTokenSource?.Cancel ();
         _inputHandlerTokenSource?.Dispose ();

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -2128,6 +2128,9 @@ internal class WindowsMainLoop : IMainLoopDriver
 
     void IMainLoopDriver.TearDown ()
     {
+        // Eat any outstanding events
+        //var r = _winConsole.ReadConsoleInput ();
+
         _inputHandlerTokenSource?.Cancel ();
         _inputHandlerTokenSource?.Dispose ();
 

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1777,8 +1777,7 @@ internal class WindowsDriver : ConsoleDriver
     {
         var mouseFlag = MouseFlags.AllEvents;
 
-        Debug.WriteLine ($"ToDriverMouse: {mouseEvent}");
-        	//$"X:{mouseEvent.MousePosition.X};Y:{mouseEvent.MousePosition.Y};ButtonState:{mouseEvent.ButtonState};EventFlags:{mouseEvent.EventFlags}");
+        //Debug.WriteLine ($"ToDriverMouse: {mouseEvent}");
 
         if (_isButtonDoubleClicked || _isOneFingerDoubleClicked)
         {
@@ -2131,17 +2130,18 @@ internal class WindowsMainLoop : IMainLoopDriver
 
     void IMainLoopDriver.TearDown ()
     {
-        // Eat any outstanding events
-        var records = _winConsole.ReadConsoleInput ();
+        // Eat any outstanding events. See #
+        //var records = 
+            _winConsole.ReadConsoleInput ();
 
-        if (records != null)
-        {
-            foreach (var rec in records)
-            {
-                Debug.WriteLine ($"Teardown: {rec.ToString ()}");
-                Debug.Assert (rec is not { EventType: WindowsConsole.EventType.Mouse, MouseEvent.ButtonState: WindowsConsole.ButtonState.Button1Pressed });
-            }
-        }
+        //if (records != null)
+        //{
+        //    foreach (var rec in records)
+        //    {
+        //        Debug.WriteLine ($"Teardown: {rec.ToString ()}");
+        //        //Debug.Assert (rec is not { EventType: WindowsConsole.EventType.Mouse, MouseEvent.ButtonState: WindowsConsole.ButtonState.Button1Pressed });
+        //    }
+        //}
 
         _inputHandlerTokenSource?.Cancel ();
         _inputHandlerTokenSource?.Dispose ();

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -883,20 +883,9 @@ internal class CharMap : ScrollView
                                    }
                                    catch (HttpRequestException e)
                                    {
-                                       (s as Dialog).Text = e.Message;
-
-                                       Application.Invoke (
-                                                           () =>
-                                                           {
-                                                               spinner.Visible = false;
-                                                               errorLabel.Text = e.Message;
-                                                               errorLabel.ColorScheme = Colors.ColorSchemes ["Error"];
-                                                               errorLabel.Visible = true;
-                                                           }
-                                                          );
+                                       Application.Invoke (() => waitIndicator.RequestStop ());
                                    }
 
-                                   (s as Dialog)?.RequestStop ();
                                };
         Application.Run (waitIndicator);
         waitIndicator.Dispose ();

--- a/UICatalog/Scenarios/Mouse.cs
+++ b/UICatalog/Scenarios/Mouse.cs
@@ -9,6 +9,7 @@ public class Mouse : Scenario
 {
     public override void Main ()
     {
+        Application.Init ();
         Window win = new ()
         {
             Title = $"{Application.QuitKey} to Quit - Scenario: {GetName ()}",

--- a/UICatalog/Scenarios/Mouse.cs
+++ b/UICatalog/Scenarios/Mouse.cs
@@ -7,45 +7,101 @@ namespace UICatalog.Scenarios;
 [ScenarioCategory ("Mouse and Keyboard")]
 public class Mouse : Scenario
 {
-    public override void Setup ()
+    public override void Main ()
     {
+        Window win = new ()
+        {
+            Title = $"{Application.QuitKey} to Quit - Scenario: {GetName ()}",
+        };
+
         Label ml;
         var count = 0;
         ml = new Label { X = 1, Y = 1, Text = "Mouse: " };
-        List<string> rme = new ();
 
-        Win.Add (ml);
+        win.Add (ml);
 
-        var logList = new ListView
-        {
-            X = Pos.AnchorEnd (41),
-            Y = 0,
-            Width = 41,
-            Height = Dim.Fill (),
-            ColorScheme = Colors.ColorSchemes ["TopLevel"],
-            Source = new ListWrapper (rme)
-        };
-        Win.Add (logList);
-
-        Application.MouseEvent += (sender, a) =>
-                                  {
-                                      ml.Text = $"Mouse: ({a.MouseEvent.X},{a.MouseEvent.Y}) - {a.MouseEvent.Flags} {count}";
-                                      rme.Add ($"({a.MouseEvent.X},{a.MouseEvent.Y}) - {a.MouseEvent.Flags} {count++}");
-                                      logList.MoveDown ();
-                                  };
-
-        Win.Add (new MouseDemo ()
+        CheckBox cbWantContinuousPresses = new CheckBox ()
         {
             X = 0,
-            Y = 3,
-            Width = 15,
-            Height = 10,
-            Text = "Mouse Demo",
+            Y = Pos.Bottom(ml) + 1,
+            Title = "_Want Continuous Button Presses",
+        };
+        cbWantContinuousPresses.Toggled += (s,e) =>
+        {
+            win.WantContinuousButtonPressed = !win.WantContinuousButtonPressed;
+        };
+
+        win.Add (cbWantContinuousPresses);
+
+        var demo = new MouseDemo ()
+        {
+            X = 0,
+            Y = Pos.Bottom (cbWantContinuousPresses) + 1,
+            Width = 20,
+            Height = 5,
+            Text = "Enter/Leave Demo",
             TextAlignment = TextAlignment.Centered,
             VerticalTextAlignment = VerticalTextAlignment.Middle,
             ColorScheme = Colors.ColorSchemes ["Dialog"],
-        });
+        };
+        win.Add (demo);
 
+        var label = new Label ()
+        {
+            Text = "_App Events:",
+            X = 0,
+            Y = Pos.Bottom (demo),
+        };
+        List<string> appLogList = new ();
+        var appLog = new ListView
+        {
+            X = Pos.Left (label),
+            Y = Pos.Bottom (label),
+            Width = Dim.Percent(49),
+            Height = Dim.Fill (),
+            ColorScheme = Colors.ColorSchemes ["TopLevel"],
+            Source = new ListWrapper (appLogList)
+        };
+        win.Add (label, appLog);
+
+        Application.MouseEvent += (sender, a) =>
+                                  {
+                                      ml.Text = $"MouseEvent: ({a.MouseEvent.X},{a.MouseEvent.Y}) - {a.MouseEvent.Flags} {count}";
+                                      appLogList.Add ($"({a.MouseEvent.X},{a.MouseEvent.Y}) - {a.MouseEvent.Flags} {count++}");
+                                      appLog.MoveDown ();
+                                  };
+
+
+        label = new Label ()
+        {
+            Text = "_Window Events:",
+            X = Pos.Percent(50),
+            Y = Pos.Bottom (demo),
+        };
+        List<string> winLogList = new ();
+        var winLog = new ListView
+        {
+            X = Pos.Left(label),
+            Y = Pos.Bottom (label),
+            Width = Dim.Percent (50),
+            Height = Dim.Fill (),
+            ColorScheme = Colors.ColorSchemes ["TopLevel"],
+            Source = new ListWrapper (winLogList)
+        };
+        win.Add (label, winLog);
+        win.MouseEvent += (sender, a) =>
+                          {
+                              winLogList.Add ($"MouseEvent: ({a.MouseEvent.X},{a.MouseEvent.Y}) - {a.MouseEvent.Flags} {count++}");
+                              winLog.MoveDown ();
+                          };
+        win.MouseClick += (sender, a) =>
+                          {
+                              winLogList.Add ($"MouseClick: ({a.MouseEvent.X},{a.MouseEvent.Y}) - {a.MouseEvent.Flags} {count++}");
+                              winLog.MoveDown ();
+                          };
+
+        Application.Run (win);
+        win.Dispose ();
     }
 
     public class MouseDemo : View


### PR DESCRIPTION
## Fixes

- Fixes #3381

## Proposed Changes/Todos

- [x] Diagnose - Between instantiations of WindowsDriver, if a double-click event was the last event, `ReadConsole` is retriving a spurious event with `Button1Pressed`.
- [x] Update `Mouse` Scenario to illustrate
- [x] Hack fix: In `Teardown` eat any outstanding ReadConsole input. 
