### PR TITLE
Fixes #3545. V1 Superview most focused view not sync with the overlapped view.

### DIFF
--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -1037,6 +1037,7 @@ namespace Terminal.Gui {
 			toplevel.LayoutSubviews ();
 			toplevel.PositionToplevels ();
 			toplevel.WillPresent ();
+			EnsuresTopOnFront ();
 			if (refreshDriver) {
 				MdiTop?.OnChildLoaded (toplevel);
 				toplevel.OnLoaded ();

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -394,6 +394,10 @@ namespace Terminal.Gui {
 								}
 							}
 						}
+
+						if (SuperView is Toplevel && Application.Current?.Focused != SuperView) {
+							Application.EnsuresTopOnFront ();
+						}
 					}
 					OnCanFocusChanged ();
 					SetNeedsDisplay ();

--- a/Terminal.Gui/Core/Window.cs
+++ b/Terminal.Gui/Core/Window.cs
@@ -104,7 +104,7 @@ namespace Terminal.Gui {
 
 			public override void OnCanFocusChanged ()
 			{
-				if (MostFocused == null && CanFocus && Visible) {
+				if (HasFocus && MostFocused == null && CanFocus && Visible) {
 					EnsureFocus ();
 				}
 

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -771,28 +771,28 @@ namespace Terminal.Gui.ApplicationTests {
 			Assert.True (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.False (win2.HasFocus);
-			Assert.Equal ("win2", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win", ((Window)top.Subviews [^1]).Title);
 
 			top.ProcessKey (new KeyEvent (Key.CtrlMask | Key.Tab, new KeyModifiers ()));
 			Assert.True (win.CanFocus);
 			Assert.False (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.True (win2.HasFocus);
-			Assert.Equal ("win2", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win2", ((Window)top.Subviews [^1]).Title);
 
 			top.ProcessKey (new KeyEvent (Key.CtrlMask | Key.Tab, new KeyModifiers ()));
 			Assert.True (win.CanFocus);
 			Assert.True (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.False (win2.HasFocus);
-			Assert.Equal ("win", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win", ((Window)top.Subviews [^1]).Title);
 
 			win2.MouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Pressed });
 			Assert.True (win.CanFocus);
 			Assert.False (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.True (win2.HasFocus);
-			Assert.Equal ("win2", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win2", ((Window)top.Subviews [^1]).Title);
 			win2.MouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Released });
 			Assert.Null (Toplevel.dragPosition);
 		}
@@ -816,35 +816,35 @@ namespace Terminal.Gui.ApplicationTests {
 			Assert.True (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.False (win2.HasFocus);
-			Assert.Equal ("win2", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win", ((Window)top.Subviews [^1]).Title);
 
 			win.CanFocus = false;
 			Assert.False (win.CanFocus);
 			Assert.False (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.True (win2.HasFocus);
-			Assert.Equal ("win2", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win2", ((Window)top.Subviews [^1]).Title);
 
 			top.ProcessKey (new KeyEvent (Key.CtrlMask | Key.Tab, new KeyModifiers ()));
 			Assert.True (win2.CanFocus);
 			Assert.False (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.True (win2.HasFocus);
-			Assert.Equal ("win2", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win2", ((Window)top.Subviews [^1]).Title);
 
 			top.ProcessKey (new KeyEvent (Key.CtrlMask | Key.Tab, new KeyModifiers ()));
 			Assert.False (win.CanFocus);
 			Assert.False (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.True (win2.HasFocus);
-			Assert.Equal ("win2", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win2", ((Window)top.Subviews [^1]).Title);
 
 			win.MouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Pressed });
 			Assert.False (win.CanFocus);
 			Assert.False (win.HasFocus);
 			Assert.True (win2.CanFocus);
 			Assert.True (win2.HasFocus);
-			Assert.Equal ("win2", ((Window)top.Subviews [top.Subviews.Count - 1]).Title);
+			Assert.Equal ("win2", ((Window)top.Subviews [^1]).Title);
 			win2.MouseEvent (new MouseEvent () { Flags = MouseFlags.Button1Released });
 			Assert.Null (Toplevel.dragPosition);
 		}


### PR DESCRIPTION
## Fixes

- Fixes #3545

## Proposed Changes/Todos

- [x] Calling EnsuresTopOnFront method on the Application.Begin.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
