### PR TITLE
Fixes #3380. WindowsDriver is sending mouse button pressed only on moving.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -2134,21 +2134,6 @@ internal class WindowsMainLoop : IMainLoopDriver
         _inputHandlerTokenSource?.Dispose ();
         _waitForProbe?.Dispose ();
 
-        // Eat any outstanding events. See #
-        // I don't recommend this because if there is no input
-        // this could being hang until some event occur
-        //var records = 
-        //_winConsole.ReadConsoleInput ();
-
-        //if (records != null)
-        //{
-        //    foreach (var rec in records)
-        //    {
-        //        Debug.WriteLine ($"Teardown: {rec.ToString ()}");
-        //        //Debug.Assert (rec is not { EventType: WindowsConsole.EventType.Mouse, MouseEvent.ButtonState: WindowsConsole.ButtonState.Button1Pressed });
-        //    }
-        //}
-
         _resultQueue?.Clear ();
 
         _eventReadyTokenSource?.Cancel ();

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1281,7 +1281,7 @@ internal class WindowsDriver : ConsoleDriver
         {
 #if HACK_CHECK_WINCHANGED
 
-            //_mainLoop.WinChanged -= ChangeWin;
+            _mainLoopDriver.WinChanged -= ChangeWin;
 #endif
         }
 
@@ -1698,7 +1698,7 @@ internal class WindowsDriver : ConsoleDriver
 
     private async Task ProcessButtonDoubleClickedAsync ()
     {
-        await Task.Delay (300);
+        await Task.Delay (200);
         _isButtonDoubleClicked = false;
         _isOneFingerDoubleClicked = false;
 
@@ -2130,9 +2130,15 @@ internal class WindowsMainLoop : IMainLoopDriver
 
     void IMainLoopDriver.TearDown ()
     {
+        _inputHandlerTokenSource?.Cancel ();
+        _inputHandlerTokenSource?.Dispose ();
+        _waitForProbe?.Dispose ();
+
         // Eat any outstanding events. See #
+        // I don't recommend this because if there is no input
+        // this could being hang until some event occur
         //var records = 
-            _winConsole.ReadConsoleInput ();
+        //_winConsole.ReadConsoleInput ();
 
         //if (records != null)
         //{
@@ -2143,20 +2149,15 @@ internal class WindowsMainLoop : IMainLoopDriver
         //    }
         //}
 
-        _inputHandlerTokenSource?.Cancel ();
-        _inputHandlerTokenSource?.Dispose ();
+        _resultQueue?.Clear ();
 
         _eventReadyTokenSource?.Cancel ();
         _eventReadyTokenSource?.Dispose ();
         _eventReady?.Dispose ();
 
-        _resultQueue?.Clear ();
-
 #if HACK_CHECK_WINCHANGED
         _winChange?.Dispose ();
 #endif
-
-        //_waitForProbe?.Dispose ();
 
         _mainLoop = null;
     }
@@ -2174,11 +2175,18 @@ internal class WindowsMainLoop : IMainLoopDriver
             }
             catch (OperationCanceledException)
             {
+                // Wakes the _waitForProbe if it's waiting
+                _waitForProbe.Set ();
                 return;
             }
             finally
             {
-                _waitForProbe.Reset ();
+                // If IsCancellationRequested is true the code after
+                // the `finally` block will not be executed.
+                if (!_inputHandlerTokenSource.IsCancellationRequested)
+                {
+                    _waitForProbe.Reset ();
+                }
             }
 
             if (_resultQueue?.Count == 0)


### PR DESCRIPTION
## Fixes

- Fixes #3380

## Proposed Changes/Todos

- [x] Dispose _waitForProbe
- [x] Decrease delay for the TripleClicked
- [x] Unsubscribe the WinChanged on End

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
