### PR TITLE
v1 Fixes #2897. ListView ListWrapper - marking does work if you give an IList which in which the count changes

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -749,6 +749,11 @@ namespace Terminal.Gui {
 		public void EnsureSelectedItemVisible ()
 		{
 			SuperView?.LayoutSubviews ();
+			// If last item is selected and is removed, ensures a valid selected item
+			if (Source != null && selected > Source.Count - 1) {
+				SelectedItem = Source.Count - 1;
+				SetNeedsDisplay ();
+			}
 			if (selected < top) {
 				top = selected;
 			} else if (Frame.Height > 0 && selected >= top + Frame.Height) {
@@ -831,10 +836,29 @@ namespace Terminal.Gui {
 		}
 
 		/// <inheritdoc/>
-		public int Count => src != null ? src.Count : 0;
+		public int Count {
+			get {
+				CheckAndResizeMarksIfRequired ();
+				return src?.Count ?? 0;
+			}
+		}
 
 		/// <inheritdoc/>
 		public int Length => len;
+
+		void CheckAndResizeMarksIfRequired ()
+		{
+			if (count != src.Count) {
+				count = src.Count;
+				BitArray newMarks = new BitArray (count);
+				for (var i = 0; i < Math.Min (marks.Length, newMarks.Length); i++) {
+					newMarks [i] = marks [i];
+				}
+				marks = newMarks;
+
+				len = GetMaxLengthItem ();
+			}
+		}
 
 		int GetMaxLengthItem ()
 		{
@@ -896,7 +920,7 @@ namespace Terminal.Gui {
 		/// <inheritdoc/>
 		public bool IsMarked (int item)
 		{
-			if (item >= 0 && item < count)
+			if (item >= 0 && item < Count)
 				return marks [item];
 			return false;
 		}
@@ -904,7 +928,7 @@ namespace Terminal.Gui {
 		/// <inheritdoc/>
 		public void SetMark (int item, bool value)
 		{
-			if (item >= 0 && item < count)
+			if (item >= 0 && item < Count)
 				marks [item] = value;
 		}
 

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -848,7 +848,7 @@ namespace Terminal.Gui {
 
 		void CheckAndResizeMarksIfRequired ()
 		{
-			if (count != src.Count) {
+			if (src != null && count != src.Count) {
 				count = src.Count;
 				BitArray newMarks = new BitArray (count);
 				for (var i = 0; i < Math.Min (marks.Length, newMarks.Length); i++) {

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -601,10 +601,12 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public virtual bool MoveEnd ()
 		{
-			if (source.Count > 0 && selected != source.Count - 1) {
+			if (source?.Count > 0 && selected != source.Count - 1) {
 				selected = source.Count - 1;
 				if (top + selected > Frame.Height - 1) {
-					top = selected;
+					top = selected < Frame.Height - 1
+						? Math.Max (Frame.Height - selected + 1, 0)
+						: Math.Max (selected - Frame.Height + 1, 0);
 				}
 				OnSelectedChanged ();
 				SetNeedsDisplay ();

--- a/UnitTests/Views/ListViewTests.cs
+++ b/UnitTests/Views/ListViewTests.cs
@@ -300,16 +300,16 @@ namespace Terminal.Gui.ViewTests {
 			Assert.Equal (19, lv.SelectedItem);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 ┌──────────┐
+│Line10    │
+│Line11    │
+│Line12    │
+│Line13    │
+│Line14    │
+│Line15    │
+│Line16    │
+│Line17    │
+│Line18    │
 │Line19    │
-│          │
-│          │
-│          │
-│          │
-│          │
-│          │
-│          │
-│          │
-│          │
 └──────────┘", output);
 
 			Assert.True (lv.ScrollUp (20));


### PR DESCRIPTION
## Fixes

- Fixes #2897

## Proposed Changes/Todos

- [x] This is only a work around because List<T> doesn't raise any event when a item is added or removed

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working


Copy and paste this code on a scenario and it will work as expected because the `listView.MoveEnd()` call on Add and the `listView.EnsureSelectedItemVisible()` call on Remove will ensures that the `Source.Count` will be read and will update the `count`, `marks` and `len` private fields.

```cs
		public override void Setup ()
		{
			var count = 0;
			var source = new List<string> ();

			var listView = new ListView {
				Width = 20,
				Height = Dim.Fill (),
				AllowsMarking = true,
				AllowsMultipleSelection = true,
				Source = new ListWrapper (source)
			};
			Win.Add (listView);

			var btnAdd = new Button ("_Add Item") {
				X = Pos.Center (),
				Y = Pos.Center ()
			};
			btnAdd.Clicked += () => {
				source.Add($"Item{count}");
				count++;
				listView.MoveEnd ();
			};
			Win.Add (btnAdd);

			var btnRemove = new Button ("_Remove Item") {
				X = Pos.Center (),
				Y = Pos.Center () + 1
			};
			btnRemove.Clicked += () => {
				if (source.Count > 0) {
					source.Remove (source [listView.SelectedItem]);
					listView.EnsureSelectedItemVisible ();
				}
			};
			Win.Add (btnRemove);
		}

```