### PR TITLE
Fixes #3394. View.Dispose doen't call UngrabMouse if MouseGrabView is the view itself.

### DIFF
--- a/Terminal.Gui/View/View.cs
+++ b/Terminal.Gui/View/View.cs
@@ -521,6 +521,11 @@ public partial class View : Responder, ISupportInitializeNotification
 
         DisposeAdornments ();
 
+        if (Application.MouseGrabView is { } && Application.MouseGrabView == this)
+        {
+            Application.UngrabMouse ();
+        }
+
         for (int i = InternalSubviews.Count - 1; i >= 0; i--)
         {
             View subview = InternalSubviews [i];

--- a/Terminal.Gui/View/View.cs
+++ b/Terminal.Gui/View/View.cs
@@ -521,11 +521,6 @@ public partial class View : Responder, ISupportInitializeNotification
 
         DisposeAdornments ();
 
-        if (Application.MouseGrabView is { } && Application.MouseGrabView == this)
-        {
-            Application.UngrabMouse ();
-        }
-
         for (int i = InternalSubviews.Count - 1; i >= 0; i--)
         {
             View subview = InternalSubviews [i];

--- a/Terminal.Gui/Views/Menu/MenuBar.cs
+++ b/Terminal.Gui/Views/Menu/MenuBar.cs
@@ -1386,6 +1386,12 @@ public class MenuBar : View
                 menu = _openSubMenu [i];
                 Application.Current.Remove (menu);
                 _openSubMenu.Remove (menu);
+
+                if (Application.MouseGrabView == menu)
+                {
+                    Application.GrabMouse (this);
+                }
+
                 menu.Dispose ();
             }
 

--- a/UnitTests/Application/MouseTests.cs
+++ b/UnitTests/Application/MouseTests.cs
@@ -371,5 +371,29 @@ public class MouseTests
         }
     }
 
+    [Fact]
+    [AutoInitShutdown]
+    public void MouseGrabView_Is_Set_To_Null_If_A_View_Was_Disposed ()
+    {
+        var count = 0;
+        var view = new View { Width = 1, Height = 1 };
+        view.MouseEvent += (s, e) => count++;
+        var top = new Toplevel ();
+        top.Add (view);
+        Application.Begin (top);
+
+        Assert.Null (Application.MouseGrabView);
+        Application.GrabMouse (view);
+        Assert.Equal (view, Application.MouseGrabView);
+        top.Remove (view);
+        view.Dispose ();
+#if DEBUG_IDISPOSABLE
+        Assert.True (view.WasDisposed);
+#endif
+
+        Application.OnMouseEvent (new () { X = 0, Y = 0, Flags = MouseFlags.Button1Pressed });
+        Assert.Null (Application.MouseGrabView);
+        Assert.Equal (0, count);
+    }
     #endregion
 }

--- a/UnitTests/Application/MouseTests.cs
+++ b/UnitTests/Application/MouseTests.cs
@@ -373,7 +373,7 @@ public class MouseTests
 
     [Fact]
     [AutoInitShutdown]
-    public void MouseGrabView_Is_Set_To_Null_If_A_View_Was_Disposed ()
+    public void View_Is_Responsible_For_Calling_UnGrabMouse_Before_Being_Disposed ()
     {
         var count = 0;
         var view = new View { Width = 1, Height = 1 };
@@ -386,6 +386,7 @@ public class MouseTests
         Application.GrabMouse (view);
         Assert.Equal (view, Application.MouseGrabView);
         top.Remove (view);
+        Application.UngrabMouse ();
         view.Dispose ();
 #if DEBUG_IDISPOSABLE
         Assert.True (view.WasDisposed);

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -3262,11 +3262,7 @@ Edit
         Rectangle pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, _output);
         Assert.Equal (new Rectangle (1, 0, 8, 1), pos);
 
-        Assert.True (
-                     menu.NewMouseEvent (
-                                      new MouseEvent { X = 1, Y = 0, Flags = MouseFlags.Button1Pressed, View = menu }
-                                     )
-                    );
+        Assert.True (menu.NewMouseEvent (new () { X = 1, Y = 0, Flags = MouseFlags.Button1Pressed, View = menu }));
         top.Draw ();
 
         expected = @"
@@ -3281,11 +3277,7 @@ Edit
         pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, _output);
         Assert.Equal (new Rectangle (1, 0, 10, 6), pos);
 
-        Assert.False (
-                      menu.NewMouseEvent (
-                                       new MouseEvent { X = 1, Y = 2, Flags = MouseFlags.Button1Clicked, View = Application.Top.Subviews [1] }
-                                      )
-                     );
+        Assert.False (menu.NewMouseEvent (new () { X = 1, Y = 2, Flags = MouseFlags.Button1Clicked, View = Application.Top.Subviews [1] }));
         top.Draw ();
 
         expected = @"
@@ -3301,11 +3293,7 @@ Edit
         pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, _output);
         Assert.Equal (new Rectangle (1, 0, 15, 7), pos);
 
-        Assert.False (
-                      menu.NewMouseEvent (
-                                       new MouseEvent { X = 1, Y = 1, Flags = MouseFlags.Button1Clicked, View = Application.Top.Subviews [2] }
-                                      )
-                     );
+        Assert.False (menu.NewMouseEvent (new () { X = 1, Y = 1, Flags = MouseFlags.Button1Clicked, View = Application.Top.Subviews [2] }));
         top.Draw ();
 
         expected = @"
@@ -3320,11 +3308,7 @@ Edit
         pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, _output);
         Assert.Equal (new Rectangle (1, 0, 10, 6), pos);
 
-        Assert.False (
-                      menu.NewMouseEvent (
-                                       new MouseEvent { X = 70, Y = 2, Flags = MouseFlags.Button1Clicked, View = Application.Top }
-                                      )
-                     );
+        Assert.False (menu.NewMouseEvent (new () { X = 70, Y = 2, Flags = MouseFlags.Button1Clicked, View = Application.Top }));
         top.Draw ();
 
         expected = @"


### PR DESCRIPTION
## Fixes

- Fixes #3394

## Proposed Changes/Todos

- [x] Ungrab the mouse on dispose if it's set

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
