### PR TITLE
Fixes #3516. Changes default `QuitKey` to `Esc`

### DIFF
--- a/Terminal.Gui/Input/ShortcutHelper.cs
+++ b/Terminal.Gui/Input/ShortcutHelper.cs
@@ -2,6 +2,7 @@
 
 namespace Terminal.Gui;
 
+// TODO: Nuke when #2975 is completed
 /// <summary>Represents a helper to manipulate shortcut keys used on views.</summary>
 public class ShortcutHelper
 {
@@ -114,8 +115,6 @@ public class ShortcutHelper
         {
             return true;
         }
-
-        Debug.WriteLine ($"WARNING: {Key.ToString (key)} is not a valid shortcut key.");
 
         return false;
     }

--- a/Terminal.Gui/Resources/config.json
+++ b/Terminal.Gui/Resources/config.json
@@ -18,7 +18,7 @@
 
   "Application.AlternateBackwardKey": "Ctrl+PageUp",
   "Application.AlternateForwardKey": "Ctrl+PageDown",
-  "Application.QuitKey": "Ctrl+Q",
+  "Application.QuitKey": "Esc",
   "Application.IsMouseDisabled": false,
   "Theme": "Default",
   "Themes": [

--- a/Terminal.Gui/Resources/config.json
+++ b/Terminal.Gui/Resources/config.json
@@ -10,7 +10,8 @@
   // note that not all values here will be recreated (e.g. the Light and Dark themes and any property initialized
   // null).
   //
-  "$schema": "https://gui-cs.github.io/Terminal.Gui/schemas/tui-config-schema.json",
+  // TODO: V2 - Reference via http
+  "$schema": "../../docfx/schemas/tui-config-schema.json",
 
   // Set this to true in a .config file to be loaded to cause JSON parsing errors
   // to throw exceptions. 
@@ -19,7 +20,6 @@
   "Application.AlternateBackwardKey": "Ctrl+PageUp",
   "Application.AlternateForwardKey": "Ctrl+PageDown",
   "Application.QuitKey": "Esc",
-  "Application.IsMouseDisabled": false,
   "Theme": "Default",
   "Themes": [
     {

--- a/Terminal.Gui/View/ViewKeyboard.cs
+++ b/Terminal.Gui/View/ViewKeyboard.cs
@@ -745,8 +745,8 @@ public partial class View
     /// <summary>
     /// Returns true if Key is bound in this view heirarchy. For debugging
     /// </summary>
-    /// <param name="key"></param>
-    /// <param name="boundView"></param>
+    /// <param name="key">The key to test.</param>
+    /// <param name="boundView">Returns the view the key is bound to.</param>
     /// <returns></returns>
     public bool IsHotKeyKeyBound (Key key, out View boundView)
     {

--- a/Terminal.Gui/View/ViewKeyboard.cs
+++ b/Terminal.Gui/View/ViewKeyboard.cs
@@ -633,6 +633,7 @@ public partial class View
     ///     <para>See <see href="../docs/keyboard.md">for an overview of Terminal.Gui keyboard APIs.</see></para>
     /// </remarks>
     /// <param name="keyEvent">Contains the details about the key that produced the event.</param>
+    /// <param name="scope">The scope.</param>
     /// <returns>
     ///     <see langword="false"/> if the key press was not handled. <see langword="true"/> if the keypress was handled
     ///     and no other view should see it.
@@ -745,6 +746,7 @@ public partial class View
     /// Returns true if Key is bound in this view heirarchy. For debugging
     /// </summary>
     /// <param name="key"></param>
+    /// <param name="boundView"></param>
     /// <returns></returns>
     public bool IsHotKeyKeyBound (Key key, out View boundView)
     {
@@ -779,6 +781,7 @@ public partial class View
     ///     <para>See <see href="../docs/keyboard.md">for an overview of Terminal.Gui keyboard APIs.</see></para>
     /// </summary>
     /// <param name="key">The key event passed.</param>
+    /// <param name="scope">The scope.</param>
     /// <returns>
     ///     <see langword="null"/> if no command was bound the <paramref name="key"/>. <see langword="true"/> if
     ///     commands were invoked and at least one handled the command. <see langword="false"/> if commands were invoked and at

--- a/Terminal.Gui/Views/Dialog.cs
+++ b/Terminal.Gui/Views/Dialog.cs
@@ -10,8 +10,8 @@ namespace Terminal.Gui;
 /// <remarks>
 ///     To run the <see cref="Dialog"/> modally, create the <see cref="Dialog"/>, and pass it to
 ///     <see cref="Application.Run(Toplevel, Func{Exception, bool})"/>. This will execute the dialog until
-///     it terminates via the
-///     [ESC] or [CTRL-Q] key, or when one of the views or buttons added to the dialog calls
+///     it terminates via the <see cref="Application.QuitKey"/> (`Esc` by default),
+///     or when one of the views or buttons added to the dialog calls
 ///     <see cref="Application.RequestStop"/>.
 /// </remarks>
 public class Dialog : Window

--- a/Terminal.Gui/Views/Line.cs
+++ b/Terminal.Gui/Views/Line.cs
@@ -11,8 +11,6 @@ public class Line : View
         SuperViewRendersLineCanvas = true;
     }
 
-    public Dim Length { get; set; } = Dim.Fill ();
-
     private Orientation _orientation;
 
     /// <summary>
@@ -30,12 +28,9 @@ public class Line : View
             {
                 case Orientation.Horizontal:
                     Height = 1;
-                    // Width = Length;
-                    //Border.Thickness = new Thickness (1, 0, 1, 0);
 
                     break;
                 case Orientation.Vertical:
-                    Height = Length;
                     Width = 1;
 
                     break;

--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -631,7 +631,7 @@ public class Shortcut : View
     ///     - if the user presses the HotKey specified by CommandView
     ///     - if HasFocus and the user presses Space or Enter (or any other key bound to Command.Accept).
     /// </summary>
-    protected new bool? OnAccept (CommandContext ctx)
+    protected bool? OnAccept (CommandContext ctx)
     {
         var cancel = false;
 

--- a/Terminal.Gui/Views/Slider.cs
+++ b/Terminal.Gui/Views/Slider.cs
@@ -1743,7 +1743,7 @@ public class Slider<T> : View
         return true;
     }
 
-    internal bool Accept ()
+    internal new bool Accept ()
     {
         SetFocusedOption ();
 

--- a/UICatalog/Resources/config.json
+++ b/UICatalog/Resources/config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://gui-cs.github.io/Terminal.Gui/schemas/tui-config-schema.json",
-  "Application.QuitKey": "Esc",
   "FileDialog.MaxSearchResults": 10000,
   "FileDialogStyle.DefaultUseColors": false,
   "FileDialogStyle.DefaultUseUnicodeCharacters": false,

--- a/UICatalog/Scenario.cs
+++ b/UICatalog/Scenario.cs
@@ -271,7 +271,7 @@ public class Scenario : IDisposable
 
     /// <summary>Defines the category names used to categorize a <see cref="Scenario"/></summary>
     [AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
-    public class ScenarioCategory (string Name) : System.Attribute
+    public class ScenarioCategory (string name) : System.Attribute
     {
         /// <summary>Static helper function to get the <see cref="Scenario"/> Categories given a Type</summary>
         /// <param name="t"></param>
@@ -291,15 +291,15 @@ public class Scenario : IDisposable
         public static string GetName (Type t) { return ((ScenarioCategory)GetCustomAttributes (t) [0]).Name; }
 
         /// <summary>Category Name</summary>
-        public string Name { get; set; } = Name;
+        public string Name { get; set; } = name;
     }
 
     /// <summary>Defines the metadata (Name and Description) for a <see cref="Scenario"/></summary>
     [AttributeUsage (AttributeTargets.Class)]
-    public class ScenarioMetadata (string Name, string Description) : System.Attribute
+    public class ScenarioMetadata (string name, string description) : System.Attribute
     {
         /// <summary><see cref="Scenario"/> Description</summary>
-        public string Description { get; set; } = Description;
+        public string Description { get; set; } = description;
 
         /// <summary>Static helper function to get the <see cref="Scenario"/> Description given a Type</summary>
         /// <param name="t"></param>
@@ -312,6 +312,6 @@ public class Scenario : IDisposable
         public static string GetName (Type t) { return ((ScenarioMetadata)GetCustomAttributes (t) [0]).Name; }
 
         /// <summary><see cref="Scenario"/> Name</summary>
-        public string Name { get; set; } = Name;
+        public string Name { get; set; } = name;
     }
 }

--- a/UICatalog/Scenarios/KeyBindings.cs
+++ b/UICatalog/Scenarios/KeyBindings.cs
@@ -54,11 +54,13 @@ public sealed class KeyBindings : Scenario
             Height = Dim.Auto (DimAutoStyle.Text),
             HotKeySpecifier = (Rune)'_',
             Title = "_KeyBindingsDemo",
-            Text = @"These keys will cause this view to show a message box:
-- Hotkey: k, K, Alt-K, Alt-Shift-K
-- Focused: F3
-- Application: F4
-Pressing Ctrl-Q will cause it to quit the app.",
+            Text = $"""
+                    These keys will cause this view to show a message box:
+                    - Hotkey: k, K, Alt-K, Alt-Shift-K
+                    - Focused: F3
+                    - Application: F4
+                    Pressing Esc or {Application.QuitKey} will cause it to quit the app.
+                    """,
             BorderStyle = LineStyle.Dashed
         };
         appWindow.Add (keyBindingsDemo);

--- a/UICatalog/Scenarios/MenuBarScenario.cs
+++ b/UICatalog/Scenarios/MenuBarScenario.cs
@@ -57,16 +57,14 @@ public class MenuBarScenario : Scenario
                                          ),
                                      null,
 
-                                     // Don't use Ctrl-Q so we can disambiguate between quitting and closing the toplevel
+                                     // Don't use Application.Quit so we can disambiguate between quitting and closing the toplevel
                                      new (
                                           "_Quit",
                                           "",
                                           () => actionFn ("Quit"),
                                           null,
                                           null,
-                                          KeyCode.AltMask
-                                          | KeyCode.CtrlMask
-                                          | KeyCode.Q
+                                          KeyCode.CtrlMask | KeyCode.Q
                                          )
                                  }
                                 ),

--- a/UICatalog/Scenarios/SingleBackgroundWorker.cs
+++ b/UICatalog/Scenarios/SingleBackgroundWorker.cs
@@ -203,7 +203,7 @@ public class SingleBackgroundWorker : Scenario
 
             _top.KeyDown += (s, e) =>
                             {
-                                // Prevents Ctrl+Q from closing this.
+                                // Prevents App.QuitKey from closing this.
                                 // Only Ctrl+C is allowed.
                                 if (e == Application.QuitKey)
                                 {

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -484,7 +484,7 @@ internal class UICatalogApp
                                           {
                                               ((CheckBox)ShForce16Colors.CommandView).Checked =
                                                   Application.Force16Colors = (bool)!((CheckBox)ShForce16Colors.CommandView).Checked!;
-                                              MiForce16Colors.Checked = Application.Force16Colors;
+                                              MiForce16Colors!.Checked = Application.Force16Colors;
                                               Application.Refresh ();
 
                                           };

--- a/UnitTests/Application/KeyboardTests.cs
+++ b/UnitTests/Application/KeyboardTests.cs
@@ -36,31 +36,32 @@ public class KeyboardTests
         Application.Begin (top);
         top.Running = true;
 
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
-        Application.Driver.SendKeys ('Q', ConsoleKey.Q, false, false, true);
+        Key prevKey = Application.QuitKey;
+
+        Application.OnKeyDown (Application.QuitKey);
         Assert.True (isQuiting);
 
         isQuiting = false;
-        Application.OnKeyDown (Key.Q.WithCtrl);
+        Application.OnKeyDown (Application.QuitKey);
         Assert.True (isQuiting);
 
         isQuiting = false;
         Application.QuitKey = Key.C.WithCtrl;
-        Application.Driver.SendKeys ('Q', ConsoleKey.Q, false, false, true);
+        Application.OnKeyDown (prevKey); // Should not quit
         Assert.False (isQuiting);
-        Application.OnKeyDown (Key.Q.WithCtrl);
+        Application.OnKeyDown (Key.Q.WithCtrl);// Should not quit
         Assert.False (isQuiting);
 
         Application.OnKeyDown (Application.QuitKey);
         Assert.True (isQuiting);
 
         // Reset the QuitKey to avoid throws errors on another tests
-        Application.QuitKey = Key.Q.WithCtrl;
+        Application.QuitKey = prevKey;
         top.Dispose ();
     }
 
     [Fact]
-    public void QuitKey_Default_Is_CtrlQ ()
+    public void QuitKey_Default_Is_Esc ()
     {
         Application.ResetState (true);
         // Before Init
@@ -68,7 +69,7 @@ public class KeyboardTests
 
         Application.Init (new FakeDriver ());
         // After Init
-        Assert.Equal (Key.Q.WithCtrl, Application.QuitKey);
+        Assert.Equal (Key.Esc, Application.QuitKey);
 
         Application.Shutdown();
     }
@@ -397,6 +398,8 @@ public class KeyboardTests
         // Setup some fake keypresses (This)
         var input = "Tests";
 
+        Key originalQuitKey = Application.QuitKey;
+        Application.QuitKey = Key.Q.WithCtrl;
         // Put a control-q in at the end
         FakeConsole.MockKeyPresses.Push (new ConsoleKeyInfo ('Q', ConsoleKey.Q, false, false, true));
 
@@ -458,6 +461,7 @@ public class KeyboardTests
                      };
 
         Application.Run (top);
+        Application.QuitKey = originalQuitKey;
 
         // Input string should match output
         Assert.Equal (input, output);

--- a/UnitTests/Configuration/ConfigurationMangerTests.cs
+++ b/UnitTests/Configuration/ConfigurationMangerTests.cs
@@ -166,7 +166,7 @@ public class ConfigurationManagerTests
             fired = true;
 
             // assert
-            Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, ((Key)Settings ["Application.QuitKey"].PropertyValue).KeyCode);
+            Assert.Equal (Key.Esc, ((Key)Settings ["Application.QuitKey"].PropertyValue).KeyCode);
 
             Assert.Equal (
                           KeyCode.PageDown | KeyCode.CtrlMask,
@@ -250,7 +250,7 @@ public class ConfigurationManagerTests
         // assert
         Assert.NotEmpty (Themes);
         Assert.Equal ("Default", Themes.Theme);
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
+        Assert.Equal (Key.Esc, Application.QuitKey);
         Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, Application.AlternateForwardKey.KeyCode);
         Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, Application.AlternateBackwardKey.KeyCode);
         Assert.False (Application.IsMouseDisabled);
@@ -271,7 +271,7 @@ public class ConfigurationManagerTests
         // assert
         Assert.NotEmpty (Themes);
         Assert.Equal ("Default", Themes.Theme);
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
+        Assert.Equal (KeyCode.Esc, Application.QuitKey.KeyCode);
         Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, Application.AlternateForwardKey.KeyCode);
         Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, Application.AlternateBackwardKey.KeyCode);
         Assert.False (Application.IsMouseDisabled);
@@ -436,9 +436,6 @@ public class ConfigurationManagerTests
     public void TestConfigurationManagerInitDriver ()
     {
         Assert.Equal ("Default", Themes.Theme);
-        Assert.True (Themes.ContainsKey ("Default"));
-
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
 
         Assert.Equal (new Color (Color.White), Colors.ColorSchemes ["Base"].Normal.Foreground);
         Assert.Equal (new Color (Color.Blue), Colors.ColorSchemes ["Base"].Normal.Background);
@@ -804,7 +801,7 @@ public class ConfigurationManagerTests
 
         Settings.Update (json, "TestConfigurationManagerUpdateFromJson");
 
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey.KeyCode);
+        Assert.Equal (KeyCode.Esc, Application.QuitKey.KeyCode);
         Assert.Equal (KeyCode.Z | KeyCode.AltMask, ((Key)Settings ["Application.QuitKey"].PropertyValue).KeyCode);
 
         Assert.Equal ("Default", Themes.Theme);

--- a/UnitTests/Configuration/SettingsScopeTests.cs
+++ b/UnitTests/Configuration/SettingsScopeTests.cs
@@ -9,7 +9,7 @@ public class SettingsScopeTests
     public void Apply_ShouldApplyProperties ()
     {
         // arrange
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, ((Key)Settings ["Application.QuitKey"].PropertyValue).KeyCode);
+        Assert.Equal (Key.Esc, (Key)Settings ["Application.QuitKey"].PropertyValue);
 
         Assert.Equal (
                       KeyCode.PageDown | KeyCode.CtrlMask,

--- a/UnitTests/UICatalog/ScenarioTests.cs
+++ b/UnitTests/UICatalog/ScenarioTests.cs
@@ -7,8 +7,6 @@ namespace UICatalog.Tests;
 
 public class ScenarioTests : TestsAllViews
 {
-    private readonly ITestOutputHelper _output;
-
     public ScenarioTests (ITestOutputHelper output)
     {
 #if DEBUG_IDISPOSABLE
@@ -17,11 +15,7 @@ public class ScenarioTests : TestsAllViews
         _output = output;
     }
 
-    public static IEnumerable<object []> AllScenarioTypes =>
-        typeof (Scenario).Assembly
-                     .GetTypes ()
-                     .Where (type => type.IsClass && !type.IsAbstract && type.IsSubclassOf (typeof (Scenario)))
-                     .Select (type => new object [] { type });
+    private readonly ITestOutputHelper _output;
 
     private object _timeoutLock;
 
@@ -34,17 +28,17 @@ public class ScenarioTests : TestsAllViews
     public void All_Scenarios_Quit_And_Init_Shutdown_Properly (Type scenarioType)
     {
         Assert.Null (_timeoutLock);
-        _timeoutLock = new object ();
+        _timeoutLock = new ();
 
         // If a previous test failed, this will ensure that the Application is in a clean state
         Application.ResetState (true);
 
         _output.WriteLine ($"Running Scenario '{scenarioType}'");
-        Scenario scenario = (Scenario)Activator.CreateInstance (scenarioType);
+        var scenario = (Scenario)Activator.CreateInstance (scenarioType);
 
         uint abortTime = 1500;
-        bool initialized = false;
-        bool shutdown = false;
+        var initialized = false;
+        var shutdown = false;
         object timeout = null;
 
         Application.InitializedChanged += OnApplicationOnInitializedChanged;
@@ -65,7 +59,6 @@ public class ScenarioTests : TestsAllViews
             }
         }
 
-
         Assert.True (initialized);
         Assert.True (shutdown);
 
@@ -80,24 +73,19 @@ public class ScenarioTests : TestsAllViews
 
         return;
 
-
         void OnApplicationOnInitializedChanged (object s, StateEventArgs<bool> a)
         {
             if (a.NewValue)
             {
-                Assert.Equal (Key.Q.WithCtrl, Application.QuitKey);
-
                 Application.Iteration += OnApplicationOnIteration;
                 initialized = true;
+
                 lock (_timeoutLock)
                 {
                     timeout = Application.AddTimeout (TimeSpan.FromMilliseconds (abortTime), ForceCloseCallback);
                 }
+
                 _output.WriteLine ($"Initialized '{Application.Driver}'");
-                //Dictionary<Key, List<View>> bindings = Application.GetKeyBindings ();
-                //Assert.NotEmpty (bindings);
-                //_output.WriteLine ($"bindings: {string.Join (",", bindings.Keys)}");
-                //Assert.True (bindings.ContainsKey (Application.QuitKey));
             }
             else
             {
@@ -116,10 +104,12 @@ public class ScenarioTests : TestsAllViews
                     timeout = null;
                 }
             }
+
             Assert.Fail (
                          $"'{scenario.GetName ()}' failed to Quit with {Application.QuitKey} after {abortTime}ms. Force quit.");
 
             Application.ResetState (true);
+
             return false;
         }
 
@@ -133,6 +123,12 @@ public class ScenarioTests : TestsAllViews
             }
         }
     }
+
+    public static IEnumerable<object []> AllScenarioTypes =>
+        typeof (Scenario).Assembly
+                         .GetTypes ()
+                         .Where (type => type.IsClass && !type.IsAbstract && type.IsSubclassOf (typeof (Scenario)))
+                         .Select (type => new object [] { type });
 
     [Fact]
     public void Run_All_Views_Tester_Scenario ()
@@ -563,7 +559,7 @@ public class ScenarioTests : TestsAllViews
                 && view.GetType ().GetProperty ("Source") != null
                 && view.GetType ().GetProperty ("Source").PropertyType == typeof (IListDataSource))
             {
-                var source = new ListWrapper<string> (["Test Text #1", "Test Text #2", "Test Text #3"]);
+                ListWrapper<string> source = new (["Test Text #1", "Test Text #2", "Test Text #3"]);
                 view?.GetType ().GetProperty ("Source")?.GetSetMethod ()?.Invoke (view, new [] { source });
             }
 
@@ -637,8 +633,7 @@ public class ScenarioTests : TestsAllViews
 
         Application.KeyDown += (sender, args) =>
                                {
-                                   // See #2474 for why this is commented out
-                                   Assert.Equal (KeyCode.CtrlMask | KeyCode.Q, args.KeyCode);
+                                   Assert.Equal (Application.QuitKey, args.KeyCode);
                                };
 
         generic.Main ();

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -1290,7 +1290,7 @@ wo
     [Theory]
     [AutoInitShutdown]
     [InlineData ("New", KeyCode.CtrlMask | KeyCode.N)]
-    [InlineData ("Quit", KeyCode.AltMask | KeyCode.CtrlMask | KeyCode.Q)]
+    [InlineData ("Quit", KeyCode.CtrlMask | KeyCode.Q)]
     [InlineData ("Copy", KeyCode.CtrlMask | KeyCode.C)]
     [InlineData ("Replace", KeyCode.CtrlMask | KeyCode.H)]
     [InlineData ("1", KeyCode.F1)]

--- a/UnitTests/Views/ToplevelTests.cs
+++ b/UnitTests/Views/ToplevelTests.cs
@@ -797,6 +797,8 @@ public class ToplevelTests (ITestOutputHelper output)
         Key alternateBackwardKey = KeyCode.Null;
         Key quitKey = KeyCode.Null;
 
+        Key previousQuitKey = Application.QuitKey;
+
         Toplevel top = new ();
         var view = new View ();
         view.Initialized += View_Initialized;
@@ -819,7 +821,7 @@ public class ToplevelTests (ITestOutputHelper output)
 
         Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, Application.AlternateForwardKey);
         Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, Application.AlternateBackwardKey);
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey);
+        Assert.Equal (Key.Esc, Application.QuitKey);
 
         Application.AlternateForwardKey = KeyCode.A;
         Application.AlternateBackwardKey = KeyCode.B;
@@ -827,7 +829,7 @@ public class ToplevelTests (ITestOutputHelper output)
 
         Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, alternateForwardKey);
         Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, alternateBackwardKey);
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, quitKey);
+        Assert.Equal (previousQuitKey, quitKey);
 
         Assert.Equal (KeyCode.A, Application.AlternateForwardKey);
         Assert.Equal (KeyCode.B, Application.AlternateBackwardKey);
@@ -836,11 +838,11 @@ public class ToplevelTests (ITestOutputHelper output)
         // Replacing the defaults keys to avoid errors on others unit tests that are using it.
         Application.AlternateForwardKey = Key.PageDown.WithCtrl;
         Application.AlternateBackwardKey = Key.PageUp.WithCtrl;
-        Application.QuitKey = Key.Q.WithCtrl;
+        Application.QuitKey = previousQuitKey;
 
         Assert.Equal (KeyCode.PageDown | KeyCode.CtrlMask, Application.AlternateForwardKey);
         Assert.Equal (KeyCode.PageUp | KeyCode.CtrlMask, Application.AlternateBackwardKey);
-        Assert.Equal (KeyCode.Q | KeyCode.CtrlMask, Application.QuitKey);
+        Assert.Equal (previousQuitKey, Application.QuitKey);
         top.Dispose ();
     }
 

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -29,14 +29,13 @@
     "template": [
       "default",
       "templates/modern"
-      // ,
-      // "templates/singulinkfx"
     ],
     "output": "_site",
     "content": [
       {
         "files": [
-          "**/*.{md,yml}"
+          "**/*.{md,yml}",
+          "schemas/**.json"
         ],
         "exclude": [
           "_site/**"

--- a/docfx/docs/migratingfromv1.md
+++ b/docfx/docs/migratingfromv1.md
@@ -166,6 +166,7 @@ The API for handling keyboard input is significantly improved. See [Keyboard API
 * The [Key](~/api/Terminal.Gui.Key.yml) class replaces the `KeyEvent` struct and provides a platform-independent abstraction for common keyboard operations. It is used for processing keyboard input and raising keyboard events. This class provides a high-level abstraction with helper methods and properties for common keyboard operations. Use this class instead of the low-level [KeyCode](~/api/Terminal.Gui.KeyCode.yml) enum when possible. See [Key](~/api/Terminal.Gui.Key.yml) for more details.
 * The preferred way to enable Application-wide or View-heirarchy-dependent keystrokes is to use the [Shortcut](~/api/Terminal.Gui.Shortcut.yml) View or the built-in View's that utilize it, such as the [Bar](~/api/Terminal.Gui.Bar.yml)-based views.
 * The preferred way to handle single keystrokes is to use **Key Bindings**. Key Bindings map a key press to a [Command](~/api/Terminal.Gui.Command.yml). A view can declare which commands it supports, and provide a lambda that implements the functionality of the command, using `View.AddCommand()`. Use the [View.Keybindings](~/api/Terminal.Gui.View.Keybindings.yml) to configure the key bindings.
+* For better consistency and user experience, the default key for closing an app or `Toplevel` is now `Esc` (it was previously `Ctrl+Q`).
 
 ### How to Fix
 
@@ -173,6 +174,7 @@ The API for handling keyboard input is significantly improved. See [Keyboard API
 * Use [View.AddCommand](~/api/Terminal.Gui.View.AddCommand.yml) to define commands your view supports.
 * Use [View.Keybindings](~/api/Terminal.Gui.View.Keybindings.yml) to configure key bindings to `Command`s.
 * It should be very uncommon for v2 code to override `OnKeyPressed` etc... 
+* Anywhere `Ctrl+Q` was hard-coded as the "quit key", replace with `Application.QuitKey`.
 
 ## Updated Mouse API
 

--- a/docfx/docs/newinv2.md
+++ b/docfx/docs/newinv2.md
@@ -55,6 +55,7 @@ The API for handling keyboard input is significantly improved. See [Keyboard API
 
 * The `Key` class replaces the `KeyEvent` struct and provides a platform-independent abstraction for common keyboard operations. It is used for processing keyboard input and raising keyboard events. This class provides a high-level abstraction with helper methods and properties for common keyboard operations. Use this class instead of the low-level `KeyCode` enum when possible. See [Key](~/api/Terminal.Gui.Key.yml) for more details.
 * The preferred way to handle single keystrokes is to use **Key Bindings**. Key Bindings map a key press to a [Command](~/api/Terminal.Gui.Command.yml). A view can declare which commands it supports, and provide a lambda that implements the functionality of the command, using `View.AddCommand()`. Use the `View.Keybindings` to configure the key bindings.
+* For better consistency and user experience, the default key for closing an app or `Toplevel` is now `Esc` (it was previously `Ctrl+Q`).
 
 ## Updated Mouse API
 

--- a/docfx/schemas/tui-config-schema.json
+++ b/docfx/schemas/tui-config-schema.json
@@ -3,10 +3,6 @@
   "description": "The JSON schema for the Terminal.Gui Configuration Manager (https://gui-cs.github.io/Terminal.Gui/schemas/tui-config-schema.json).",
   "type": "object",
   "properties": {
-    "Application.HeightAsBuffer": {
-      "description": "See HeightAsBuffer API documentation.",
-      "type": "boolean"
-    },
     "Application.AlternateForwardKey": {
       "description": "Alternative key for navigating forwards through views. SCtrl+Tab is the primary key.",
       "$ref": "#/definitions/Key"
@@ -16,7 +12,7 @@
       "$ref": "#/definitions/Key"
     },
     "Application.QuitKey": {
-      "description": "The key to quit the application. Ctrl+Q is the default.",
+      "description": "The key to quit the application. Esc is the default.",
       "$ref": "#/definitions/Key"
     },
     "Application.IsMouseDisabled": {


### PR DESCRIPTION
## Fixes

- Fixes #3516 

## Proposed Changes/Todos

- [x] Change to `Esc`
- [x] Fix tests
- [x] Fix scenarios (if any)
- [x] Update docs

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
