### PR TITLE
Fixes #3536. Application.Run<T> is broken by not calling Init before initializing T.

### DIFF
--- a/Terminal.Gui/Application/Application.cs
+++ b/Terminal.Gui/Application/Application.cs
@@ -679,6 +679,12 @@ public static partial class Application
     public static T Run<T> (Func<Exception, bool> errorHandler = null, ConsoleDriver driver = null)
         where T : Toplevel, new ()
     {
+        if (!_initialized)
+        {
+            // Init() has NOT been called.
+            InternalInit (driver, null, true);
+        }
+
         var top = new T ();
 
         Run (top, errorHandler, driver);
@@ -708,7 +714,10 @@ public static partial class Application
     ///         <see cref="RunLoop(RunState)"/> method will only process any pending events, timers, idle handlers and then
     ///         return control immediately.
     ///     </para>
-    ///     <para>Calling <see cref="Init"/> first is not needed as this function will initialize the application.</para>
+    ///     <para>Calling <see cref="Init"/> first is not needed if only <see cref="Run{T}"/> or
+    ///         <see cref="Run(System.Func{System.Exception,bool},Terminal.Gui.ConsoleDriver)"/>
+    ///         has been used, otherwise it's needed to call <see cref="Init"/> first.
+    ///     </para>
     ///     <para>
     ///         RELEASE builds only: When <paramref name="errorHandler"/> is <see langword="null"/> any exceptions will be
     ///         rethrown. Otherwise, if <paramref name="errorHandler"/> will be called. If <paramref name="errorHandler"/>
@@ -746,7 +755,9 @@ public static partial class Application
         else
         {
             // Init() has NOT been called.
-            InternalInit (driver, null, true);
+            throw new InvalidOperationException (
+                                                 "Init() has not been called. Only Run() or Run<T>() can be used without calling Init()."
+                                                );
         }
 
         var resume = true;

--- a/Terminal.Gui/Application/Application.cs
+++ b/Terminal.Gui/Application/Application.cs
@@ -686,7 +686,7 @@ public static partial class Application
 
         var top = new T ();
 
-        Run (top, errorHandler, driver);
+        Run (top, errorHandler);
 
         return top;
     }
@@ -729,12 +729,7 @@ public static partial class Application
     ///     RELEASE builds only: Handler for any unhandled exceptions (resumes when returns true,
     ///     rethrows when null).
     /// </param>
-    /// <param name="driver">
-    ///     The <see cref="ConsoleDriver"/> to use. If not specified the default driver for the platform will
-    ///     be used ( <see cref="WindowsDriver"/>, <see cref="CursesDriver"/>, or <see cref="NetDriver"/>). Must be
-    ///     <see langword="null"/> if <see cref="Init"/> was called.
-    /// </param>
-    public static void Run (Toplevel view, Func<Exception, bool> errorHandler = null, ConsoleDriver driver = null)
+    public static void Run (Toplevel view, Func<Exception, bool> errorHandler = null)
     {
         ArgumentNullException.ThrowIfNull (view);
 

--- a/Terminal.Gui/Application/Application.cs
+++ b/Terminal.Gui/Application/Application.cs
@@ -713,9 +713,9 @@ public static partial class Application
     ///         <see cref="RunLoop(RunState)"/> method will only process any pending events, timers, idle handlers and then
     ///         return control immediately.
     ///     </para>
-    ///     <para>Calling <see cref="Init"/> first is not needed if only <see cref="Run{T}"/> or
+    ///     <para>When using <see cref="Run{T}"/> or
     ///         <see cref="Run(System.Func{System.Exception,bool},Terminal.Gui.ConsoleDriver)"/>
-    ///         has been used, otherwise it's needed to call <see cref="Init"/> first.
+    ///         <see cref="Init"/> will be called automatically.
     ///     </para>
     ///     <para>
     ///         RELEASE builds only: When <paramref name="errorHandler"/> is <see langword="null"/> any exceptions will be

--- a/Terminal.Gui/Application/Application.cs
+++ b/Terminal.Gui/Application/Application.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
-using System.Text.Json.Serialization;
 
 namespace Terminal.Gui;
 

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -962,7 +962,7 @@ public class ApplicationTests
 
         Assert.Null (Application.Top);
 
-        Assert.Throws<InvalidOperationException> (() => Application.Run (new (), null, driver));
+        Assert.Throws<InvalidOperationException> (() => Application.Run (new Toplevel ()));
 
         Application.Init (driver);
         Application.Iteration += (s, e) =>
@@ -970,7 +970,7 @@ public class ApplicationTests
                                      Assert.NotNull (Application.Top);
                                      Application.RequestStop ();
                                  };
-        Application.Run (new (), null, driver);
+        Application.Run (new Toplevel ());
 #if DEBUG_IDISPOSABLE
         Assert.False (Application.Top.WasDisposed);
         Exception exception = Record.Exception (Application.Shutdown);


### PR DESCRIPTION
## Fixes

- Fixes #3536

## Proposed Changes/Todos

- [x] Call first `InternalInit` before initialize `T`
- [x] Throwing exception if not `_initialized` on the `Application.Run(new(Toplevel))`

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
