### PR TITLE
Fixes #3545. Superview most focused view not sync with the overlapped view.

### DIFF
--- a/Terminal.Gui/Application/Application.cs
+++ b/Terminal.Gui/Application/Application.cs
@@ -530,6 +530,7 @@ public static partial class Application
         toplevel.LayoutSubviews ();
         toplevel.PositionToplevels ();
         toplevel.FocusFirst ();
+        BringOverlappedTopToFront ();
 
         if (refreshDriver)
         {

--- a/Terminal.Gui/View/ViewSubViews.cs
+++ b/Terminal.Gui/View/ViewSubViews.cs
@@ -438,7 +438,7 @@ public partial class View
                 SetHasFocus (false, this);
                 SuperView?.EnsureFocus ();
 
-                if (SuperView is { } && SuperView.Focused is null)
+                if (SuperView is { Focused: null })
                 {
                     SuperView.FocusNext ();
 
@@ -476,6 +476,11 @@ public partial class View
                             view._addingView = false;
                         }
                     }
+                }
+
+                if (this is Toplevel && Application.Current.Focused != this)
+                {
+                    Application.BringOverlappedTopToFront ();
                 }
             }
 

--- a/Terminal.Gui/Views/ToplevelOverlapped.cs
+++ b/Terminal.Gui/Views/ToplevelOverlapped.cs
@@ -67,7 +67,7 @@ public static partial class Application
 
         View top = FindTopFromView (Top?.MostFocused);
 
-        if (top is Toplevel && Top.Subviews.Count > 1 && Top.Subviews [Top.Subviews.Count - 1] != top)
+        if (top is Toplevel && Top.Subviews.Count > 1 && Top.Subviews [^1] != top)
         {
             Top.BringSubviewToFront (top);
         }

--- a/UnitTests/Application/KeyboardTests.cs
+++ b/UnitTests/Application/KeyboardTests.cs
@@ -193,7 +193,7 @@ public class KeyboardTests
         Assert.True (win.HasFocus);
         Assert.True (win2.CanFocus);
         Assert.False (win2.HasFocus);
-        Assert.Equal ("win2", ((Window)top.Subviews [^1]).Title);
+        Assert.Equal ("win", ((Window)top.Subviews [^1]).Title);
 
         win.CanFocus = false;
         Assert.False (win.CanFocus);
@@ -220,7 +220,7 @@ public class KeyboardTests
 
     [Fact]
     [AutoInitShutdown]
-    public void EnsuresTopOnFront_CanFocus_True_By_Keyboard_ ()
+    public void EnsuresTopOnFront_CanFocus_True_By_Keyboard ()
     {
         Toplevel top = new ();
 
@@ -253,7 +253,7 @@ public class KeyboardTests
         Assert.True (win.HasFocus);
         Assert.True (win2.CanFocus);
         Assert.False (win2.HasFocus);
-        Assert.Equal ("win2", ((Window)top.Subviews [^1]).Title);
+        Assert.Equal ("win", ((Window)top.Subviews [^1]).Title);
 
         top.NewKeyDownEvent (Key.Tab.WithCtrl);
         Assert.True (win.CanFocus);


### PR DESCRIPTION
## Fixes

- Fixes #3545

## Proposed Changes/Todos

- [x] Calling BringOverlappedTopToFront method on the Application.Begin.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
