### PR TITLE
Fixes #3467. Views without subviews can't show the cursor.

### DIFF
--- a/Terminal.Gui/Application.cs
+++ b/Terminal.Gui/Application.cs
@@ -574,9 +574,15 @@ public static partial class Application
 
         if (mostFocused is null)
         {
-            return false;
+            if (view is { HasFocus: true })
+            {
+                mostFocused = view;
+            }
+            else
+            {
+                return false;
+            }
         }
-
 
         // If the view is not visible or enabled, don't position the cursor
         if (!mostFocused.Visible || !mostFocused.Enabled)
@@ -598,7 +604,6 @@ public static partial class Application
             return false;
         }
 
-        Point? prevCursor = new (Driver.Row, Driver.Col);
         Point? cursor = mostFocused.PositionCursor ();
 
         Driver.GetCursorVisibility (out CursorVisibility currentCursorVisibility);

--- a/UnitTests/Application/CursorTests.cs
+++ b/UnitTests/Application/CursorTests.cs
@@ -111,7 +111,7 @@ public class CursorTests
         Assert.False (Application.PositionCursor (view));
     }
 
-    [Fact, Trait("BUGBUG", "Views without subviews don't support Focused or MostFocused")]
+    [Fact]
     [SetupFakeDriver]
     public void PositionCursor_Focused_With_Position_Returns_True ()
     {
@@ -124,7 +124,7 @@ public class CursorTests
         view.CanFocus = true;
         view.SetFocus ();
         view.TestLocation = new Point (0, 0);
-        Assert.False (Application.PositionCursor (view));  // BUGBUG: This should be true
+        Assert.True (Application.PositionCursor (view));
     }
 
     [Fact]
@@ -144,5 +144,4 @@ public class CursorTests
         Application.Driver.GetCursorVisibility (out CursorVisibility cursor);
         Assert.Equal (CursorVisibility.Invisible, cursor);
     }
-
 }


### PR DESCRIPTION
## Fixes

- Fixes #3467

## Proposed Changes/Todos

- [x] View with focus and without subviews also can show the cursor if applicable

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
