### PR TITLE
Fixes #3464 - dont alter ps prompt on module import or remove

### DIFF
--- a/Scripts/Terminal.Gui.PowerShell.Core.psm1
+++ b/Scripts/Terminal.Gui.PowerShell.Core.psm1
@@ -73,12 +73,6 @@ Function Set-PowerShellEnvironment {
   New-Variable -Name InternalAnalyzersProjectDirectory -Value (Join-Path -Resolve $AnalyzersDirectory "Terminal.Gui.Analyzers.Internal") -Option ReadOnly -Scope Global -Visibility Public
   New-Variable -Name InternalAnalyzersProjectFilePath -Value (Join-Path -Resolve $InternalAnalyzersProjectDirectory "Terminal.Gui.Analyzers.Internal.csproj") -Option ReadOnly -Scope Global -Visibility Public
 
-  # Set a custom prompt to indicate we're in our modified environment.
-  # Save the normal one first, though.
-  # And save it as ReadOnly and without the -Force parameter, so this will be skipped if run more than once in the same session without a reset.
-  New-Variable -Name NormalPrompt -Option ReadOnly -Scope Global -Value (Get-Item Function:prompt).ScriptBlock -ErrorAction SilentlyContinue
-  Set-Item Function:prompt { "TGPS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "; }
-
   # Save existing PSModulePath for optional reset later.
   # If it is already saved, do not overwrite, but continue anyway.
   New-Variable -Name OriginalPSModulePath -Visibility Public -Option ReadOnly -Scope Global -Value ($Env:PSModulePath) -ErrorAction SilentlyContinue
@@ -130,11 +124,6 @@ Function Reset-PowerShellEnvironment {
 
   if($Exit) {
     [Environment]::Exit(0)
-  }
-
-  if(Get-Variable -Name NormalPrompt -Scope Global -ErrorAction SilentlyContinue){
-    Set-Item Function:prompt $NormalPrompt
-    Remove-Variable -Name NormalPrompt -Scope Global -Force -ErrorAction SilentlyContinue
   }
 
   if(Get-Variable -Name OriginalPSModulePath -Scope Global -ErrorAction SilentlyContinue){


### PR DESCRIPTION
All set

## Fixes

- Fixes #3464

## Proposed Changes/Todos

- [x] Remove prompt function re-mapping in Terminal.Gui.PowerShell.Core.psm1

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
