### PR TITLE
Fixes #3420 - Adding analyzers to solution and demonstrating simple use

### DIFF
--- a/Analyzers/Directory.build.props
+++ b/Analyzers/Directory.build.props
@@ -11,8 +11,8 @@
     <DefineTrace>True</DefineTrace>
   </PropertyGroup>
   <ItemGroup>
-      <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
-      <PackageReference Update="JetBrains.ExternalAnnotations" Version="10.2.147" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageReference Include="JetBrains.ExternalAnnotations" Version="10.2.147" />
   </ItemGroup>
   <ItemGroup>
       <Using Include="System.Buffers" />

--- a/Analyzers/Directory.build.props
+++ b/Analyzers/Directory.build.props
@@ -7,6 +7,8 @@
     <Deterministic>true</Deterministic>
     <UTF8OutPut>true</UTF8OutPut>
     <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS;CONTRACTS_FULL;CODE_ANALYSIS</DefineConstants>
+    <NoLogo>True</NoLogo>
+    <DefineTrace>True</DefineTrace>
   </PropertyGroup>
   <ItemGroup>
       <Using Include="System.Buffers" />

--- a/Analyzers/Directory.build.props
+++ b/Analyzers/Directory.build.props
@@ -11,6 +11,10 @@
     <DefineTrace>True</DefineTrace>
   </PropertyGroup>
   <ItemGroup>
+      <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
+      <PackageReference Update="JetBrains.ExternalAnnotations" Version="10.2.147" />
+  </ItemGroup>
+  <ItemGroup>
       <Using Include="System.Buffers" />
       <Using Include="System.Collections.Specialized" />
       <Using Include="System.Numerics" />

--- a/Analyzers/Directory.build.props
+++ b/Analyzers/Directory.build.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <WarningLevel>7</WarningLevel>
+    <CharacterSet>UTF-8</CharacterSet>
+    <Deterministic>true</Deterministic>
+    <UTF8OutPut>true</UTF8OutPut>
+    <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS;CONTRACTS_FULL;CODE_ANALYSIS</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+      <Using Include="System.Buffers" />
+      <Using Include="System.Collections.Specialized" />
+      <Using Include="System.Numerics" />
+      <Using Include="System.Runtime.CompilerServices" />
+  </ItemGroup>
+</Project>

--- a/Analyzers/Terminal.Gui.Analyzers.Internal.Debugging/Terminal.Gui.Analyzers.Internal.Debugging.csproj
+++ b/Analyzers/Terminal.Gui.Analyzers.Internal.Debugging/Terminal.Gui.Analyzers.Internal.Debugging.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" PrivateAssets="all" />

--- a/Analyzers/Terminal.Gui.Analyzers.Internal.Tests/Terminal.Gui.Analyzers.Internal.Tests.csproj
+++ b/Analyzers/Terminal.Gui.Analyzers.Internal.Tests/Terminal.Gui.Analyzers.Internal.Tests.csproj
@@ -4,15 +4,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12</LangVersion>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineTrace>True</DefineTrace>
     <DebugType>portable</DebugType>
     <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS;CONTRACTS_FULL;CODE_ANALYSIS</DefineConstants>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoLogo>True</NoLogo>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 

--- a/Analyzers/Terminal.Gui.Analyzers.Internal/Generators/EnumExtensions/EnumExtensionMethodsIncrementalGenerator.cs
+++ b/Analyzers/Terminal.Gui.Analyzers.Internal/Generators/EnumExtensions/EnumExtensionMethodsIncrementalGenerator.cs
@@ -260,8 +260,8 @@ public sealed class EnumExtensionMethodsIncrementalGenerator : IIncrementalGener
                                            ///     Used to enable source generation of a common set of extension methods for enum types.
                                            /// </summary>
                                            {{Strings.Templates.AttributesForGeneratedTypes}}
-                                           [System.AttributeUsageAttribute (System.AttributeTargets.Enum)]
-                                           public sealed class {{GeneratorAttributeName}} : Attribute
+                                           [{{Strings.DotnetNames.Types.AttributeUsageAttribute}} ({{Strings.DotnetNames.Types.AttributeTargets}}.Enum)]
+                                           public sealed class {{GeneratorAttributeName}} : {{Strings.DotnetNames.Types.Attribute}}
                                            {
                                                /// <summary>
                                                ///     The name of the generated static class.

--- a/Analyzers/Terminal.Gui.Analyzers.Internal/Terminal.Gui.Analyzers.Internal.csproj
+++ b/Analyzers/Terminal.Gui.Analyzers.Internal/Terminal.Gui.Analyzers.Internal.csproj
@@ -11,21 +11,14 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <LangVersion>12</LangVersion>
-        <Nullable>enable</Nullable>
         <RootNamespace>Terminal.Gui.Analyzers.Internal</RootNamespace>
         <ImplicitUsings>disable</ImplicitUsings>
         <InvariantGlobalization>true</InvariantGlobalization>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-        <AnalysisLevel>latest-recommended</AnalysisLevel>
-        <WarningLevel>7</WarningLevel>
-        <CharacterSet>UTF-8</CharacterSet>
         <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
-        <Deterministic>true</Deterministic>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-        <UTF8OutPut>true</UTF8OutPut>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-        <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS;CONTRACTS_FULL;CODE_ANALYSIS</DefineConstants>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <IsRoslynComponent>true</IsRoslynComponent>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
@@ -87,12 +80,4 @@
         </PackageReference>
         <PackageReference Include="Roslynator.CSharp" Version="4.12.1" PrivateAssets="all" />
     </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="System.Buffers" />
-        <Using Include="System.Collections.Specialized" />
-        <Using Include="System.Numerics" />
-        <Using Include="System.Runtime.CompilerServices" />
-    </ItemGroup>
-
 </Project>

--- a/Analyzers/Terminal.Gui.Analyzers.Internal/Terminal.Gui.Analyzers.Internal.csproj
+++ b/Analyzers/Terminal.Gui.Analyzers.Internal/Terminal.Gui.Analyzers.Internal.csproj
@@ -45,9 +45,9 @@
         <Compile Include="Compatibility/SetsRequiredMembersAttribute.cs" />             
         <Compile Include="Compatibility/NumericExtensions.cs" />
         <Compile Include="Compatibility/SkipLocalsInitAttribute.cs" />
-    </ItemGroup>                                                                        
+    </ItemGroup>
 
-  <ItemGroup>
+    <ItemGroup>
         <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
         <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     </ItemGroup>

--- a/Analyzers/Terminal.Gui.Analyzers.Internal/Terminal.Gui.Analyzers.Internal.csproj
+++ b/Analyzers/Terminal.Gui.Analyzers.Internal/Terminal.Gui.Analyzers.Internal.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <!-- 
-        Do not remove netstandard2.0 from the TargetFrameworks.
+        Do not remove netstandard2.0 from the TargetFramework.
         Visual Studio requires that Analyzers/Generators target netstandard2.0 to work properly.
-        Additional TFMs are for support of additional APIs and language features.
+        Also do not change this to TargetFrameworks without fully understanding the behavior change that implies.
         -->
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -32,36 +32,22 @@
         <Compile Remove="Compatibility/*.cs" />
     </ItemGroup>
 
-    <Choose>
-        <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
-            <PropertyGroup>
-                <!-- Disabling some useless warnings caused by the netstandard2.0 target -->
-                <NoWarn>$(NoWarn);nullable;CA1067</NoWarn>
-            </PropertyGroup>
-            <ItemGroup>                                                                         
-                <Compile Include="Compatibility/CompilerFeatureRequiredAttribute.cs" />         
-                <Compile Include="Compatibility/IsExternalInit.cs" />                           
-                <Compile Include="Compatibility/IEqualityOperators.cs" />
-                <Compile Include="Compatibility/NullableAttributes.cs" />                         
-                <Compile Include="Compatibility/RequiredMemberAttribute.cs" />                  
-                <Compile Include="Compatibility/SetsRequiredMembersAttribute.cs" />             
-            </ItemGroup>                                                                        
-            <ItemGroup>
-                <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" PrivateAssets="all" />
-                <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" PrivateAssets="all" />
-                <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" PrivateAssets="all" />
-            </ItemGroup>
-        </When>
-        <When Condition="'$(TargetFramework)' == 'net8.0'">
-        </When>
-    </Choose>
-    
-    <ItemGroup>
+    <PropertyGroup>
+        <!-- Disabling some useless warnings caused by the netstandard2.0 target -->
+        <NoWarn>$(NoWarn);nullable;CA1067</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>                                                                         
+        <Compile Include="Compatibility/CompilerFeatureRequiredAttribute.cs" />         
+        <Compile Include="Compatibility/IsExternalInit.cs" />                           
+        <Compile Include="Compatibility/IEqualityOperators.cs" />
+        <Compile Include="Compatibility/NullableAttributes.cs" />                         
+        <Compile Include="Compatibility/RequiredMemberAttribute.cs" />                  
+        <Compile Include="Compatibility/SetsRequiredMembersAttribute.cs" />             
         <Compile Include="Compatibility/NumericExtensions.cs" />
         <Compile Include="Compatibility/SkipLocalsInitAttribute.cs" />
-    </ItemGroup>
+    </ItemGroup>                                                                        
 
-    <ItemGroup>
+  <ItemGroup>
         <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
         <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     </ItemGroup>
@@ -79,5 +65,8 @@
             <!--<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
         </PackageReference>
         <PackageReference Include="Roslynator.CSharp" Version="4.12.1" PrivateAssets="all" />
+        <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" PrivateAssets="all" />
+        <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" PrivateAssets="all" />
+        <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/Scripts/Terminal.Gui.PowerShell.Analyzers.psm1
+++ b/Scripts/Terminal.Gui.PowerShell.Analyzers.psm1
@@ -55,43 +55,34 @@ Function Build-Analyzers {
     return
   }
   
-  New-Variable -Name solutionRoot -Visibility Public -Value (Resolve-Path ..)
-  Push-Location $solutionRoot
-  New-Variable -Name solutionFile -Visibility Public -Value (Resolve-Path ./Terminal.sln)
-  $mainProjectRoot = Resolve-Path ./Terminal.Gui
-  $mainProjectFile = Join-Path $mainProjectRoot Terminal.Gui.csproj
-  $analyzersRoot = Resolve-Path ./Analyzers
-  $internalAnalyzersProjectRoot = Join-Path $analyzersRoot Terminal.Gui.Analyzers.Internal
-  $internalAnalyzersProjectFile = Join-Path $internalAnalyzersProjectRoot Terminal.Gui.Analyzers.Internal.csproj
+  Push-Location $InternalAnalyzersProjectDirectory
   
   if(!$NoClean) {
     if(!$Quiet) {
       Write-Host Deleting bin and obj folders for Terminal.Gui
     }
-    if(Test-Path $mainProjectRoot/bin) {
-      Remove-Item -Recurse -Force $mainProjectRoot/bin
-      Remove-Item -Recurse -Force $mainProjectRoot/obj
-    }
+    Remove-Item -Recurse -Force $TerminalGuiProjectDirectory/bin -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $TerminalGuiProjectDirectory/obj -ErrorAction SilentlyContinue
 
     if(!$Quiet) {
       Write-Host Deleting bin and obj folders for Terminal.Gui.InternalAnalyzers
     }
-    if(Test-Path $internalAnalyzersProjectRoot/bin) {
-      Remove-Item -Recurse -Force $internalAnalyzersProjectRoot/bin
-      Remove-Item -Recurse -Force $internalAnalyzersProjectRoot/obj
-    }
+    Remove-Item -Recurse -Force $InternalAnalyzersProjectDirectory/bin -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $InternalAnalyzersProjectDirectory/obj -ErrorAction SilentlyContinue
   }
   
   if(!$Quiet) {
     Write-Host Building analyzers in Debug configuration
   }
-  dotnet build $internalAnalyzersProjectFile --no-incremental --nologo --force --configuration Debug
+  dotnet build $InternalAnalyzersProjectFilePath --no-incremental --nologo --force --configuration Debug
 
   if(!$Quiet) {
     Write-Host Building analyzers in Release configuration
   }
-  dotnet build $internalAnalyzersProjectFile --no-incremental --nologo --force --configuration Release
+  dotnet build $InternalAnalyzersProjectFilePath --no-incremental --nologo --force --configuration Release
 
+  Pop-Location
+  
   if(!$AutoLaunch) {
     Write-Host -ForegroundColor Green Finished. Restart Visual Studio for changes to take effect.
   } else {

--- a/Scripts/Terminal.Gui.PowerShell.Core.psm1
+++ b/Scripts/Terminal.Gui.PowerShell.Core.psm1
@@ -69,6 +69,9 @@ Function Set-PowerShellEnvironment {
   New-Variable -Name SolutionFilePath -Value (Join-Path -Resolve $RepositoryRootDirectory "Terminal.sln") -Option ReadOnly -Scope Global -Visibility Public
   New-Variable -Name TerminalGuiProjectDirectory -Value (Join-Path -Resolve $RepositoryRootDirectory "Terminal.Gui") -Option ReadOnly -Scope Global -Visibility Public
   New-Variable -Name TerminalGuiProjectFilePath -Value (Join-Path -Resolve $TerminalGuiProjectDirectory "Terminal.Gui.csproj") -Option ReadOnly -Scope Global -Visibility Public
+  New-Variable -Name AnalyzersDirectory -Value (Join-Path -Resolve $RepositoryRootDirectory "Analyzers") -Option ReadOnly -Scope Global -Visibility Public
+  New-Variable -Name InternalAnalyzersProjectDirectory -Value (Join-Path -Resolve $AnalyzersDirectory "Terminal.Gui.Analyzers.Internal") -Option ReadOnly -Scope Global -Visibility Public
+  New-Variable -Name InternalAnalyzersProjectFilePath -Value (Join-Path -Resolve $InternalAnalyzersProjectDirectory "Terminal.Gui.Analyzers.Internal.csproj") -Option ReadOnly -Scope Global -Visibility Public
 
   # Set a custom prompt to indicate we're in our modified environment.
   # Save the normal one first, though.
@@ -145,6 +148,9 @@ Function Reset-PowerShellEnvironment {
   Remove-Variable -Name TerminalGuiProjectDirectory -Scope Global -Force -ErrorAction SilentlyContinue
   Remove-Variable -Name TerminalGuiProjectFilePath -Scope Global -Force -ErrorAction SilentlyContinue
   Remove-Variable -Name ScriptsDirectory -Scope Global -Force -ErrorAction SilentlyContinue
+  Remove-Variable -Name AnalyzersDirectory -Scope Global -Force -ErrorAction SilentlyContinue
+  Remove-Variable -Name InternalAnalyzersProjectDirectory -Scope Global -Force -ErrorAction SilentlyContinue
+  Remove-Variable -Name InternalAnalyzersProjectFilePath -Scope Global -Force -ErrorAction SilentlyContinue
 }
 
 # This ensures the environment is reset when unloading the module.

--- a/Scripts/Terminal.Gui.PowerShell.Core.psm1
+++ b/Scripts/Terminal.Gui.PowerShell.Core.psm1
@@ -14,17 +14,18 @@ Function Open-Solution {
   [CmdletBinding()]
   param(
     [Parameter(Mandatory=$false, HelpMessage="The path to the solution file to open.")]
-    [Uri]$SolutionFilePath = (Resolve-Path "../Terminal.sln")
+    [ValidatePattern(".*Terminal\.sln" )]
+    [string]$Path = $SolutionFilePath
   )
   
   if(!$IsWindows) {
     [string]$warningMessage = "The Open-Solution cmdlet is only supported on Windows.`n`
-    Attempt to open file $SolutionFilePath with the system default handler?"
+    Attempt to open file $Path with the system default handler?"
     
     Write-Warning $warningMessage -WarningAction Inquire
   }
   
-  Invoke-Item $SolutionFilePath
+  Invoke-Item $Path
   return
 }
 
@@ -61,6 +62,13 @@ Function Close-Solution {
 Function Set-PowerShellEnvironment {
   [CmdletBinding()]
   param()
+
+  # Set up some common globals
+  New-Variable -Name ScriptsDirectory -Value $PSScriptRoot -Option ReadOnly -Scope Global -Visibility Public
+  New-Variable -Name RepositoryRootDirectory -Value (Join-Path -Resolve $ScriptsDirectory "..") -Option ReadOnly -Scope Global -Visibility Public
+  New-Variable -Name SolutionFilePath -Value (Join-Path -Resolve $RepositoryRootDirectory "Terminal.sln") -Option ReadOnly -Scope Global -Visibility Public
+  New-Variable -Name TerminalGuiProjectDirectory -Value (Join-Path -Resolve $RepositoryRootDirectory "Terminal.Gui") -Option ReadOnly -Scope Global -Visibility Public
+  New-Variable -Name TerminalGuiProjectFilePath -Value (Join-Path -Resolve $TerminalGuiProjectDirectory "Terminal.Gui.csproj") -Option ReadOnly -Scope Global -Visibility Public
 
   # Set a custom prompt to indicate we're in our modified environment.
   # Save the normal one first, though.
@@ -132,6 +140,11 @@ Function Reset-PowerShellEnvironment {
   }
 
   Remove-Variable -Name PathVarSeparator -Scope Global -Force -ErrorAction SilentlyContinue
+  Remove-Variable -Name RepositoryRootDirectory -Scope Global -Force -ErrorAction SilentlyContinue
+  Remove-Variable -Name SolutionFilePath -Scope Global -Force -ErrorAction SilentlyContinue
+  Remove-Variable -Name TerminalGuiProjectDirectory -Scope Global -Force -ErrorAction SilentlyContinue
+  Remove-Variable -Name TerminalGuiProjectFilePath -Scope Global -Force -ErrorAction SilentlyContinue
+  Remove-Variable -Name ScriptsDirectory -Scope Global -Force -ErrorAction SilentlyContinue
 }
 
 # This ensures the environment is reset when unloading the module.

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <!-- =================================================================== -->
   <!-- Version numbers -->
   <!-- Automatically updated by gitversion (run `dotnet-gitversion /updateprojectfiles`)  -->
@@ -45,7 +45,7 @@
   <!-- =================================================================== -->
   <ItemGroup>
     <PackageReference Include="ColorHelper" Version="1.8.1" />
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All" />
     <!-- Enable Nuget Source Link for github -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.IO.Abstractions" Version="21.0.2" />

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -18,7 +18,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineTrace>True</DefineTrace>
     <DebugType>portable</DebugType>
-    <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS;CONTRACTS_FULL</DefineConstants>
+    <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS;CONTRACTS_FULL;CODE_ANALYSIS</DefineConstants>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoLogo>True</NoLogo>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
@@ -46,18 +46,26 @@
   <ItemGroup>
     <PackageReference Include="ColorHelper" Version="1.8.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
     <!-- Enable Nuget Source Link for github -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.IO.Abstractions" Version="21.0.2" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />
     <PackageReference Include="Wcwidth" Version="2.0.0" />
+    <ProjectReference Include="..\Analyzers\Terminal.Gui.Analyzers.Internal\Terminal.Gui.Analyzers.Internal.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <!-- =================================================================== -->
   <!-- Global Usings and Type Aliases -->
   <!-- =================================================================== -->
   <ItemGroup>
     <Using Include="JetBrains.Annotations" />
-    <Using Include="System.Diagnostics.Contracts.PureAttribute" Alias="PureAttribute" />
+    <Using Include="JetBrains.Annotations.PureAttribute" Alias="PureAttribute" />
     <Using Include="System.Drawing" />
     <Using Include="System.Text" />
   </ItemGroup>

--- a/Terminal.Gui/View/Adornment/Adornment.cs
+++ b/Terminal.Gui/View/Adornment/Adornment.cs
@@ -244,7 +244,7 @@ public class Adornment : View
     protected internal override bool OnMouseLeave (MouseEvent mouseEvent)
     {
         // Invert Normal
-        if (Diagnostics.HasFlag (ViewDiagnosticFlags.MouseEnter) && ColorScheme != null)
+        if (Diagnostics.FastHasFlags (ViewDiagnosticFlags.MouseEnter) && ColorScheme != null)
         {
             var cs = new ColorScheme (ColorScheme)
             {

--- a/Terminal.Gui/View/ViewDiagnostics.cs
+++ b/Terminal.Gui/View/ViewDiagnostics.cs
@@ -1,8 +1,11 @@
 ﻿
+using Terminal.Gui.Analyzers.Internal.Attributes;
+
 namespace Terminal.Gui;
 
 /// <summary>Enables diagnostic functions for <see cref="View"/>.</summary>
 [Flags]
+[GenerateEnumExtensionMethods(FastHasFlags = true)]
 public enum ViewDiagnosticFlags : uint
 {
     /// <summary>All diagnostics off</summary>

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -34,9 +34,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Analyzers", "Analyzers", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terminal.Gui.Analyzers.Internal", "Analyzers\Terminal.Gui.Analyzers.Internal\Terminal.Gui.Analyzers.Internal.csproj", "{5DE91722-8765-4E2B-97E4-2A18010B5CED}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terminal.Gui.Analyzers.Internal.Tests", "Analyzers\Terminal.Gui.Analyzers.Internal.Tests\Terminal.Gui.Analyzers.Internal.Tests.csproj", "{715DB4BA-F989-4DF6-B46F-5ED26A32B2DD}"
+EndProject
 Global
 	GlobalSection(NestedProjects) = preSolution
 		{5DE91722-8765-4E2B-97E4-2A18010B5CED} = {CCADA0BC-61CF-4B4B-96BA-A3B0C0A7F54D}
+		{715DB4BA-F989-4DF6-B46F-5ED26A32B2DD} = {CCADA0BC-61CF-4B4B-96BA-A3B0C0A7F54D}
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +54,10 @@ Global
 		{5DE91722-8765-4E2B-97E4-2A18010B5CED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5DE91722-8765-4E2B-97E4-2A18010B5CED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5DE91722-8765-4E2B-97E4-2A18010B5CED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{715DB4BA-F989-4DF6-B46F-5ED26A32B2DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{715DB4BA-F989-4DF6-B46F-5ED26A32B2DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{715DB4BA-F989-4DF6-B46F-5ED26A32B2DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{715DB4BA-F989-4DF6-B46F-5ED26A32B2DD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -30,6 +30,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		testenvironments.json = testenvironments.json
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Analyzers", "Analyzers", "{CCADA0BC-61CF-4B4B-96BA-A3B0C0A7F54D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,15 +66,16 @@ Global
 		SolutionGuid = {9F8F8A4D-7B8D-4C2A-AC5E-CD7117F74C03}
 	EndGlobalSection
 EndGlobal
-CPU.ActiveCfg = Release|Any CPU
-		{B0A602CD-E176-449D-8663-64238D54F857}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B0A602CD-E176-449D-8663-64238D54F857}.Release|x86.ActiveCfg = Release|Any CPU
-		{B0A602CD-E176-449D-8663-64238D54F857}.Release|x86.Build.0 = Release|Any CPU
+uild.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9F8F8A4D-7B8D-4C2A-AC5E-CD7117F74C03}
+	EndGlobalSection
+EndGlobal
+nsibilityGlobals) = postSolution
 		SolutionGuid = {9F8F8A4D-7B8D-4C2A-AC5E-CD7117F74C03}
 	EndGlobalSection
 EndGlobal

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -33,48 +33,38 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Debug|x86.Build.0 = Debug|Any CPU
 		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Release|x86.ActiveCfg = Release|Any CPU
-		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Release|x86.Build.0 = Release|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{88979F89-9A42-448F-AE3E-3060145F6375}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{88979F89-9A42-448F-AE3E-3060145F6375}.Debug|x86.Build.0 = Debug|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Release|Any CPU.Build.0 = Release|Any CPU
-		{88979F89-9A42-448F-AE3E-3060145F6375}.Release|x86.ActiveCfg = Release|Any CPU
-		{88979F89-9A42-448F-AE3E-3060145F6375}.Release|x86.Build.0 = Release|Any CPU
 		{8B901EDE-8974-4820-B100-5226917E2990}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8B901EDE-8974-4820-B100-5226917E2990}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8B901EDE-8974-4820-B100-5226917E2990}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{8B901EDE-8974-4820-B100-5226917E2990}.Debug|x86.Build.0 = Debug|Any CPU
 		{8B901EDE-8974-4820-B100-5226917E2990}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B901EDE-8974-4820-B100-5226917E2990}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8B901EDE-8974-4820-B100-5226917E2990}.Release|x86.ActiveCfg = Release|Any CPU
-		{8B901EDE-8974-4820-B100-5226917E2990}.Release|x86.Build.0 = Release|Any CPU
 		{44E15B48-0DB2-4560-82BD-D3B7989811C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{44E15B48-0DB2-4560-82BD-D3B7989811C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{44E15B48-0DB2-4560-82BD-D3B7989811C3}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{44E15B48-0DB2-4560-82BD-D3B7989811C3}.Debug|x86.Build.0 = Debug|Any CPU
 		{44E15B48-0DB2-4560-82BD-D3B7989811C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44E15B48-0DB2-4560-82BD-D3B7989811C3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{44E15B48-0DB2-4560-82BD-D3B7989811C3}.Release|x86.ActiveCfg = Release|Any CPU
-		{44E15B48-0DB2-4560-82BD-D3B7989811C3}.Release|x86.Build.0 = Release|Any CPU
 		{B0A602CD-E176-449D-8663-64238D54F857}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B0A602CD-E176-449D-8663-64238D54F857}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B0A602CD-E176-449D-8663-64238D54F857}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{B0A602CD-E176-449D-8663-64238D54F857}.Debug|x86.Build.0 = Debug|Any CPU
 		{B0A602CD-E176-449D-8663-64238D54F857}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0A602CD-E176-449D-8663-64238D54F857}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9F8F8A4D-7B8D-4C2A-AC5E-CD7117F74C03}
+	EndGlobalSection
+EndGlobal
+CPU.ActiveCfg = Release|Any CPU
 		{B0A602CD-E176-449D-8663-64238D54F857}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B0A602CD-E176-449D-8663-64238D54F857}.Release|x86.ActiveCfg = Release|Any CPU
 		{B0A602CD-E176-449D-8663-64238D54F857}.Release|x86.Build.0 = Release|Any CPU
@@ -84,35 +74,5 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F8F8A4D-7B8D-4C2A-AC5E-CD7117F74C03}
-	EndGlobalSection
-	GlobalSection(MonoDevelopProperties) = preSolution
-		Policies = $0
-		$0.TextStylePolicy = $1
-		$1.FileWidth = 80
-		$1.scope = text/x-csharp
-		$1.TabWidth = 8
-		$1.IndentWidth = 8
-		$0.CSharpFormattingPolicy = $2
-		$2.scope = text/x-csharp
-		$2.IndentSwitchSection = False
-		$2.NewLinesForBracesInTypes = False
-		$2.NewLinesForBracesInProperties = False
-		$2.NewLinesForBracesInAccessors = False
-		$2.NewLinesForBracesInAnonymousMethods = False
-		$2.NewLinesForBracesInControlBlocks = False
-		$2.NewLinesForBracesInAnonymousTypes = False
-		$2.NewLinesForBracesInObjectCollectionArrayInitializers = False
-		$2.NewLinesForBracesInLambdaExpressionBody = False
-		$2.NewLineForElse = False
-		$2.NewLineForCatch = False
-		$2.NewLineForFinally = False
-		$2.NewLineForMembersInObjectInit = False
-		$2.NewLineForMembersInAnonymousTypes = False
-		$2.NewLineForClausesInQuery = False
-		$2.SpacingAfterMethodDeclarationName = True
-		$2.SpaceAfterMethodCallName = True
-		$2.SpaceBeforeOpenSquareBracket = True
-		$0.DotNetNamingPolicy = $3
-		$0.StandardHeader = $4
 	EndGlobalSection
 EndGlobal

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -36,10 +36,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terminal.Gui.Analyzers.Inte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terminal.Gui.Analyzers.Internal.Tests", "Analyzers\Terminal.Gui.Analyzers.Internal.Tests\Terminal.Gui.Analyzers.Internal.Tests.csproj", "{715DB4BA-F989-4DF6-B46F-5ED26A32B2DD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terminal.Gui.Analyzers.Internal.Debugging", "Analyzers\Terminal.Gui.Analyzers.Internal.Debugging\Terminal.Gui.Analyzers.Internal.Debugging.csproj", "{C2AD09BD-D579-45A7-ACA3-E4EF3BC027D2}"
+EndProject
 Global
 	GlobalSection(NestedProjects) = preSolution
 		{5DE91722-8765-4E2B-97E4-2A18010B5CED} = {CCADA0BC-61CF-4B4B-96BA-A3B0C0A7F54D}
 		{715DB4BA-F989-4DF6-B46F-5ED26A32B2DD} = {CCADA0BC-61CF-4B4B-96BA-A3B0C0A7F54D}
+		{C2AD09BD-D579-45A7-ACA3-E4EF3BC027D2} = {CCADA0BC-61CF-4B4B-96BA-A3B0C0A7F54D}
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -74,6 +77,10 @@ Global
 		{B0A602CD-E176-449D-8663-64238D54F857}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0A602CD-E176-449D-8663-64238D54F857}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0A602CD-E176-449D-8663-64238D54F857}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2AD09BD-D579-45A7-ACA3-E4EF3BC027D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2AD09BD-D579-45A7-ACA3-E4EF3BC027D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2AD09BD-D579-45A7-ACA3-E4EF3BC027D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2AD09BD-D579-45A7-ACA3-E4EF3BC027D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -32,7 +32,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Analyzers", "Analyzers", "{CCADA0BC-61CF-4B4B-96BA-A3B0C0A7F54D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terminal.Gui.Analyzers.Internal", "Analyzers\Terminal.Gui.Analyzers.Internal\Terminal.Gui.Analyzers.Internal.csproj", "{5DE91722-8765-4E2B-97E4-2A18010B5CED}"
+EndProject
 Global
+	GlobalSection(NestedProjects) = preSolution
+		{5DE91722-8765-4E2B-97E4-2A18010B5CED} = {CCADA0BC-61CF-4B4B-96BA-A3B0C0A7F54D}
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -42,6 +47,10 @@ Global
 		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00F366F8-DEE4-482C-B9FD-6DB0200B79E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DE91722-8765-4E2B-97E4-2A18010B5CED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DE91722-8765-4E2B-97E4-2A18010B5CED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DE91722-8765-4E2B-97E4-2A18010B5CED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DE91722-8765-4E2B-97E4-2A18010B5CED}.Release|Any CPU.Build.0 = Release|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88979F89-9A42-448F-AE3E-3060145F6375}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -63,19 +72,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {9F8F8A4D-7B8D-4C2A-AC5E-CD7117F74C03}
-	EndGlobalSection
-EndGlobal
-uild.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {9F8F8A4D-7B8D-4C2A-AC5E-CD7117F74C03}
-	EndGlobalSection
-EndGlobal
-nsibilityGlobals) = postSolution
 		SolutionGuid = {9F8F8A4D-7B8D-4C2A-AC5E-CD7117F74C03}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Alrighty, y'all.

This PR is the next phase of introducing the analyzers.

I made some refinements to the PowerShell modules to make them handle paths better, so it doesn't do things like change your current working directory without going back after it finishes.

But the major item is that the Analyzer, in its current state, is now part of the solution, along with its companion debug project and a unit test project for it.

I also annotated an existing enum with the generator attribute and changed a usage of that enum to use the generated code in one place, as a demonstration of it in use.

Remember: Before you open the solution for the first time after pulling this, import the Terminal.Gui.PowerShell.psd1 module and then run `Build-Analyzers` (optionally also with other supported switches it has available - I typically run it as `Build-Analyzers -AutoClose -AutoLaunch -Force -NoClean`).

Next phase will most likely be including the BitVector32 stuff I mentioned.

This is ready to go if it looks good to y'all.

## Fixes

- Fixes #3420

## Proposed Changes/Todos

- [x] Additional refinements to PowerShell modules
- [x] Add the new analyzer projects to the solution
- [x] Wire the analyzer up to the Terminal.Gui project and show a simple use

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
   - The generator documents code it writes.
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
