### PR TITLE
Fixes #3475. FakeConsole throws System.IndexOutOfRangeException using SetupFakeDriverAttribute.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -40,6 +40,28 @@ public class FakeDriver : ConsoleDriver
     public static Behaviors FakeBehaviors = new ();
     public override bool SupportsTrueColor => false;
 
+    /// <inheritdoc />
+    public override int Cols
+    {
+        get => base.Cols;
+        internal set
+        {
+            base.Cols = value;
+            FakeConsole.SetBufferSize (Cols, Rows);
+        }
+    }
+
+    /// <inheritdoc />
+    public override int Rows
+    {
+        get => base.Rows;
+        internal set
+        {
+            base.Rows = value;
+            FakeConsole.SetBufferSize (Cols, Rows);
+        }
+    }
+
     public FakeDriver ()
     {
         Cols = FakeConsole.WindowWidth = FakeConsole.BufferWidth = FakeConsole.WIDTH;

--- a/UnitTests/TestHelpers.cs
+++ b/UnitTests/TestHelpers.cs
@@ -171,6 +171,8 @@ public class SetupFakeDriverAttribute : BeforeAfterTestAttribute
         Debug.WriteLine ($"Before: {methodUnderTest.Name}");
         Assert.Null (Application.Driver);
         Application.Driver = new FakeDriver { Rows = 25, Cols = 25 };
+        Assert.Equal (FakeConsole.BufferWidth, Application.Driver.Cols);
+        Assert.Equal (FakeConsole.BufferHeight, Application.Driver.Rows);
         base.Before (methodUnderTest);
     }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3475

## Proposed Changes/Todos

- [x] Override Cols and Rows to resize the FakeConsole BufferWidth/BufferHeight

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
