### PR TITLE
Fixes #3344. `OnResizeNeeded` using Top's Bounds for Top. 

### DIFF
--- a/Terminal.Gui/View/Adornment/Adornment.cs
+++ b/Terminal.Gui/View/Adornment/Adornment.cs
@@ -24,8 +24,6 @@ public class Adornment : View
     /// <param name="parent"></param>
     public Adornment (View parent)
     {
-        Application.GrabbingMouse += Application_GrabbingMouse;
-        Application.UnGrabbingMouse += Application_UnGrabbingMouse;
         CanFocus = true;
         Parent = parent;
     }
@@ -209,9 +207,6 @@ public class Adornment : View
         return Thickness.Contains (frame, x, y);
     }
 
-    private Point? _dragPosition;
-    private Point _startGrabPoint;
-
     /// <inheritdoc/>
     protected internal override bool OnMouseEnter (MouseEvent mouseEvent)
     {
@@ -257,70 +252,6 @@ public class Adornment : View
             return OnMouseClick (args);
         }
 
-        if (!Parent.CanFocus || !Parent.Arrangement.HasFlag (ViewArrangement.Movable))
-        {
-            return true;
-        }
-
-        // BUGBUG: See https://github.com/gui-cs/Terminal.Gui/issues/3312
-        if (!_dragPosition.HasValue && mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed))
-        {
-            Parent.SetFocus ();
-            Application.BringOverlappedTopToFront ();
-
-            // Only start grabbing if the user clicks in the Thickness area
-            // Adornment.Contains takes Parent SuperView=relative coords.
-            if (Contains (mouseEvent.X + Parent.Frame.X + Frame.X, mouseEvent.Y+ Parent.Frame.Y + Frame.Y))
-            {
-                // Set the start grab point to the Frame coords
-                _startGrabPoint = new (mouseEvent.X + Frame.X, mouseEvent.Y + Frame.Y);
-                _dragPosition = new (mouseEvent.X, mouseEvent.Y);
-                Application.GrabMouse (this);
-            }
-
-            return true;
-        }
-
-        if (mouseEvent.Flags is (MouseFlags.Button1Pressed | MouseFlags.ReportMousePosition))
-        {
-            if (Application.MouseGrabView == this && _dragPosition.HasValue)
-            {
-                if (Parent.SuperView is null)
-                {
-                    // Redraw the entire app window.
-                    Application.Top.SetNeedsDisplay ();
-                }
-                else
-                {
-                    Parent.SuperView.SetNeedsDisplay ();
-                }
-
-                _dragPosition = new Point (mouseEvent.X, mouseEvent.Y);
-
-                Point parentLoc = Parent.SuperView?.ScreenToBounds (mouseEvent.ScreenPosition.X, mouseEvent.ScreenPosition.Y) ?? mouseEvent.ScreenPosition;
-
-                GetLocationEnsuringFullVisibility (
-                                     Parent,
-                                     parentLoc.X - _startGrabPoint.X,
-                                     parentLoc.Y - _startGrabPoint.Y,
-                                     out int nx,
-                                     out int ny,
-                                     out _
-                                    );
-
-                Parent.X = nx;
-                Parent.Y = ny;
-
-                return true;
-            }
-        }
-
-        if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Released) && _dragPosition.HasValue)
-        {
-            _dragPosition = null;
-            Application.UngrabMouse ();
-        }
-
         return false;
     }
 
@@ -340,30 +271,5 @@ public class Adornment : View
         return base.OnMouseLeave (mouseEvent);
     }
 
-    /// <inheritdoc/>
-    protected override void Dispose (bool disposing)
-    {
-        Application.GrabbingMouse -= Application_GrabbingMouse;
-        Application.UnGrabbingMouse -= Application_UnGrabbingMouse;
-
-        _dragPosition = null;
-        base.Dispose (disposing);
-    }
-
-    private void Application_GrabbingMouse (object sender, GrabMouseEventArgs e)
-    {
-        if (Application.MouseGrabView == this && _dragPosition.HasValue)
-        {
-            e.Cancel = true;
-        }
-    }
-
-    private void Application_UnGrabbingMouse (object sender, GrabMouseEventArgs e)
-    {
-        if (Application.MouseGrabView == this && _dragPosition.HasValue)
-        {
-            e.Cancel = true;
-        }
-    }
     #endregion Mouse Support
 }

--- a/Terminal.Gui/View/Adornment/Border.cs
+++ b/Terminal.Gui/View/Adornment/Border.cs
@@ -198,9 +198,14 @@ public class Border : Adornment
             return true;
         }
 
-        if (!Parent.CanFocus || !Parent.Arrangement.HasFlag (ViewArrangement.Movable))
+        if (!Parent.CanFocus)
         {
-            return true;
+            return false;
+        }
+
+        if (!Parent.Arrangement.HasFlag (ViewArrangement.Movable))
+        {
+            return false;
         }
 
         // BUGBUG: See https://github.com/gui-cs/Terminal.Gui/issues/3312

--- a/Terminal.Gui/View/Adornment/Border.cs
+++ b/Terminal.Gui/View/Adornment/Border.cs
@@ -54,6 +54,8 @@ public class Border : Adornment
     {
         /* Do nothing; View.CreateAdornment requires a constructor that takes a parent */
         Parent = parent;
+        Application.GrabbingMouse += Application_GrabbingMouse;
+        Application.UnGrabbingMouse += Application_UnGrabbingMouse;
     }
 
 #if SUBVIEW_BASED_BORDER
@@ -182,6 +184,117 @@ public class Border : Adornment
         }
         set => _lineStyle = value;
     }
+
+    #region Mouse Support
+
+    private Point? _dragPosition;
+    private Point _startGrabPoint;
+
+    /// <inheritdoc />
+    protected internal override bool OnMouseEvent (MouseEvent mouseEvent)
+    {
+        if (base.OnMouseEvent (mouseEvent))
+        {
+            return true;
+        }
+
+        if (!Parent.CanFocus || !Parent.Arrangement.HasFlag (ViewArrangement.Movable))
+        {
+            return true;
+        }
+
+        // BUGBUG: See https://github.com/gui-cs/Terminal.Gui/issues/3312
+        if (!_dragPosition.HasValue && mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed))
+        {
+            Parent.SetFocus ();
+            Application.BringOverlappedTopToFront ();
+
+            // Only start grabbing if the user clicks in the Thickness area
+            // Adornment.Contains takes Parent SuperView=relative coords.
+            if (Contains (mouseEvent.X + Parent.Frame.X + Frame.X, mouseEvent.Y + Parent.Frame.Y + Frame.Y))
+            {
+                // Set the start grab point to the Frame coords
+                _startGrabPoint = new (mouseEvent.X + Frame.X, mouseEvent.Y + Frame.Y);
+                _dragPosition = new (mouseEvent.X, mouseEvent.Y);
+                Application.GrabMouse (this);
+            }
+
+            return true;
+        }
+
+        if (mouseEvent.Flags is (MouseFlags.Button1Pressed | MouseFlags.ReportMousePosition))
+        {
+            if (Application.MouseGrabView == this && _dragPosition.HasValue)
+            {
+                if (Parent.SuperView is null)
+                {
+                    // Redraw the entire app window.
+                    Application.Top.SetNeedsDisplay ();
+                }
+                else
+                {
+                    Parent.SuperView.SetNeedsDisplay ();
+                }
+
+                _dragPosition = new Point (mouseEvent.X, mouseEvent.Y);
+
+                Point parentLoc = Parent.SuperView?.ScreenToBounds (mouseEvent.ScreenPosition.X, mouseEvent.ScreenPosition.Y) ?? mouseEvent.ScreenPosition;
+
+                GetLocationEnsuringFullVisibility (
+                                     Parent,
+                                     parentLoc.X - _startGrabPoint.X,
+                                     parentLoc.Y - _startGrabPoint.Y,
+                                     out int nx,
+                                     out int ny,
+                                     out _
+                                    );
+
+                Parent.X = nx;
+                Parent.Y = ny;
+
+                return true;
+            }
+        }
+
+        if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Released) && _dragPosition.HasValue)
+        {
+            _dragPosition = null;
+            Application.UngrabMouse ();
+
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /// <inheritdoc/>
+    protected override void Dispose (bool disposing)
+    {
+        Application.GrabbingMouse -= Application_GrabbingMouse;
+        Application.UnGrabbingMouse -= Application_UnGrabbingMouse;
+
+        _dragPosition = null;
+        base.Dispose (disposing);
+    }
+
+    private void Application_GrabbingMouse (object sender, GrabMouseEventArgs e)
+    {
+        if (Application.MouseGrabView == this && _dragPosition.HasValue)
+        {
+            e.Cancel = true;
+        }
+    }
+
+    private void Application_UnGrabbingMouse (object sender, GrabMouseEventArgs e)
+    {
+        if (Application.MouseGrabView == this && _dragPosition.HasValue)
+        {
+            e.Cancel = true;
+        }
+    }
+
+#endregion Mouse Support
 
     /// <inheritdoc/>
     public override void OnDrawContent (Rectangle contentArea)

--- a/Terminal.Gui/View/Layout/ViewLayout.cs
+++ b/Terminal.Gui/View/Layout/ViewLayout.cs
@@ -975,7 +975,7 @@ public partial class View
         // First try SuperView.Bounds, then Application.Top, then Driver.Bounds.
         // Finally, if none of those are valid, use int.MaxValue (for Unit tests).
         Rectangle relativeBounds = SuperView is { IsInitialized: true } ? SuperView.Bounds :
-                                   Application.Top is { } && Application.Top.IsInitialized ? Application.Top.Bounds :
+                                   Application.Top is { } && Application.Top != this && Application.Top.IsInitialized ? Application.Top.Bounds :
                                    Application.Driver?.Bounds ?? new Rectangle (0, 0, int.MaxValue, int.MaxValue);
         SetRelativeLayout (relativeBounds);
 

--- a/UnitTests/View/MouseTests.cs
+++ b/UnitTests/View/MouseTests.cs
@@ -38,22 +38,22 @@ public class MouseTests (ITestOutputHelper output)
     [Theory]
     [InlineData (0, 0, 0, 0, false)]
     [InlineData (0, 0, 0, 4, false)]
-    [InlineData (1, 0, 0, 4, true)]
+    [InlineData (1, 0, 0, 4, false)]
     [InlineData (0, 1, 0, 4, true)]
     [InlineData (0, 0, 1, 4, false)]
 
     [InlineData (1, 1, 0, 3, false)]
-    [InlineData (1, 1, 0, 4, true)]
+    [InlineData (1, 1, 0, 4, false)]
     [InlineData (1, 1, 0, 5, true)]
     [InlineData (1, 1, 0, 6, false)]
 
 
     [InlineData (1, 1, 0, 11, false)]
     [InlineData (1, 1, 0, 12, true)]
-    [InlineData (1, 1, 0, 13, true)]
+    [InlineData (1, 1, 0, 13, false)]
     [InlineData (1, 1, 0, 14, false)]
     [AutoInitShutdown]
-    public void ButtonPressed_In_Margin_Or_Border_Starts_Drag (int marginThickness, int borderThickness, int paddingThickness, int xy, bool expectedMoved)
+    public void ButtonPressed_In_Border_Starts_Drag (int marginThickness, int borderThickness, int paddingThickness, int xy, bool expectedMoved)
     {
         var testView = new View
         {


### PR DESCRIPTION
## Fixes

- Fixes #3344

## Proposed Changes/Todos

- [x] Only border drags now, not margin.
- [x] Found, fixed, updated unit tests.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
