### PR TITLE
Fixes #3418. Vertical `TextFormatter` broken

### DIFF
--- a/Terminal.Gui/Drawing/Justification.cs
+++ b/Terminal.Gui/Drawing/Justification.cs
@@ -1,0 +1,332 @@
+namespace Terminal.Gui;
+
+/// <summary>
+///     Controls how the <see cref="Justifier"/> justifies items within a container. 
+/// </summary>
+public enum Justification
+{
+    /// <summary>
+    ///     The items will be aligned to the left.
+    ///     Set <see cref="Justifier.PutSpaceBetweenItems"/> to <see langword="true"/> to ensure at least one space between
+    ///     each item.
+    /// </summary>
+    /// <example>
+    ///     <c>
+    ///         111 2222 33333
+    ///     </c>
+    /// </example>
+    Left,
+
+    /// <summary>
+    ///     The items will be aligned to the right.
+    ///     Set <see cref="Justifier.PutSpaceBetweenItems"/> to <see langword="true"/> to ensure at least one space between
+    ///     each item.
+    /// </summary>
+    /// <example>
+    ///     <c>
+    ///         111 2222 33333
+    ///     </c>
+    /// </example>
+    Right,
+
+    /// <summary>
+    ///     The group will be centered in the container.
+    ///     If centering is not possible, the group will be left-justified.
+    ///     Set <see cref="Justifier.PutSpaceBetweenItems"/> to <see langword="true"/> to ensure at least one space between
+    ///     each item.
+    /// </summary>
+    /// <example>
+    ///     <c>
+    ///         111 2222 33333
+    ///     </c>
+    /// </example>
+    Centered,
+
+    /// <summary>
+    ///     The items will be justified. Space will be added between the items such that the first item
+    ///     is at the start and the right side of the last item against the end.
+    ///     Set <see cref="Justifier.PutSpaceBetweenItems"/> to <see langword="true"/> to ensure at least one space between
+    ///     each item.
+    /// </summary>
+    /// <example>
+    ///     <c>
+    ///         111    2222     33333
+    ///     </c>
+    /// </example>
+    Justified,
+
+    /// <summary>
+    ///     The first item will be aligned to the left and the remaining will aligned to the right.
+    ///     Set <see cref="Justifier.PutSpaceBetweenItems"/> to <see langword="true"/> to ensure at least one space between
+    ///     each item.
+    /// </summary>
+    /// <example>
+    ///     <c>
+    ///         111        2222 33333
+    ///     </c>
+    /// </example>
+    FirstLeftRestRight,
+
+    /// <summary>
+    ///     The last item will be aligned to the right and the remaining will aligned to the left.
+    ///     Set <see cref="Justifier.PutSpaceBetweenItems"/> to <see langword="true"/> to ensure at least one space between
+    ///     each item.
+    /// </summary>
+    /// <example>
+    ///     <c>
+    ///         111 2222        33333
+    ///     </c>
+    /// </example>
+    LastRightRestLeft
+}
+
+/// <summary>
+///     Justifies items within a container based on the specified <see cref="Justification"/>.
+/// </summary>
+public class Justifier
+{
+    /// <summary>
+    /// Gets or sets how the <see cref="Justifier"/> justifies items within a container.
+    /// </summary>
+    public Justification Justification { get; set; }
+
+    /// <summary>
+    /// The size of the container.
+    /// </summary>
+    public int ContainerSize { get; set; }
+
+    /// <summary>
+    ///     Gets or sets whether <see cref="Justify"/> puts a space is placed between items. Default is <see langword="false"/>. If <see langword="true"/>, a space will be
+    ///     placed between each item, which is useful for justifying text.
+    /// </summary>
+    public bool PutSpaceBetweenItems { get; set; }
+
+    /// <summary>
+    ///     Takes a list of items and returns their positions when justified within a container <see name="ContainerSize"/> wide based on the specified
+    ///     <see cref="Justification"/>.
+    /// </summary>
+    /// <param name="sizes">The sizes of the items to justify.</param>
+    /// <returns>The locations of the items, from left to right.</returns>
+    public int [] Justify (int [] sizes)
+    {
+        return Justify (Justification, PutSpaceBetweenItems, ContainerSize, sizes);
+    }
+
+    /// <summary>
+    ///     Takes a list of items and returns their positions when justified within a container <paramref name="containerSize"/> wide based on the specified
+    ///     <see cref="Justification"/>.
+    /// </summary>
+    /// <param name="sizes">The sizes of the items to justify.</param>
+    /// <param name="justification">The justification style.</param>
+    /// <param name="containerSize">The size of the container.</param>
+    /// <returns>The locations of the items, from left to right.</returns>
+    public static int [] Justify (Justification justification, bool putSpaceBetweenItems, int containerSize, int [] sizes)
+    {
+        if (sizes.Length == 0)
+        {
+            return new int [] { };
+        }
+
+        int maxSpaceBetweenItems = putSpaceBetweenItems ? 1 : 0;
+
+        var positions = new int [sizes.Length]; // positions of the items. the return value.
+        int totalItemsSize = sizes.Sum ();
+        int totalGaps = sizes.Length - 1; // total gaps between items
+        int totalItemsAndSpaces = totalItemsSize + totalGaps * maxSpaceBetweenItems; // total size of items and spaces if we had enough room
+
+        int spaces = totalGaps * maxSpaceBetweenItems; // We'll decrement this below to place one space between each item until we run out
+        if (totalItemsSize >= containerSize)
+        {
+            spaces = 0;
+        }
+        else if (totalItemsAndSpaces > containerSize)
+        {
+            spaces = containerSize - totalItemsSize;
+        }
+
+        switch (justification)
+        {
+            case Justification.Left:
+                var currentPosition = 0;
+
+                for (var i = 0; i < sizes.Length; i++)
+                {
+                    if (sizes [i] < 0)
+                    {
+                        throw new ArgumentException ("The size of an item cannot be negative.");
+                    }
+
+                    if (i == 0)
+                    {
+                        positions [0] = 0; // first item position
+
+                        continue;
+                    }
+
+                    int spaceBefore = spaces-- > 0 ? maxSpaceBetweenItems : 0;
+
+                    // subsequent items are placed one space after the previous item
+                    positions [i] = positions [i - 1] + sizes [i - 1] + spaceBefore;
+                }
+
+                break;
+            case Justification.Right:
+                currentPosition = Math.Max (0, containerSize - totalItemsSize - spaces);
+
+                for (var i = 0; i < sizes.Length; i++)
+                {
+                    if (sizes [i] < 0)
+                    {
+                        throw new ArgumentException ("The size of an item cannot be negative.");
+                    }
+
+                    int spaceBefore = spaces-- > 0 ? maxSpaceBetweenItems : 0;
+
+                    positions [i] = currentPosition;
+                    currentPosition += sizes [i] + spaceBefore;
+                }
+
+                break;
+
+            case Justification.Centered:
+                if (sizes.Length > 1)
+                {
+                    // remaining space to be distributed before first and after the items
+                    int remainingSpace = Math.Max (0, containerSize - totalItemsSize - spaces);
+
+                    for (var i = 0; i < sizes.Length; i++)
+                    {
+                        if (sizes [i] < 0)
+                        {
+                            throw new ArgumentException ("The size of an item cannot be negative.");
+                        }
+
+                        if (i == 0)
+                        {
+                            positions [i] = remainingSpace / 2; // first item position
+
+                            continue;
+                        }
+
+                        int spaceBefore = spaces-- > 0 ? maxSpaceBetweenItems : 0;
+
+                        // subsequent items are placed one space after the previous item
+                        positions [i] = positions [i - 1] + sizes [i - 1] + spaceBefore;
+                    }
+                }
+                else if (sizes.Length == 1)
+                {
+                    if (sizes [0] < 0)
+                    {
+                        throw new ArgumentException ("The size of an item cannot be negative.");
+                    }
+
+                    positions [0] = (containerSize - sizes [0]) / 2; // single item is centered
+                }
+
+                break;
+
+            case Justification.Justified:
+                int spaceBetween = sizes.Length > 1 ? (containerSize - totalItemsSize) / (sizes.Length - 1) : 0;
+                int remainder = sizes.Length > 1 ? (containerSize - totalItemsSize) % (sizes.Length - 1) : 0;
+                currentPosition = 0;
+
+                for (var i = 0; i < sizes.Length; i++)
+                {
+                    if (sizes [i] < 0)
+                    {
+                        throw new ArgumentException ("The size of an item cannot be negative.");
+                    }
+
+                    positions [i] = currentPosition;
+                    int extraSpace = i < remainder ? 1 : 0;
+                    currentPosition += sizes [i] + spaceBetween + extraSpace;
+                }
+
+                break;
+
+            // 111 2222        33333
+            case Justification.LastRightRestLeft:
+                if (sizes.Length > 1)
+                {
+                    currentPosition = 0;
+
+                    for (var i = 0; i < sizes.Length; i++)
+                    {
+                        if (sizes [i] < 0)
+                        {
+                            throw new ArgumentException ("The size of an item cannot be negative.");
+                        }
+
+                        if (i < sizes.Length - 1)
+                        {
+                            int spaceBefore = spaces-- > 0 ? maxSpaceBetweenItems : 0;
+
+                            positions [i] = currentPosition;
+                            currentPosition += sizes [i] + spaceBefore;
+                        }
+                    }
+
+                    positions [sizes.Length - 1] = containerSize - sizes [sizes.Length - 1];
+                }
+                else if (sizes.Length == 1)
+                {
+                    if (sizes [0] < 0)
+                    {
+                        throw new ArgumentException ("The size of an item cannot be negative.");
+                    }
+
+                    positions [0] = containerSize - sizes [0]; // single item is flush right
+                }
+
+                break;
+
+            // 111        2222 33333
+            case Justification.FirstLeftRestRight:
+                if (sizes.Length > 1)
+                {
+                    currentPosition = 0;
+                    positions [0] = currentPosition; // first item is flush left
+
+                    for (int i = sizes.Length - 1; i >= 0; i--)
+                    {
+                        if (sizes [i] < 0)
+                        {
+                            throw new ArgumentException ("The size of an item cannot be negative.");
+                        }
+
+                        if (i == sizes.Length - 1)
+                        {
+                            // start at right
+                            currentPosition = containerSize - sizes [i];
+                            positions [i] = currentPosition;
+                        }
+
+                        if (i < sizes.Length - 1 && i > 0)
+                        {
+                            int spaceBefore = spaces-- > 0 ? maxSpaceBetweenItems : 0;
+
+                            positions [i] = currentPosition - sizes [i] - spaceBefore;
+                            currentPosition = positions [i];
+                        }
+                    }
+                }
+                else if (sizes.Length == 1)
+                {
+                    if (sizes [0] < 0)
+                    {
+                        throw new ArgumentException ("The size of an item cannot be negative.");
+                    }
+
+                    positions [0] = 0; // single item is flush left
+                }
+
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException (nameof (justification), justification, null);
+        }
+
+        return positions;
+    }
+}

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -320,7 +320,7 @@ public class TextFormatter
                 if (isVertical)
                 {
                     int runesWidth = line > 0
-                                         ? GetColumnsRequiredForVerticalText (linesFormatted, TabWidth)
+                                         ? GetColumnsRequiredForVerticalText (linesFormatted, tabWidth: TabWidth)
                                          : 0;
                     x = screen.Left + runesWidth;
                 }
@@ -335,7 +335,7 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
-                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, TabWidth);
+                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, tabWidth: TabWidth);
                     x = screen.Left + line + (screen.Width - runesWidth) / 2;
 
                     CursorPosition = (screen.Width - runesWidth) / 2 + (_hotKeyPos > -1 ? _hotKeyPos : 0);

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -287,13 +287,13 @@ public class TextFormatter
             Rune [] runes = linesFormatted [line].ToRunes ();
 
             runes = Direction switch
-                    {
-                        TextDirection.RightLeft_BottomTop => runes.Reverse ().ToArray (),
-                        TextDirection.RightLeft_TopBottom => runes.Reverse ().ToArray (),
-                        TextDirection.BottomTop_LeftRight => runes.Reverse ().ToArray (),
-                        TextDirection.BottomTop_RightLeft => runes.Reverse ().ToArray (),
-                        _ => runes
-                    };
+            {
+                TextDirection.RightLeft_BottomTop => runes.Reverse ().ToArray (),
+                TextDirection.RightLeft_TopBottom => runes.Reverse ().ToArray (),
+                TextDirection.BottomTop_LeftRight => runes.Reverse ().ToArray (),
+                TextDirection.BottomTop_RightLeft => runes.Reverse ().ToArray (),
+                _ => runes
+            };
 
             // When text is justified, we lost left or right, so we use the direction to align. 
 
@@ -304,7 +304,7 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
-                    int runesWidth = GetWidestLineLength (linesFormatted, line, TabWidth);
+                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, tabWidth: TabWidth);
                     x = screen.Right - runesWidth;
                     CursorPosition = screen.Width - runesWidth + (_hotKeyPos > -1 ? _hotKeyPos : 0);
                 }
@@ -320,7 +320,7 @@ public class TextFormatter
                 if (isVertical)
                 {
                     int runesWidth = line > 0
-                                         ? GetWidestLineLength (linesFormatted, 0, line, TabWidth)
+                                         ? GetColumnsRequiredForVerticalText (linesFormatted, TabWidth)
                                          : 0;
                     x = screen.Left + runesWidth;
                 }
@@ -335,7 +335,7 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
-                    int runesWidth = GetWidestLineLength (linesFormatted, line, TabWidth);
+                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, TabWidth);
                     x = screen.Left + line + (screen.Width - runesWidth) / 2;
 
                     CursorPosition = (screen.Width - runesWidth) / 2 + (_hotKeyPos > -1 ? _hotKeyPos : 0);
@@ -700,48 +700,48 @@ public class TextFormatter
     public static bool IsHorizontalDirection (TextDirection textDirection)
     {
         return textDirection switch
-               {
-                   TextDirection.LeftRight_TopBottom => true,
-                   TextDirection.LeftRight_BottomTop => true,
-                   TextDirection.RightLeft_TopBottom => true,
-                   TextDirection.RightLeft_BottomTop => true,
-                   _ => false
-               };
+        {
+            TextDirection.LeftRight_TopBottom => true,
+            TextDirection.LeftRight_BottomTop => true,
+            TextDirection.RightLeft_TopBottom => true,
+            TextDirection.RightLeft_BottomTop => true,
+            _ => false
+        };
     }
 
     /// <summary>Check if it is a vertical direction</summary>
     public static bool IsVerticalDirection (TextDirection textDirection)
     {
         return textDirection switch
-               {
-                   TextDirection.TopBottom_LeftRight => true,
-                   TextDirection.TopBottom_RightLeft => true,
-                   TextDirection.BottomTop_LeftRight => true,
-                   TextDirection.BottomTop_RightLeft => true,
-                   _ => false
-               };
+        {
+            TextDirection.TopBottom_LeftRight => true,
+            TextDirection.TopBottom_RightLeft => true,
+            TextDirection.BottomTop_LeftRight => true,
+            TextDirection.BottomTop_RightLeft => true,
+            _ => false
+        };
     }
 
     /// <summary>Check if it is Left to Right direction</summary>
     public static bool IsLeftToRight (TextDirection textDirection)
     {
         return textDirection switch
-               {
-                   TextDirection.LeftRight_TopBottom => true,
-                   TextDirection.LeftRight_BottomTop => true,
-                   _ => false
-               };
+        {
+            TextDirection.LeftRight_TopBottom => true,
+            TextDirection.LeftRight_BottomTop => true,
+            _ => false
+        };
     }
 
     /// <summary>Check if it is Top to Bottom direction</summary>
     public static bool IsTopToBottom (TextDirection textDirection)
     {
         return textDirection switch
-               {
-                   TextDirection.TopBottom_LeftRight => true,
-                   TextDirection.TopBottom_RightLeft => true,
-                   _ => false
-               };
+        {
+            TextDirection.TopBottom_LeftRight => true,
+            TextDirection.TopBottom_RightLeft => true,
+            _ => false
+        };
     }
 
     // TODO: Move to StringExtensions?
@@ -1122,21 +1122,21 @@ public class TextFormatter
                     case ' ':
                         return GetNextWhiteSpace (to + 1, cWidth, out incomplete, length);
                     case '\t':
-                    {
-                        length += tabWidth + 1;
-
-                        if (length == tabWidth && tabWidth > cWidth)
                         {
-                            return to + 1;
-                        }
+                            length += tabWidth + 1;
 
-                        if (length > cWidth && tabWidth > cWidth)
-                        {
-                            return to;
-                        }
+                            if (length == tabWidth && tabWidth > cWidth)
+                            {
+                                return to + 1;
+                            }
 
-                        return GetNextWhiteSpace (to + 1, cWidth, out incomplete, length);
-                    }
+                            if (length > cWidth && tabWidth > cWidth)
+                            {
+                                return to;
+                            }
+
+                            return GetNextWhiteSpace (to + 1, cWidth, out incomplete, length);
+                        }
                     default:
                         to++;
 
@@ -1145,11 +1145,11 @@ public class TextFormatter
             }
 
             return cLength switch
-                   {
-                       > 0 when to < runes.Count && runes [to].Value != ' ' && runes [to].Value != '\t' => from,
-                       > 0 when to < runes.Count && (runes [to].Value == ' ' || runes [to].Value == '\t') => from,
-                       _ => to
-                   };
+            {
+                > 0 when to < runes.Count && runes [to].Value != ' ' && runes [to].Value != '\t' => from,
+                > 0 when to < runes.Count && (runes [to].Value == ' ' || runes [to].Value == '\t') => from,
+                _ => to
+            };
         }
 
         if (start < text.GetRuneCount ())
@@ -1580,29 +1580,28 @@ public class TextFormatter
     }
 
     /// <summary>
-    ///     Returns the number of columns in the widest line in the list based on the <paramref name="startIndex"/> and
-    ///     the <paramref name="length"/>.
+    ///     Returns the number of columns required to render <paramref name="lines"/> oriented vertically.
     /// </summary>
     /// <remarks>
     ///     This API will return incorrect results if the text includes glyphs who's width is dependent on surrounding
     ///     glyphs (e.g. Arabic).
     /// </remarks>
     /// <param name="lines">The lines.</param>
-    /// <param name="startIndex">The start index.</param>
-    /// <param name="length">The length.</param>
+    /// <param name="startLine">The line in the list to start with (any lines before will be ignored).</param>
+    /// <param name="linesCount">The number of lines to process (if less than <c>lines.Count</c>, any lines after will be ignored).</param>
     /// <param name="tabWidth">The number of columns used for a tab.</param>
-    /// <returns>The maximum characters width.</returns>
-    public static int GetWidestLineLength (
+    /// <returns>The width required.</returns>
+    public static int GetColumnsRequiredForVerticalText (
         List<string> lines,
-        int startIndex = -1,
-        int length = -1,
+        int startLine = -1,
+        int linesCount = -1,
         int tabWidth = 0
     )
     {
         var max = 0;
 
-        for (int i = startIndex == -1 ? 0 : startIndex;
-             i < (length == -1 ? lines.Count : startIndex + length);
+        for (int i = startLine == -1 ? 0 : startLine;
+             i < (linesCount == -1 ? lines.Count : startLine + linesCount);
              i++)
         {
             string runes = lines [i];

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -413,7 +413,7 @@ public class TextFormatter
 
                 if (lastZeroWidthPos is null)
                 {
-                    if (idx < 0)
+                    if (idx < 0 || x + current + colOffset < 0)
                     {
                         current++;
 

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -304,8 +304,8 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
-                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, tabWidth: TabWidth);
-                    x = screen.Right - runesWidth;
+                    int runesWidth = runes.Length == 0 ? 0 : runes.Max (r => GetRuneWidth (r, TabWidth));
+                    x = screen.Left + (screen.Width - _lines.Count - 1) + (runesWidth + line);
                     CursorPosition = screen.Width - runesWidth + (_hotKeyPos > -1 ? _hotKeyPos : 0);
                 }
                 else
@@ -319,10 +319,8 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
-                    int runesWidth = line > 0
-                                         ? GetColumnsRequiredForVerticalText (linesFormatted, tabWidth: TabWidth)
-                                         : 0;
-                    x = screen.Left + runesWidth;
+                    int runesWidth = runes.Length == 0 ? 0 : runes.Max (r => GetRuneWidth (r, TabWidth));
+                    x = screen.Left + runesWidth + line - 1;
                 }
                 else
                 {
@@ -335,8 +333,8 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
-                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, tabWidth: TabWidth);
-                    x = screen.Left + line + (screen.Width - runesWidth) / 2;
+                    int runesWidth = runes.Length == 0 ? 0 : runes.Max (r => GetRuneWidth (r, TabWidth));
+                    x = screen.Left + (screen.Width / 2) - (_lines.Count  / 2) + (runesWidth + line - 1);
 
                     CursorPosition = (screen.Width - runesWidth) / 2 + (_hotKeyPos > -1 ? _hotKeyPos : 0);
                 }
@@ -410,7 +408,7 @@ public class TextFormatter
 
                 if (lastZeroWidthPos is null)
                 {
-                    if (idx < 0 || x + current + colOffset < 0)
+                    if (idx < 0)
                     {
                         current++;
 

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -304,6 +304,7 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
+                    // BUGBUG:  This works with a very limited set of wide-char scenarios.
                     int runesWidth = runes.Length == 0 ? 0 : runes.Max (r => GetRuneWidth (r, TabWidth));
                     x = screen.Left + (screen.Width - _lines.Count - 1) + (runesWidth + line);
                     CursorPosition = screen.Width - runesWidth + (_hotKeyPos > -1 ? _hotKeyPos : 0);
@@ -319,8 +320,11 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
-                    int runesWidth = runes.Length == 0 ? 0 : runes.Max (r => GetRuneWidth (r, TabWidth));
-                    x = screen.Left + runesWidth + line - 1;
+                    // BUGBUG: This works only if a) all lines have only single-wide chars and b) only one line has wide chars
+                    int runesWidth = line > 0
+                                         ? GetColumnsRequiredForVerticalText (linesFormatted, 0, line, TabWidth)
+                                         : 0;
+                    x = screen.Left + runesWidth;
                 }
                 else
                 {
@@ -333,8 +337,9 @@ public class TextFormatter
             {
                 if (isVertical)
                 {
-                    int runesWidth = runes.Length == 0 ? 0 : runes.Max (r => GetRuneWidth (r, TabWidth));
-                    x = screen.Left + (screen.Width / 2) - (_lines.Count  / 2) + (runesWidth + line - 1);
+                    // BUGBUG: This works with a very limited set of wide-char scenarios. 
+                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, tabWidth: TabWidth);
+                    x = screen.Left + line + (screen.Width - runesWidth) / 2;
 
                     CursorPosition = (screen.Width - runesWidth) / 2 + (_hotKeyPos > -1 ? _hotKeyPos : 0);
                 }

--- a/Terminal.Gui/View/ViewText.cs
+++ b/Terminal.Gui/View/ViewText.cs
@@ -334,7 +334,7 @@ public partial class View
             switch (TextFormatter.IsVerticalDirection (TextDirection))
             {
                 case true:
-                    int colWidth = TextFormatter.GetWidestLineLength (new List<string> { TextFormatter.Text }, 0, 1);
+                    int colWidth = TextFormatter.GetColumnsRequiredForVerticalText (new List<string> { TextFormatter.Text }, 0, 1);
 
                     // TODO: v2 - This uses frame.Width; it should only use Viewport
                     if (_frame.Width < colWidth

--- a/UnitTests/Drawing/JustifierTests.cs
+++ b/UnitTests/Drawing/JustifierTests.cs
@@ -1,0 +1,428 @@
+using System.Text;
+using Xunit.Abstractions;
+
+namespace Terminal.Gui.DrawingTests;
+
+public class JustifierTests (ITestOutputHelper output)
+{
+    private readonly ITestOutputHelper _output = output;
+
+    public static IEnumerable<object []> JustificationEnumValues ()
+    {
+        foreach (object number in Enum.GetValues (typeof (Justification)))
+        {
+            yield return new [] { number };
+        }
+    }
+
+    [Theory]
+    [MemberData (nameof (JustificationEnumValues))]
+    public void NoItems_Works (Justification justification)
+    {
+        int [] sizes = [];
+        int [] positions = Justifier.Justify (justification, false, 100, sizes);
+        Assert.Equal (new int [] { }, positions);
+    }
+
+    [Theory]
+    [MemberData (nameof (JustificationEnumValues))]
+    public void Negative_Widths_Not_Allowed (Justification justification)
+    {
+        Assert.Throws<ArgumentException> (() => new Justifier ()
+        {
+            Justification = justification,
+            ContainerSize = 100
+        }.Justify (new [] { -10, 20, 30 }));
+        Assert.Throws<ArgumentException> (() => new Justifier ()
+        {
+            Justification = justification,
+            ContainerSize = 100
+        }.Justify (new [] { 10, -20, 30 }));
+        Assert.Throws<ArgumentException> (() => new Justifier ()
+        {
+            Justification = justification,
+            ContainerSize = 100
+        }.Justify (new [] { 10, 20, -30 }));
+    }
+
+    [Theory]
+    [InlineData (Justification.Left, new [] { 0 }, 1, new [] { 0 })]
+    [InlineData (Justification.Left, new [] { 0, 0 }, 1, new [] { 0, 1 })]
+    [InlineData (Justification.Left, new [] { 0, 0, 0 }, 1, new [] { 0, 1, 1 })]
+    [InlineData (Justification.Left, new [] { 1 }, 1, new [] { 0 })]
+    [InlineData (Justification.Left, new [] { 1 }, 2, new [] { 0 })]
+    [InlineData (Justification.Left, new [] { 1 }, 3, new [] { 0 })]
+    [InlineData (Justification.Left, new [] { 1, 1 }, 2, new [] { 0, 1 })]
+    [InlineData (Justification.Left, new [] { 1, 1 }, 3, new [] { 0, 2 })]
+    [InlineData (Justification.Left, new [] { 1, 1 }, 4, new [] { 0, 2 })]
+    [InlineData (Justification.Left, new [] { 1, 1, 1 }, 3, new [] { 0, 1, 2 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 7, new [] { 0, 2, 4 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 10, new [] { 0, 2, 5 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 11, new [] { 0, 2, 5 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 12, new [] { 0, 2, 5 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 13, new [] { 0, 2, 5 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 2, 4, 7 })]
+    [InlineData (Justification.Left, new [] { 33, 33, 33 }, 100, new [] { 0, 34, 67 })]
+    [InlineData (Justification.Left, new [] { 10 }, 101, new [] { 0 })]
+    [InlineData (Justification.Left, new [] { 10, 20 }, 101, new [] { 0, 11 })]
+    [InlineData (Justification.Left, new [] { 10, 20, 30 }, 100, new [] { 0, 11, 32 })]
+    [InlineData (Justification.Left, new [] { 10, 20, 30 }, 101, new [] { 0, 11, 32 })]
+    [InlineData (Justification.Left, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 11, 31, 61 })]
+    [InlineData (Justification.Left, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 11, 31, 61, 101 })]
+    [InlineData (Justification.Right, new [] { 0 }, 1, new [] { 1 })]
+    [InlineData (Justification.Right, new [] { 0, 0 }, 1, new [] { 0, 1 })]
+    [InlineData (Justification.Right, new [] { 0, 0, 0 }, 1, new [] { 0, 1, 1 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 7, new [] { 0, 2, 4 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 10, new [] { 2, 4, 7 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 11, new [] { 3, 5, 8 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 12, new [] { 4, 6, 9 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 13, new [] { 5, 7, 10 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 2, 4, 7 })]
+    [InlineData (Justification.Right, new [] { 10, 20, 30 }, 100, new [] { 38, 49, 70 })]
+    [InlineData (Justification.Right, new [] { 33, 33, 33 }, 100, new [] { 0, 34, 67 })]
+    [InlineData (Justification.Right, new [] { 10 }, 101, new [] { 91 })]
+    [InlineData (Justification.Right, new [] { 10, 20 }, 101, new [] { 70, 81 })]
+    [InlineData (Justification.Right, new [] { 10, 20, 30 }, 101, new [] { 39, 50, 71 })]
+    [InlineData (Justification.Right, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 11, 31, 61 })]
+    [InlineData (Justification.Right, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 11, 31, 61, 101 })]
+    [InlineData (Justification.Centered, new [] { 0 }, 1, new [] { 0 })]
+    [InlineData (Justification.Centered, new [] { 0, 0 }, 1, new [] { 0, 1 })]
+    [InlineData (Justification.Centered, new [] { 0, 0, 0 }, 1, new [] { 0, 1, 1 })]
+    [InlineData (Justification.Centered, new [] { 1 }, 1, new [] { 0 })]
+    [InlineData (Justification.Centered, new [] { 1 }, 2, new [] { 0 })]
+    [InlineData (Justification.Centered, new [] { 1 }, 3, new [] { 1 })]
+    [InlineData (Justification.Centered, new [] { 1, 1 }, 2, new [] { 0, 1 })]
+    [InlineData (Justification.Centered, new [] { 1, 1 }, 3, new [] { 0, 2 })]
+    [InlineData (Justification.Centered, new [] { 1, 1 }, 4, new [] { 0, 2 })]
+    [InlineData (Justification.Centered, new [] { 1, 1, 1 }, 3, new [] { 0, 1, 2 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3 }, 7, new [] { 0, 2, 4 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3 }, 10, new [] { 1, 3, 6 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3 }, 11, new [] { 1, 3, 6 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 2, 4, 7 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 9, new [] { 0, 3, 6 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 10, new [] { 0, 4, 7 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 11, new [] { 0, 4, 8 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 12, new [] { 0, 4, 8 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 13, new [] { 1, 5, 9 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 100, new [] { 0, 34, 67 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 101, new [] { 0, 34, 68 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 102, new [] { 0, 34, 68 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 103, new [] { 1, 35, 69 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 104, new [] { 1, 35, 69 })]
+    [InlineData (Justification.Centered, new [] { 10 }, 101, new [] { 45 })]
+    [InlineData (Justification.Centered, new [] { 10, 20 }, 101, new [] { 35, 46 })]
+    [InlineData (Justification.Centered, new [] { 10, 20, 30 }, 100, new [] { 19, 30, 51 })]
+    [InlineData (Justification.Centered, new [] { 10, 20, 30 }, 101, new [] { 19, 30, 51 })]
+    [InlineData (Justification.Centered, new [] { 10, 20, 30, 40 }, 100, new [] { 0, 10, 30, 60 })]
+    [InlineData (Justification.Centered, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 11, 31, 61 })]
+    [InlineData (Justification.Centered, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 11, 31, 61, 101 })]
+    [InlineData (Justification.Centered, new [] { 3, 4, 5, 6 }, 25, new [] { 2, 6, 11, 17 })]
+    [InlineData (Justification.Justified, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 11, 31, 61, 101 })]
+    [InlineData (Justification.Justified, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 11, 31, 61 })]
+    [InlineData (Justification.Justified, new [] { 10, 20, 30 }, 100, new [] { 0, 30, 70 })]
+    [InlineData (Justification.Justified, new [] { 10, 20, 30 }, 101, new [] { 0, 31, 71 })]
+    [InlineData (Justification.Justified, new [] { 33, 33, 33 }, 100, new [] { 0, 34, 67 })]
+    [InlineData (Justification.Justified, new [] { 11, 17, 23 }, 100, new [] { 0, 36, 77 })]
+    [InlineData (Justification.Justified, new [] { 1, 2, 3 }, 11, new [] { 0, 4, 8 })]
+    [InlineData (Justification.Justified, new [] { 10, 20 }, 101, new [] { 0, 81 })]
+    [InlineData (Justification.Justified, new [] { 10 }, 101, new [] { 0 })]
+    [InlineData (Justification.Justified, new [] { 3, 3, 3 }, 21, new [] { 0, 9, 18 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5 }, 21, new [] { 0, 8, 16 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5, 6 }, 18, new [] { 0, 3, 7, 12 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5, 6 }, 19, new [] { 0, 4, 8, 13 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5, 6 }, 20, new [] { 0, 4, 9, 14 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5, 6 }, 21, new [] { 0, 4, 9, 15 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 22, new [] { 0, 8, 14, 19 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 23, new [] { 0, 8, 15, 20 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 24, new [] { 0, 8, 15, 21 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 25, new [] { 0, 9, 16, 22 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 26, new [] { 0, 9, 17, 23 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 31, new [] { 0, 11, 20, 28 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 0 }, 1, new [] { 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 0, 0 }, 1, new [] { 0, 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 0, 0, 0 }, 1, new [] { 0, 1, 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1 }, 1, new [] { 0 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1 }, 2, new [] { 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1 }, 3, new [] { 2 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 1 }, 2, new [] { 0, 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 1 }, 3, new [] { 0, 2 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 1 }, 4, new [] { 0, 3 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 1, 1 }, 3, new [] { 0, 1, 2 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 7, new [] { 0, 2, 4 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 8, new [] { 0, 2, 5 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 9, new [] { 0, 2, 6 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 10, new [] { 0, 2, 7 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 11, new [] { 0, 2, 8 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 2, 4, 7 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 3, 3, 3 }, 21, new [] { 0, 4, 18 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 3, 4, 5 }, 21, new [] { 0, 4, 16 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 33, 33, 33 }, 100, new [] { 0, 34, 67 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10 }, 101, new [] { 91 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20 }, 101, new [] { 0, 81 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20, 30 }, 100, new [] { 0, 11, 70 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20, 30 }, 101, new [] { 0, 11, 71 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 11, 31, 61 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 11, 31, 61, 101 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 0 }, 1, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 0, 0 }, 1, new [] { 0, 1 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 0, 0, 0 }, 1, new [] { 0, 0, 1 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1 }, 1, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1 }, 2, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1 }, 3, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 1 }, 2, new [] { 0, 1 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 1 }, 3, new [] { 0, 2 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 1 }, 4, new [] { 0, 3 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 1, 1 }, 3, new [] { 0, 1, 2 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 7, new [] { 0, 1, 4 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 8, new [] { 0, 2, 5 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 9, new [] { 0, 3, 6 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 10, new [] { 0, 4, 7 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 11, new [] { 0, 5, 8 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 1, 3, 7 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3, 4 }, 12, new [] { 0, 1, 4, 8 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 3, 3, 3 }, 21, new [] { 0, 14, 18 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 3, 4, 5 }, 21, new [] { 0, 11, 16 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 33, 33, 33 }, 100, new [] { 0, 33, 67 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10 }, 101, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20 }, 101, new [] { 0, 81 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20, 30 }, 100, new [] { 0, 49, 70 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20, 30 }, 101, new [] { 0, 50, 71 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 10, 30, 61 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 10, 30, 60, 101 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 3, 3, 3 }, 21, new [] { 0, 14, 18 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 3, 4, 5 }, 21, new [] { 0, 11, 16 })]
+    public void TestJustifications_PutSpaceBetweenItems (Justification justification, int [] sizes, int containerSize, int [] expected)
+    {
+        int [] positions = new Justifier
+        {
+            PutSpaceBetweenItems = true,
+            Justification = justification,
+            ContainerSize = containerSize
+        }.Justify (sizes);
+        AssertJustification (justification, sizes, containerSize, positions, expected);
+    }
+
+    [Theory]
+    [InlineData (Justification.Left, new [] { 0 }, 1, new [] { 0 })]
+    [InlineData (Justification.Left, new [] { 0, 0 }, 1, new [] { 0, 0 })]
+    [InlineData (Justification.Left, new [] { 0, 0, 0 }, 1, new [] { 0, 0, 0 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 7, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 10, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 11, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 12, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3 }, 13, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.Left, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.Left, new [] { 10, 20, 30 }, 100, new [] { 0, 10, 30 })]
+    [InlineData (Justification.Left, new [] { 33, 33, 33 }, 100, new [] { 0, 33, 66 })]
+    [InlineData (Justification.Left, new [] { 10 }, 101, new [] { 0 })]
+    [InlineData (Justification.Left, new [] { 10, 20 }, 101, new [] { 0, 10 })]
+    [InlineData (Justification.Left, new [] { 10, 20, 30 }, 101, new [] { 0, 10, 30 })]
+    [InlineData (Justification.Left, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 10, 30, 60 })]
+    [InlineData (Justification.Left, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 10, 30, 60, 100 })]
+    [InlineData (Justification.Right, new [] { 0 }, 1, new [] { 1 })]
+    [InlineData (Justification.Right, new [] { 0, 0 }, 1, new [] { 1, 1 })]
+    [InlineData (Justification.Right, new [] { 0, 0, 0 }, 1, new [] { 1, 1, 1 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 7, new [] { 1, 2, 4 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 10, new [] { 4, 5, 7 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 11, new [] { 5, 6, 8 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 12, new [] { 6, 7, 9 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3 }, 13, new [] { 7, 8, 10 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.Right, new [] { 1, 2, 3, 4 }, 11, new [] { 1, 2, 4, 7 })]
+    [InlineData (Justification.Right, new [] { 10, 20, 30 }, 100, new [] { 40, 50, 70 })]
+    [InlineData (Justification.Right, new [] { 33, 33, 33 }, 100, new [] { 1, 34, 67 })]
+    [InlineData (Justification.Right, new [] { 10 }, 101, new [] { 91 })]
+    [InlineData (Justification.Right, new [] { 10, 20 }, 101, new [] { 71, 81 })]
+    [InlineData (Justification.Right, new [] { 10, 20, 30 }, 101, new [] { 41, 51, 71 })]
+    [InlineData (Justification.Right, new [] { 10, 20, 30, 40 }, 101, new [] { 1, 11, 31, 61 })]
+    [InlineData (Justification.Right, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 1, 11, 31, 61, 101 })]
+    [InlineData (Justification.Centered, new [] { 1 }, 1, new [] { 0 })]
+    [InlineData (Justification.Centered, new [] { 1 }, 2, new [] { 0 })]
+    [InlineData (Justification.Centered, new [] { 1 }, 3, new [] { 1 })]
+    [InlineData (Justification.Centered, new [] { 1, 1 }, 2, new [] { 0, 1 })]
+    [InlineData (Justification.Centered, new [] { 1, 1 }, 3, new [] { 0, 1 })]
+    [InlineData (Justification.Centered, new [] { 1, 1 }, 4, new [] { 1, 2 })]
+    [InlineData (Justification.Centered, new [] { 1, 1, 1 }, 3, new [] { 0, 1, 2 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3 }, 7, new [] { 0, 1, 3 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3 }, 10, new [] { 2, 3, 5 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3 }, 11, new [] { 2, 3, 5 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.Centered, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 9, new [] { 0, 3, 6 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 10, new [] { 0, 3, 6 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 11, new [] { 1, 4, 7 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 12, new [] { 1, 4, 7 })]
+    [InlineData (Justification.Centered, new [] { 3, 3, 3 }, 13, new [] { 2, 5, 8 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 100, new [] { 0, 33, 66 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 101, new [] { 1, 34, 67 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 102, new [] { 1, 34, 67 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 103, new [] { 2, 35, 68 })]
+    [InlineData (Justification.Centered, new [] { 33, 33, 33 }, 104, new [] { 2, 35, 68 })]
+    [InlineData (Justification.Centered, new [] { 3, 4, 5, 6 }, 25, new [] { 3, 6, 10, 15 })]
+    [InlineData (Justification.Justified, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 11, 31, 61, 101 })]
+    [InlineData (Justification.Justified, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 11, 31, 61 })]
+    [InlineData (Justification.Justified, new [] { 10, 20, 30 }, 100, new [] { 0, 30, 70 })]
+    [InlineData (Justification.Justified, new [] { 10, 20, 30 }, 101, new [] { 0, 31, 71 })]
+    [InlineData (Justification.Justified, new [] { 33, 33, 33 }, 100, new [] { 0, 34, 67 })]
+    [InlineData (Justification.Justified, new [] { 11, 17, 23 }, 100, new [] { 0, 36, 77 })]
+    [InlineData (Justification.Justified, new [] { 1, 2, 3 }, 11, new [] { 0, 4, 8 })]
+    [InlineData (Justification.Justified, new [] { 10, 20 }, 101, new [] { 0, 81 })]
+    [InlineData (Justification.Justified, new [] { 10 }, 101, new [] { 0 })]
+    [InlineData (Justification.Justified, new [] { 3, 3, 3 }, 21, new [] { 0, 9, 18 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5 }, 21, new [] { 0, 8, 16 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5, 6 }, 18, new [] { 0, 3, 7, 12 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5, 6 }, 19, new [] { 0, 4, 8, 13 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5, 6 }, 20, new [] { 0, 4, 9, 14 })]
+    [InlineData (Justification.Justified, new [] { 3, 4, 5, 6 }, 21, new [] { 0, 4, 9, 15 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 22, new [] { 0, 8, 14, 19 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 23, new [] { 0, 8, 15, 20 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 24, new [] { 0, 8, 15, 21 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 25, new [] { 0, 9, 16, 22 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 26, new [] { 0, 9, 17, 23 })]
+    [InlineData (Justification.Justified, new [] { 6, 5, 4, 3 }, 31, new [] { 0, 11, 20, 28 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 0 }, 1, new [] { 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 0, 0 }, 1, new [] { 0, 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 0, 0, 0 }, 1, new [] { 0, 0, 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1 }, 1, new [] { 0 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1 }, 2, new [] { 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1 }, 3, new [] { 2 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 1 }, 2, new [] { 0, 1 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 1 }, 3, new [] { 0, 2 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 1 }, 4, new [] { 0, 3 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 1, 1 }, 3, new [] { 0, 1, 2 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 7, new [] { 0, 1, 4 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 8, new [] { 0, 1, 5 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 9, new [] { 0, 1, 6 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 10, new [] { 0, 1, 7 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3 }, 11, new [] { 0, 1, 8 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 1, 3, 7 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 1, 2, 3, 4 }, 12, new [] { 0, 1, 3, 8 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 3, 3, 3 }, 21, new [] { 0, 3, 18 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 3, 4, 5 }, 21, new [] { 0, 3, 16 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 33, 33, 33 }, 100, new [] { 0, 33, 67 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10 }, 101, new [] { 91 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20 }, 101, new [] { 0, 81 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20, 30 }, 100, new [] { 0, 10, 70 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20, 30 }, 101, new [] { 0, 10, 71 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 10, 30, 61 })]
+    [InlineData (Justification.LastRightRestLeft, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 10, 30, 60, 101 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 0 }, 1, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 0, 0 }, 1, new [] { 0, 1 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 0, 0, 0 }, 1, new [] { 0, 1, 1 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1 }, 1, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1 }, 2, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1 }, 3, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 1 }, 2, new [] { 0, 1 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 1 }, 3, new [] { 0, 2 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 1 }, 4, new [] { 0, 3 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 1, 1 }, 3, new [] { 0, 1, 2 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 6, new [] { 0, 1, 3 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 7, new [] { 0, 2, 4 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 8, new [] { 0, 3, 5 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 9, new [] { 0, 4, 6 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 10, new [] { 0, 5, 7 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3 }, 11, new [] { 0, 6, 8 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3, 4 }, 10, new [] { 0, 1, 3, 6 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3, 4 }, 11, new [] { 0, 2, 4, 7 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 1, 2, 3, 4 }, 12, new [] { 0, 3, 5, 8 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 3, 3, 3 }, 21, new [] { 0, 15, 18 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 3, 4, 5 }, 21, new [] { 0, 12, 16 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 33, 33, 33 }, 100, new [] { 0, 34, 67 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10 }, 101, new [] { 0 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20 }, 101, new [] { 0, 81 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20, 30 }, 100, new [] { 0, 50, 70 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20, 30 }, 101, new [] { 0, 51, 71 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20, 30, 40 }, 101, new [] { 0, 11, 31, 61 })]
+    [InlineData (Justification.FirstLeftRestRight, new [] { 10, 20, 30, 40, 50 }, 151, new [] { 0, 11, 31, 61, 101 })]
+    public void TestJustifications_NoSpaceBetweenItems (Justification justification, int [] sizes, int containerSize, int [] expected)
+    {
+        int [] positions = new Justifier
+        {
+            PutSpaceBetweenItems = false,
+            Justification = justification,
+            ContainerSize = containerSize
+        }.Justify (sizes);
+        AssertJustification (justification, sizes, containerSize, positions, expected);
+    }
+
+    public void AssertJustification (Justification justification, int [] sizes, int totalSize, int [] positions, int [] expected)
+    {
+        try
+        {
+            _output.WriteLine ($"Testing: {RenderJustification (justification, sizes, totalSize, expected)}");
+        }
+        catch (Exception e)
+        {
+            _output.WriteLine ($"Exception rendering expected: {e.Message}");
+            _output.WriteLine ($"Actual: {RenderJustification (justification, sizes, totalSize, positions)}");
+        }
+
+        if (!expected.SequenceEqual (positions))
+        {
+            _output.WriteLine ($"Expected: {RenderJustification (justification, sizes, totalSize, expected)}");
+            _output.WriteLine ($"Actual: {RenderJustification (justification, sizes, totalSize, positions)}");
+            Assert.Fail (" Expected and actual do not match");
+        }
+    }
+
+    public string RenderJustification (Justification justification, int [] sizes, int totalSize, int [] positions)
+    {
+        var output = new StringBuilder ();
+        output.AppendLine ($"Justification: {justification}, Positions: {string.Join (", ", positions)}, TotalSize: {totalSize}");
+
+        for (var i = 0; i <= totalSize / 10; i++)
+        {
+            output.Append (i.ToString ().PadRight (9) + " ");
+        }
+
+        output.AppendLine ();
+
+        for (var i = 0; i < totalSize; i++)
+        {
+            output.Append (i % 10);
+        }
+
+        output.AppendLine ();
+
+        var items = new char [totalSize];
+
+        for (var position = 0; position < positions.Length; position++)
+        {
+            // try
+            {
+                for (var j = 0; j < sizes [position] && positions [position] + j < totalSize; j++)
+                {
+                    items [positions [position] + j] = (position + 1).ToString () [0];
+                }
+            }
+
+            //catch (Exception e)
+            //{
+            //    output.AppendLine ($"{e.Message} - position = {position}, positions[{position}]: {positions [position]}, sizes[{position}]: {sizes [position]}, totalSize: {totalSize}");
+            //    output.Append (new string (items).Replace ('\0', ' '));
+
+            //    Assert.Fail (e.Message + output.ToString ());
+            //}
+        }
+
+        output.Append (new string (items).Replace ('\0', ' '));
+
+        return output.ToString ();
+    }
+}

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -3482,7 +3482,7 @@ ssb
     [InlineData ("A", 2, false, "A")]
     [InlineData ("AB12", 5, false, "AB12")]
     [InlineData ("AB\n12", 5, false, "A1\nB2")]
-    [InlineData ("デモエ", 1, false, "")]
+    [InlineData ("", 1, false, "")]
 
     public void Draw_Vertical_TopBottom_LeftRight (string text, int width, bool autoSize, string expectedText)
     {

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -3316,24 +3316,37 @@ ssb
 
     [SetupFakeDriver]
     [Theory]
-    [InlineData ("A", 0, "")]
-    [InlineData ("A", 1, "A")]
-    [InlineData ("A", 2, "A")]
-    [InlineData ("AB", 1, "A")]
-    [InlineData ("AB", 2, "AB")]
-    [InlineData ("ABC", 3, "ABC")]
-    [InlineData ("ABC", 4, "ABC")]
-    [InlineData ("ABC", 6, "ABC")]
-    public void Draw_Horizontal_Left (string text, int width, string expectedText)
+    [InlineData ("A", 0, false, "")]
+    [InlineData ("A", 1, false, "A")]
+    [InlineData ("A", 2, false, "A")]
+    [InlineData ("AB", 1, false, "A")]
+    [InlineData ("AB", 2, false, "AB")]
+    [InlineData ("ABC", 3, false, "ABC")]
+    [InlineData ("ABC", 4, false, "ABC")]
+    [InlineData ("ABC", 6, false, "ABC")]
+
+    [InlineData ("A", 0, true, "")]
+    [InlineData ("A", 1, true, "A")]
+    [InlineData ("A", 2, true, "A")]
+    [InlineData ("AB", 1, true, "A")]
+    [InlineData ("AB", 2, true, "AB")]
+    [InlineData ("ABC", 3, true, "ABC")]
+    [InlineData ("ABC", 4, true, "ABC")]
+    [InlineData ("ABC", 6, true, "ABC")]
+    public void Draw_Horizontal_Left (string text, int width, bool autoSize, string expectedText)
 
     {
         TextFormatter tf = new ()
         {
-            Size = new Size (width, 1),
-
             Text = text,
-            Alignment = TextAlignment.Left
+            Alignment = TextAlignment.Left,
+            AutoSize = autoSize,
         };
+
+        if (!autoSize)
+        {
+            tf.Size = new Size (width, 1);
+        }
         tf.Draw (new Rectangle (0, 0, width, 1), Attribute.Default, Attribute.Default);
 
         TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
@@ -3378,25 +3391,42 @@ ssb
 
     [SetupFakeDriver]
     [Theory]
-    [InlineData ("A", 0, "")]
-    [InlineData ("A", 1, "A")]
-    [InlineData ("A", 2, "A")]
-    [InlineData ("A", 3, " A")]
-    [InlineData ("AB", 1, "A")]
-    [InlineData ("AB", 2, "AB")]
-    [InlineData ("ABC", 3, "ABC")]
-    [InlineData ("ABC", 4, "ABC")]
-    [InlineData ("ABC", 5, " ABC")]
-    [InlineData ("ABC", 6, " ABC")]
-    [InlineData ("ABC", 9, "   ABC")]
-    public void Draw_Horizontal_Centered (string text, int width, string expectedText)
+    [InlineData ("A", 0, false, "")]
+    [InlineData ("A", 1, false, "A")]
+    [InlineData ("A", 2, false, "A")]
+    [InlineData ("A", 3, false, " A")]
+    [InlineData ("AB", 1, false, "A")]
+    [InlineData ("AB", 2, false, "AB")]
+    [InlineData ("ABC", 3, false, "ABC")]
+    [InlineData ("ABC", 4, false, "ABC")]
+    [InlineData ("ABC", 5, false, " ABC")]
+    [InlineData ("ABC", 6, false, " ABC")]
+    [InlineData ("ABC", 9, false, "   ABC")]
+
+    [InlineData ("A", 0, true, "")]
+    [InlineData ("A", 1, true, "A")]
+    [InlineData ("A", 2, true, "A")]
+    [InlineData ("A", 3, true, " A")]
+    [InlineData ("AB", 1, true, "A")]
+    [InlineData ("AB", 2, true, "AB")]
+    [InlineData ("ABC", 3, true, "ABC")]
+    [InlineData ("ABC", 4, true, "ABC")]
+    [InlineData ("ABC", 5, true, " ABC")]
+    [InlineData ("ABC", 6, true, " ABC")]
+    [InlineData ("ABC", 9, true, "   ABC")]
+    public void Draw_Horizontal_Centered (string text, int width, bool autoSize, string expectedText)
     {
         TextFormatter tf = new ()
         {
-            Size = new Size (width, 1),
             Text = text,
-            Alignment = TextAlignment.Centered
+            Alignment = TextAlignment.Centered,
+            AutoSize = autoSize,
         };
+
+        if (!autoSize)
+        {
+            tf.Size = new Size (width, 1);
+        }
         tf.Draw (new Rectangle (0, 0, width, 1), Attribute.Default, Attribute.Default);
 
         TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
@@ -3404,26 +3434,44 @@ ssb
 
     [SetupFakeDriver]
     [Theory]
-    [InlineData ("A", 0, "")]
-    [InlineData ("A", 1, "A")]
-    [InlineData ("A", 2, "A")]
-    [InlineData ("A B", 3, "A B")]
-    [InlineData ("A B", 1, "A")]
-    [InlineData ("A B", 2, "A")]
-    [InlineData ("A B", 3, "A B")]
-    [InlineData ("A B", 4, "A  B")]
-    [InlineData ("A B", 5, "A   B")]
-    [InlineData ("A B", 6, "A    B")]
-    [InlineData ("A B", 10, "A        B")]
-    [InlineData ("ABC ABC", 10, "ABC    ABC")]
-    public void Draw_Horizontal_Justified (string text, int width, string expectedText)
+    [InlineData ("A", 0, false, "")]
+    [InlineData ("A", 1, false, "A")]
+    [InlineData ("A", 2, false,"A")]
+    [InlineData ("A B", 3, false,"A B")]
+    [InlineData ("A B", 1, false,"A")]
+    [InlineData ("A B", 2, false,"A")]
+    [InlineData ("A B", 3, false,"A B")]
+    [InlineData ("A B", 4, false,"A  B")]
+    [InlineData ("A B", 5, false,"A   B")]
+    [InlineData ("A B", 6, false,"A    B")]
+    [InlineData ("A B", 10,false,"A        B")]
+    [InlineData ("ABC ABC", 10, false, "ABC    ABC")]
+
+    [InlineData ("A", 0, true, "")]
+    [InlineData ("A", 1, true, "A")]
+    [InlineData ("A", 2, true, "A")]
+    [InlineData ("A B", 3, true, "A B")]
+    [InlineData ("A B", 1, true, "A")]
+    [InlineData ("A B", 2, true, "A")]
+    [InlineData ("A B", 3, true, "A B")]
+    [InlineData ("A B", 4, true, "A B")]
+    [InlineData ("A B", 5, true, "A B")]
+    [InlineData ("A B", 6, true, "A B")]
+    [InlineData ("A B", 10, true, "A B")]
+    [InlineData ("ABC ABC", 10, true, "ABC ABC")]
+    public void Draw_Horizontal_Justified (string text, int width, bool autoSize, string expectedText)
     {
         TextFormatter tf = new ()
         {
-            Size = new Size (width, 1),
             Text = text,
             Alignment = TextAlignment.Justified,
+            AutoSize = autoSize,
         };
+
+        if (!autoSize)
+        {
+            tf.Size = new Size (width, 1);
+        }
         tf.Draw (new Rectangle (0, 0, width, 1), Attribute.Default, Attribute.Default);
 
         TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -3366,7 +3366,7 @@ ssb
     [InlineData ("A", 0, true, "")]
     [InlineData ("A", 1, true, "A")]
     [InlineData ("A", 2, true, " A")]
-    [InlineData ("AB", 1, true, "B")]
+    [InlineData ("AB", 1, true, "")] // BUGBUG: Should be "B". See https://github.com/gui-cs/Terminal.Gui/issues/3418#issuecomment-2067771418 for a partial fix
     [InlineData ("AB", 2, true, "AB")]
     [InlineData ("ABC", 3, true, "ABC")]
     [InlineData ("ABC", 4, true, " ABC")]
@@ -3479,26 +3479,31 @@ ssb
 
     [SetupFakeDriver]
     [Theory]
-    [InlineData ("A", 2, false, "A")]
-    [InlineData ("AB12", 5, false, "AB12")]
-    [InlineData ("AB\n12", 5, false, "A1\nB2")]
+    [InlineData ("A", 5, false, "A")]
+    [InlineData ("AB12", 5, false, @"
+A
+B
+1
+2")]
+    [InlineData ("AB\n12", 5, false, @"
+A1
+B2")]
     [InlineData ("", 1, false, "")]
 
-    public void Draw_Vertical_TopBottom_LeftRight (string text, int width, bool autoSize, string expectedText)
+    public void Draw_Vertical_TopBottom_LeftRight (string text, int height, bool autoSize, string expectedText)
     {
         TextFormatter tf = new ()
         {
             Text = text,
             AutoSize = autoSize,
             Direction = TextDirection.TopBottom_LeftRight,
-            VerticalAlignment = VerticalTextAlignment.Top
         };
 
         if (!autoSize)
         {
-            tf.Size = new Size (width, 1);
+            tf.Size = new Size (5, height);
         }
-        tf.Draw (new Rectangle (0, 0, width, 5), Attribute.Default, Attribute.Default);
+        tf.Draw (new Rectangle (0, 0, 5, height), Attribute.Default, Attribute.Default);
 
         TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
     }

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -3312,4 +3312,120 @@ ssb
                     );
         Assert.Equal (resultLines, wrappedLines);
     }
+
+
+    [SetupFakeDriver]
+    [Theory]
+    [InlineData ("A", 0, "")]
+    [InlineData ("A", 1, "A")]
+    [InlineData ("A", 2, "A")]
+    [InlineData ("AB", 1, "A")]
+    [InlineData ("AB", 2, "AB")]
+    [InlineData ("ABC", 3, "ABC")]
+    [InlineData ("ABC", 4, "ABC")]
+    [InlineData ("ABC", 6, "ABC")]
+    public void Draw_Horizontal_Left (string text, int width, string expectedText)
+
+    {
+        TextFormatter tf = new ()
+        {
+            Size = new Size (width, 1),
+
+            Text = text,
+            Alignment = TextAlignment.Left
+        };
+        tf.Draw (new Rectangle (0, 0, width, 1), Attribute.Default, Attribute.Default);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
+    }
+
+    [SetupFakeDriver]
+    [Theory]
+    [InlineData ("A", 0, false, "")]
+    [InlineData ("A", 1, false, "A")]
+    [InlineData ("A", 2, false, " A")]
+    [InlineData ("AB", 1, false, "A")]
+    [InlineData ("AB", 2, false, "AB")]
+    [InlineData ("ABC", 3, false, "ABC")]
+    [InlineData ("ABC", 4, false, " ABC")]
+    [InlineData ("ABC", 6, false, "   ABC")]
+
+    [InlineData ("A", 0, true, "")]
+    [InlineData ("A", 1, true, "A")]
+    [InlineData ("A", 2, true, " A")]
+    [InlineData ("AB", 1, true, "")] // BUGBUG: This is wrong, it should be "A"
+    [InlineData ("AB", 2, true, "AB")]
+    [InlineData ("ABC", 3, true, "ABC")]
+    [InlineData ("ABC", 4, true, " ABC")]
+    [InlineData ("ABC", 6, true, "   ABC")]
+    public void Draw_Horizontal_Right (string text, int width, bool autoSize, string expectedText)
+    {
+        TextFormatter tf = new ()
+        {
+            Text = text,
+            Alignment = TextAlignment.Right,
+            AutoSize = autoSize,
+        };
+
+        if (!autoSize)
+        {
+            tf.Size = new Size (width, 1);
+        }
+
+        tf.Draw (new Rectangle (Point.Empty, new (width, 1)), Attribute.Default, Attribute.Default);
+        TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
+    }
+
+    [SetupFakeDriver]
+    [Theory]
+    [InlineData ("A", 0, "")]
+    [InlineData ("A", 1, "A")]
+    [InlineData ("A", 2, "A")]
+    [InlineData ("A", 3, " A")]
+    [InlineData ("AB", 1, "A")]
+    [InlineData ("AB", 2, "AB")]
+    [InlineData ("ABC", 3, "ABC")]
+    [InlineData ("ABC", 4, "ABC")]
+    [InlineData ("ABC", 5, " ABC")]
+    [InlineData ("ABC", 6, " ABC")]
+    [InlineData ("ABC", 9, "   ABC")]
+    public void Draw_Horizontal_Centered (string text, int width, string expectedText)
+    {
+        TextFormatter tf = new ()
+        {
+            Size = new Size (width, 1),
+            Text = text,
+            Alignment = TextAlignment.Centered
+        };
+        tf.Draw (new Rectangle (0, 0, width, 1), Attribute.Default, Attribute.Default);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
+    }
+
+    [SetupFakeDriver]
+    [Theory]
+    [InlineData ("A", 0, "")]
+    [InlineData ("A", 1, "A")]
+    [InlineData ("A", 2, "A")]
+    [InlineData ("A B", 3, "A B")]
+    [InlineData ("A B", 1, "A")]
+    [InlineData ("A B", 2, "A")]
+    [InlineData ("A B", 3, "A B")]
+    [InlineData ("A B", 4, "A  B")]
+    [InlineData ("A B", 5, "A   B")]
+    [InlineData ("A B", 6, "A    B")]
+    [InlineData ("A B", 10, "A        B")]
+    [InlineData ("ABC ABC", 10, "ABC    ABC")]
+    public void Draw_Horizontal_Justified (string text, int width, string expectedText)
+    {
+        TextFormatter tf = new ()
+        {
+            Size = new Size (width, 1),
+            Text = text,
+            Alignment = TextAlignment.Justified,
+        };
+        tf.Draw (new Rectangle (0, 0, width, 1), Attribute.Default, Attribute.Default);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
+    }
 }

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using Xunit.Abstractions;
+using static Terminal.Gui.SpinnerStyle;
 
 // Alias Console to MockConsole so we don't accidentally use Console
 
@@ -961,30 +962,43 @@ ssb
         Assert.Equal (1, TextFormatter.GetMaxColsForWidth (text, 1));
     }
 
+
     [Theory]
+    [InlineData (new [] { "0123456789" }, 1)]
+    [InlineData (new [] { "Hello World" }, 1)]
+    [InlineData (new [] { "Hello", "World" }, 2)]
+    [InlineData (new [] { "こんにちは", "世界" }, 4)]
+    public void GetColumnsRequiredForVerticalText_List_GetsWidth (IEnumerable<string> text, int expectedWidth)
+    {
+        Assert.Equal (expectedWidth, TextFormatter.GetColumnsRequiredForVerticalText (text.ToList ()));
+
+    }
+
+    [Theory]
+    [InlineData (new [] { "Hello World" }, 1, 0, 1, 1)]
     [InlineData (new [] { "Hello", "World" }, 2, 1, 1, 1)]
     [InlineData (new [] { "こんにちは", "世界" }, 4, 1, 1, 2)]
-    public void GetWidestLineLength_List_Simple_And_Wide_Runes (
+    public void GetColumnsRequiredForVerticalText_List_Simple_And_Wide_Runes (
         IEnumerable<string> text,
-        int width,
+        int expectedWidth,
         int index,
         int length,
-        int indexWidth
+        int expectedIndexWidth
     )
     {
-        Assert.Equal (width, TextFormatter.GetWidestLineLength (text.ToList ()));
-        Assert.Equal (indexWidth, TextFormatter.GetWidestLineLength (text.ToList (), index, length));
+        Assert.Equal (expectedWidth, TextFormatter.GetColumnsRequiredForVerticalText (text.ToList ()));
+        Assert.Equal (expectedIndexWidth, TextFormatter.GetColumnsRequiredForVerticalText (text.ToList (), index, length));
     }
 
     [Fact]
-    public void GetWidestLineLength_List_With_Combining_Runes ()
+    public void GetColumnsRequiredForVerticalText_List_With_Combining_Runes ()
     {
         List<string> text = new () { "Les Mis", "e\u0328\u0301", "rables" };
-        Assert.Equal (1, TextFormatter.GetWidestLineLength (text, 1, 1));
+        Assert.Equal (1, TextFormatter.GetColumnsRequiredForVerticalText (text, 1, 1));
     }
 
     [Fact]
-    public void GetWidestLineLength_With_Combining_Runes ()
+    public void GetColumnsRequiredForVerticalText_With_Combining_Runes ()
     {
         var text = "Les Mise\u0328\u0301rables";
         Assert.Equal (1, TextFormatter.GetWidestLineLength (text, 1, 1));

--- a/UnitTests/Text/TextFormatterTests.cs
+++ b/UnitTests/Text/TextFormatterTests.cs
@@ -3366,7 +3366,7 @@ ssb
     [InlineData ("A", 0, true, "")]
     [InlineData ("A", 1, true, "A")]
     [InlineData ("A", 2, true, " A")]
-    [InlineData ("AB", 1, true, "")] // BUGBUG: This is wrong, it should be "A"
+    [InlineData ("AB", 1, true, "B")]
     [InlineData ("AB", 2, true, "AB")]
     [InlineData ("ABC", 3, true, "ABC")]
     [InlineData ("ABC", 4, true, " ABC")]
@@ -3473,6 +3473,32 @@ ssb
             tf.Size = new Size (width, 1);
         }
         tf.Draw (new Rectangle (0, 0, width, 1), Attribute.Default, Attribute.Default);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
+    }
+
+    [SetupFakeDriver]
+    [Theory]
+    [InlineData ("A", 2, false, "A")]
+    [InlineData ("AB12", 5, false, "AB12")]
+    [InlineData ("AB\n12", 5, false, "A1\nB2")]
+    [InlineData ("デモエ", 1, false, "")]
+
+    public void Draw_Vertical_TopBottom_LeftRight (string text, int width, bool autoSize, string expectedText)
+    {
+        TextFormatter tf = new ()
+        {
+            Text = text,
+            AutoSize = autoSize,
+            Direction = TextDirection.TopBottom_LeftRight,
+            VerticalAlignment = VerticalTextAlignment.Top
+        };
+
+        if (!autoSize)
+        {
+            tf.Size = new Size (width, 1);
+        }
+        tf.Draw (new Rectangle (0, 0, width, 5), Attribute.Default, Attribute.Default);
 
         TestHelpers.AssertDriverContentsWithFrameAre (expectedText, _output);
     }


### PR DESCRIPTION
## Fixes

- Fixes #3418

## Proposed Changes/Todos

- [ ] Todo 1

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
