### PR TITLE
Fix typos

### DIFF
--- a/Terminal.Gui/Application/Application.cs
+++ b/Terminal.Gui/Application/Application.cs
@@ -157,7 +157,7 @@ public static partial class Application
         Colors.Reset ();
 
         // Reset synchronization context to allow the user to run async/await,
-        // as the main loop has been ended, the synchronization context from 
+        // as the main loop has been ended, the synchronization context from
         // gui.cs does no longer process any callbacks. See #1084 for more details:
         // (https://github.com/gui-cs/Terminal.Gui/issues/1084).
         SynchronizationContext.SetSynchronizationContext (null);
@@ -203,11 +203,11 @@ public static partial class Application
     // INTERNAL function for initializing an app with a Toplevel factory object, driver, and mainloop.
     //
     // Called from:
-    // 
+    //
     // Init() - When the user wants to use the default Toplevel. calledViaRunT will be false, causing all state to be reset.
     // Run<T>() - When the user wants to use a custom Toplevel. calledViaRunT will be true, enabling Run<T>() to be called without calling Init first.
     // Unit Tests - To initialize the app with a custom Toplevel, using the FakeDriver. calledViaRunT will be false, causing all state to be reset.
-    // 
+    //
     // calledViaRunT: If false (default) all state will be reset. If true the state will not be reset.
     [RequiresUnreferencedCode ("AOT")]
     [RequiresDynamicCode ("AOT")]
@@ -242,7 +242,7 @@ public static partial class Application
         // Start the process of configuration management.
         // Note that we end up calling LoadConfigurationFromAllSources
         // multiple times. We need to do this because some settings are only
-        // valid after a Driver is loaded. In this cases we need just 
+        // valid after a Driver is loaded. In this case we need just
         // `Settings` so we can determine which driver to use.
         // Don't reset, so we can inherit the theme from the previous run.
         Load ();
@@ -383,7 +383,7 @@ public static partial class Application
     /// </remarks>
     public static event EventHandler<RunStateEventArgs> NotifyNewRunState;
 
-    /// <summary>Notify that a existent <see cref="RunState"/> is stopping (<see cref="End(RunState)"/> was called).</summary>
+    /// <summary>Notify that an existent <see cref="RunState"/> is stopping (<see cref="End(RunState)"/> was called).</summary>
     /// <remarks>
     ///     If <see cref="EndAfterFirstIteration"/> is <see langword="true"/> callers to <see cref="Begin(Toplevel)"/>
     ///     must also subscribe to <see cref="NotifyStopRunState"/> and manually dispose of the <see cref="RunState"/> token
@@ -463,7 +463,7 @@ public static partial class Application
                 Top.OnLeave (toplevel);
             }
 
-            // BUGBUG: We should not depend on `Id` internally. 
+            // BUGBUG: We should not depend on `Id` internally.
             // BUGBUG: It is super unclear what this code does anyway.
             if (string.IsNullOrEmpty (toplevel.Id))
             {
@@ -851,7 +851,7 @@ public static partial class Application
     }
 
     // TODO: Determine if this is really needed. The only code that calls WakeUp I can find
-    // is ProgressBarStyles and it's not clear it needs to.
+    // is ProgressBarStyles, and it's not clear it needs to.
     /// <summary>Wakes up the running application that might be waiting on input.</summary>
     public static void Wakeup () { MainLoop?.Wakeup (); }
 
@@ -1160,13 +1160,13 @@ public static partial class Application
             runState.Toplevel.OnUnloaded ();
         }
 
-        // End the RunState.Toplevel 
+        // End the RunState.Toplevel
         // First, take it off the Toplevel Stack
         if (_topLevels.Count > 0)
         {
             if (_topLevels.Peek () != runState.Toplevel)
             {
-                // If there the top of the stack is not the RunState.Toplevel then
+                // If the top of the stack is not the RunState.Toplevel then
                 // this call to End is not balanced with the call to Begin that started the RunState
                 throw new ArgumentException ("End must be balanced with calls to Begin");
             }
@@ -1177,8 +1177,8 @@ public static partial class Application
         // Notify that it is closing
         runState.Toplevel?.OnClosed (runState.Toplevel);
 
-        // If there is a OverlappedTop that is not the RunState.Toplevel then runstate.TopLevel 
-        // is a child of MidTop and we should notify the OverlappedTop that it is closing
+        // If there is a OverlappedTop that is not the RunState.Toplevel then RunState.Toplevel
+        // is a child of MidTop, and we should notify the OverlappedTop that it is closing
         if (OverlappedTop is { } && !runState.Toplevel.Modal && runState.Toplevel != OverlappedTop)
         {
             OverlappedTop.OnChildClosed (runState.Toplevel);
@@ -1234,7 +1234,7 @@ public static partial class Application
 
     /// <summary>Holds the stack of TopLevel views.</summary>
 
-    // BUGBUG: Techncally, this is not the full lst of TopLevels. THere be dragons hwre. E.g. see how Toplevel.Id is used. What
+    // BUGBUG: Technically, this is not the full lst of TopLevels. There be dragons here, e.g. see how Toplevel.Id is used. What
     // about TopLevels that are just a SubView of another View?
     internal static readonly Stack<Toplevel> _topLevels = new ();
 

--- a/Terminal.Gui/Clipboard/IClipboard.cs
+++ b/Terminal.Gui/Clipboard/IClipboard.cs
@@ -6,21 +6,21 @@ public interface IClipboard
     /// <summary>Returns true if the environmental dependencies are in place to interact with the OS clipboard.</summary>
     bool IsSupported { get; }
 
-    /// <summary>Get the operation system clipboard.</summary>
+    /// <summary>Get the operating system clipboard.</summary>
     /// <exception cref="NotSupportedException">Thrown if it was not possible to read the clipboard contents.</exception>
     string GetClipboardData ();
 
-    /// <summary>Sets the operation system clipboard.</summary>
+    /// <summary>Sets the operating system clipboard.</summary>
     /// <param name="text"></param>
     /// <exception cref="NotSupportedException">Thrown if it was not possible to set the clipboard contents.</exception>
     void SetClipboardData (string text);
 
-    /// <summary>Gets the operation system clipboard if possible.</summary>
+    /// <summary>Gets the operating system clipboard if possible.</summary>
     /// <param name="result">Clipboard contents read</param>
     /// <returns>true if it was possible to read the OS clipboard.</returns>
     bool TryGetClipboardData (out string result);
 
-    /// <summary>Sets the operation system clipboard if possible.</summary>
+    /// <summary>Sets the operating system clipboard if possible.</summary>
     /// <param name="text"></param>
     /// <returns>True if the clipboard content was set successfully.</returns>
     bool TrySetClipboardData (string text);

--- a/Terminal.Gui/Configuration/ConfigurationManager.cs
+++ b/Terminal.Gui/Configuration/ConfigurationManager.cs
@@ -125,7 +125,7 @@ public static class ConfigurationManager
     /// </remarks>
     private static SettingsScope? _settings;
 
-    /// <summary>Name of the running application. By default this property is set to the application's assembly name.</summary>
+    /// <summary>Name of the running application. By default, this property is set to the application's assembly name.</summary>
     public static string AppName { get; set; } = Assembly.GetEntryAssembly ()?.FullName?.Split (',') [0]?.Trim ()!;
 
     /// <summary>Application-specific configuration settings scope.</summary>

--- a/Terminal.Gui/Configuration/ConfigurationManagerEventArgs.cs
+++ b/Terminal.Gui/Configuration/ConfigurationManagerEventArgs.cs
@@ -15,6 +15,6 @@ public class ThemeManagerEventArgs : EventArgs
     /// <summary>Initializes a new instance of <see cref="ThemeManagerEventArgs"/></summary>
     public ThemeManagerEventArgs (string newTheme) { NewTheme = newTheme; }
 
-    /// <summary>The name of the new active theme..</summary>
+    /// <summary>The name of the new active theme.</summary>
     public string NewTheme { get; set; } = string.Empty;
 }

--- a/Terminal.Gui/Configuration/SerializableConfigurationProperty.cs
+++ b/Terminal.Gui/Configuration/SerializableConfigurationProperty.cs
@@ -2,7 +2,7 @@
 
 namespace Terminal.Gui;
 
-/// <summary>An attribute that can be applied to a property to indicate that it should included in the configuration file.</summary>
+/// <summary>An attribute that can be applied to a property to indicate that it should be included in the configuration file.</summary>
 /// <example>
 ///     [SerializableConfigurationProperty(Scope = typeof(Configuration.ThemeManager.ThemeScope)), JsonConverter
 ///     (typeof (JsonStringEnumConverter))] public static LineStyle DefaultBorderStyle { ...

--- a/Terminal.Gui/Configuration/ThemeManager.cs
+++ b/Terminal.Gui/Configuration/ThemeManager.cs
@@ -9,7 +9,7 @@ namespace Terminal.Gui;
 /// <summary>Contains a dictionary of the <see cref="ThemeManager.Theme"/>s for a Terminal.Gui application.</summary>
 /// <remarks>
 ///     <para>A Theme is a collection of settings that are named. The default theme is named "Default".</para>
-///     <para>The <see cref="ThemeManager.Theme"/> property is used to detemrine the currently active theme.</para>
+///     <para>The <see cref="ThemeManager.Theme"/> property is used to determine the currently active theme.</para>
 /// </remarks>
 /// <para>
 ///     <see cref="ThemeManager"/> is a singleton class. It is created when the first <see cref="ThemeManager"/> property

--- a/Terminal.Gui/ConsoleDrivers/ConsoleDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/ConsoleDriver.cs
@@ -567,7 +567,7 @@ public abstract class ConsoleDriver
 
     /// <summary>Called when a key is released. Fires the <see cref="KeyUp"/> event.</summary>
     /// <remarks>
-    ///     Drivers that do not support key release events will calls this method after <see cref="OnKeyDown"/> processing
+    ///     Drivers that do not support key release events will call this method after <see cref="OnKeyDown"/> processing
     ///     is complete.
     /// </remarks>
     /// <param name="a"></param>
@@ -603,7 +603,7 @@ public enum CursorVisibility
     /// <summary>Cursor caret has default</summary>
     /// <remarks>
     ///     Works under Xterm-like terminal otherwise this is equivalent to <see ref="Underscore"/>. This default directly
-    ///     depends of the XTerm user configuration settings so it could be Block, I-Beam, Underline with possible blinking.
+    ///     depends on the XTerm user configuration settings, so it could be Block, I-Beam, Underline with possible blinking.
     /// </remarks>
     Default = 0x00010119,
 
@@ -681,7 +681,7 @@ public enum KeyCode : uint
 
     /// <summary>
     ///     If the <see cref="SpecialMask"/> is set, then the value is that of the special mask, otherwise, the value is
-    ///     in the the lower bits (as extracted by <see cref="CharMask"/>).
+    ///     in the lower bits (as extracted by <see cref="CharMask"/>).
     /// </summary>
     SpecialMask = 0x_fff0_0000,
 
@@ -838,9 +838,9 @@ public enum KeyCode : uint
     //Delete = 127,
 
     // --- Special keys ---
-    // The values below are common non-alphanum keys. Their values are 
+    // The values below are common non-alphanum keys. Their values are
     // based on the .NET ConsoleKey values, which, in-turn are based on the
-    // VK_ values from the Windows API. 
+    // VK_ values from the Windows API.
     // We add MaxCodePoint to avoid conflicts with the Unicode values.
 
     /// <summary>The maximum Unicode codepoint value. Used to encode the non-alphanumeric control keys.</summary>

--- a/Terminal.Gui/ConsoleDrivers/ConsoleKeyMapping.cs
+++ b/Terminal.Gui/ConsoleDrivers/ConsoleKeyMapping.cs
@@ -1435,7 +1435,7 @@ public static class ConsoleKeyMapping
                              (VK)'2',
                              ConsoleModifiers.Shift,
                              '\"'
-                            ), // BUGBUG: This is true for Portugese keyboard, but not ENG (@) or DEU (")
+                            ), // BUGBUG: This is true for Portuguese keyboard, but not ENG (@) or DEU (")
         new ScanCodeMapping (
                              3,
                              (VK)'2',

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/ClipboardImpl.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/ClipboardImpl.cs
@@ -89,7 +89,7 @@ internal class CursesClipboard : ClipboardBase
 
 /// <summary>
 ///     A clipboard implementation for MacOSX. This implementation uses the Mac clipboard API (via P/Invoke) to
-///     copy/paste. The existance of the Mac pbcopy and pbpaste commands is used to determine if copy/paste is supported.
+///     copy/paste. The existence of the Mac pbcopy and pbpaste commands is used to determine if copy/paste is supported.
 /// </summary>
 internal class MacOSXClipboard : ClipboardBase
 {

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -317,7 +317,7 @@ internal class CursesDriver : ConsoleDriver
             Curses.doupdate ();
 
             // 
-            // We are setting Invisible as default so we could ignore XTerm DECSUSR setting
+            // We are setting Invisible as default, so we could ignore XTerm DECSUSR setting
             //
             switch (Curses.curs_set (0))
             {
@@ -977,7 +977,7 @@ internal static class Platform
     private static int _suspendSignal;
 
     /// <summary>Suspends the process by sending SIGTSTP to itself</summary>
-    /// <returns>The suspend.</returns>
+    /// <returns>True if the suspension was successful.</returns>
     public static bool Suspend ()
     {
         int signal = GetSuspendSignal ();

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnmanagedLibrary.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnmanagedLibrary.cs
@@ -291,7 +291,7 @@ internal class UnmanagedLibrary
     }
 
     /// <summary>
-    ///     On Linux systems, using using dlopen and dlsym results in DllNotFoundException("libdl.so not found") if
+    ///     On Linux systems, using dlopen and dlsym results in DllNotFoundException("libdl.so not found") if
     ///     libc6-dev is not installed. As a workaround, we load symbols for dlopen and dlsym from the current process as on
     ///     Linux Mono sure is linked against these symbols.
     /// </summary>

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqReq.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqReq.cs
@@ -22,7 +22,7 @@ public class EscSeqReqStatus
     /// <summary>Gets the number of requests.</summary>
     public int NumRequests { get; }
 
-    /// <summary>Gets the Escape Sequence Termintor (e.g. ESC[8t ... t is the terminator).</summary>
+    /// <summary>Gets the Escape Sequence Terminator (e.g. ESC[8t ... t is the terminator).</summary>
     public string Terminator { get; }
 }
 

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -159,10 +159,10 @@ public static class EscSeqUtils
     ///     Decodes an ANSI escape sequence.
     /// </summary>
     /// <param name="escSeqRequests">The <see cref="EscSeqRequests"/> which may contain a request.</param>
-    /// <param name="newConsoleKeyInfo">The <see cref="ConsoleKeyInfo"/> which may changes.</param>
-    /// <param name="key">The <see cref="ConsoleKey"/> which may changes.</param>
+    /// <param name="newConsoleKeyInfo">The <see cref="ConsoleKeyInfo"/> which may change.</param>
+    /// <param name="key">The <see cref="ConsoleKey"/> which may change.</param>
     /// <param name="cki">The <see cref="ConsoleKeyInfo"/> array.</param>
-    /// <param name="mod">The <see cref="ConsoleModifiers"/> which may changes.</param>
+    /// <param name="mod">The <see cref="ConsoleModifiers"/> which may change.</param>
     /// <param name="c1Control">The control returned by the <see cref="GetC1ControlChar"/> method.</param>
     /// <param name="code">The code returned by the <see cref="GetEscapeResult(char[])"/> method.</param>
     /// <param name="values">The values returned by the <see cref="GetEscapeResult(char[])"/> method.</param>
@@ -426,7 +426,7 @@ public static class EscSeqUtils
     #nullable restore
 
     /// <summary>
-    ///     Gets all the needed information about a escape sequence.
+    ///     Gets all the needed information about an escape sequence.
     /// </summary>
     /// <param name="kChar">The array with all chars.</param>
     /// <returns>

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -198,7 +198,7 @@ public class FakeDriver : ConsoleDriver
         FakeConsole.CursorTop = 0;
         FakeConsole.CursorLeft = 0;
 
-        //SetCursorVisibility (savedVisibitity);
+        //SetCursorVisibility (savedVisibility);
 
         void WriteToConsole (StringBuilder output, ref int lastCol, int row, ref int outputWidth)
         {
@@ -437,7 +437,7 @@ public class FakeDriver : ConsoleDriver
     {
         if (FakeConsole.WindowHeight > 0)
         {
-            // Can raise an exception while is still resizing.
+            // Can raise an exception while it is still resizing.
             try
             {
                 FakeConsole.CursorTop = 0;

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -1669,7 +1669,7 @@ internal class NetDriver : ConsoleDriver
 
 /// <summary>
 ///     Mainloop intended to be used with the .NET System.Console API, and can be used on Windows and Unix, it is
-///     cross platform but lacks things like file descriptor monitoring.
+///     cross-platform but lacks things like file descriptor monitoring.
 /// </summary>
 /// <remarks>This implementation is used for NetDriver.</remarks>
 internal class NetMainLoop : IMainLoopDriver

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -659,7 +659,7 @@ internal class WindowsConsole
     {
         public char Char { get; set; }
         public Attribute Attribute { get; set; }
-        public bool Empty { get; set; } // TODO: Temp hack until virutal terminal sequences
+        public bool Empty { get; set; } // TODO: Temp hack until virtual terminal sequences
 
         public ExtendedCharInfo (char character, Attribute attribute)
         {
@@ -901,7 +901,7 @@ internal class WindowsConsole
         }
     }
 
-#if false // Not needed on the constructor. Perhaps could be used on resizing. To study.                                                                                     
+#if false // Not needed on the constructor. Perhaps could be used on resizing. To study.
 		[DllImport ("kernel32.dll", ExactSpelling = true)]
 		static extern IntPtr GetConsoleWindow ();
 
@@ -1397,7 +1397,7 @@ internal class WindowsDriver : ConsoleDriver
             {
                 if (WinConsole is { })
                 {
-                    // BUGBUG: The results from GetConsoleOutputWindow are incorrect when called from Init. 
+                    // BUGBUG: The results from GetConsoleOutputWindow are incorrect when called from Init.
                     // Our thread in WindowsMainLoop.CheckWin will get the correct results. See #if HACK_CHECK_WINCHANGED
                     Size winSize = WinConsole.GetConsoleOutputWindow (out Point pos);
                     Cols = winSize.Width;
@@ -1642,7 +1642,7 @@ internal class WindowsDriver : ConsoleDriver
 
                     if (keyInfo.Modifiers != 0)
                     {
-                        // These Oem keys have well defined chars. We ensure the representative char is used.
+                        // These Oem keys have well-defined chars. We ensure the representative char is used.
                         // If we don't do this, then on some keyboard layouts the wrong char is 
                         // returned (e.g. on ENG OemPlus un-shifted is =, not +). This is important
                         // for key persistence ("Ctrl++" vs. "Ctrl+=").
@@ -1656,7 +1656,7 @@ internal class WindowsDriver : ConsoleDriver
                         };
                     }
 
-                    // Return the mappedChar with they modifiers. Because mappedChar is un-shifted, if Shift was down
+                    // Return the mappedChar with modifiers. Because mappedChar is un-shifted, if Shift was down
                     // we should keep it
                     return MapToKeyCodeModifiers (keyInfo.Modifiers, (KeyCode)mappedChar);
                 }
@@ -1901,8 +1901,8 @@ internal class WindowsDriver : ConsoleDriver
 
         // The ButtonState member of the MouseEvent structure has bit corresponding to each mouse button.
         // This will tell when a mouse button is pressed. When the button is released this event will
-        // be fired with it's bit set to 0. So when the button is up ButtonState will be 0.
-        // To map to the correct driver events we save the last pressed mouse button so we can
+        // be fired with its bit set to 0. So when the button is up ButtonState will be 0.
+        // To map to the correct driver events we save the last pressed mouse button, so we can
         // map to the correct clicked event.
         if ((_lastMouseButtonPressed is { } || _isButtonReleased) && mouseEvent.ButtonState != 0)
         {

--- a/Terminal.Gui/Drawing/ColorScheme.cs
+++ b/Terminal.Gui/Drawing/ColorScheme.cs
@@ -77,7 +77,7 @@ public record ColorScheme : IEqualityOperators<ColorScheme, ColorScheme, bool>
         init => _focus = value;
     }
 
-    /// <summary>The foreground and background color for for text in a focused view that indicates a <see cref="View.HotKey"/>.</summary>
+    /// <summary>The foreground and background color for text in a focused view that indicates a <see cref="View.HotKey"/>.</summary>
     public Attribute HotFocus
     {
         get => _hotFocus;

--- a/Terminal.Gui/Drawing/Glyphs.cs
+++ b/Terminal.Gui/Drawing/Glyphs.cs
@@ -348,7 +348,7 @@ public class GlyphDefinitions
     /// <summary>Box Drawings Left Tee - Heavy Vertical and Heavy Horizontal (U+2527) - ┣</summary>
     public Rune LeftTeeHvDblH { get; set; } = (Rune)'┣';
 
-    /// <summary>Box Drawings Righ Tee - Single Vertical and Single Horizontal (U+2524) - ┤</summary>
+    /// <summary>Box Drawings Right Tee - Single Vertical and Single Horizontal (U+2524) - ┤</summary>
     public Rune RightTee { get; set; } = (Rune)'┤';
 
     /// <summary>Box Drawings Right Tee - Single Vertical and Double Horizontal (U+2561) - ╡</summary>

--- a/Terminal.Gui/Drawing/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas.cs
@@ -199,7 +199,7 @@ public class LineCanvas : IDisposable
     }
 
     // TODO: Unless there's an obvious use case for this API we should delete it in favor of the
-    // simpler version that doensn't take an area.
+    // simpler version that doesn't take an area.
     /// <summary>
     ///     Evaluates the lines that have been added to the canvas and returns a map containing the glyphs and their
     ///     locations. The glyphs are the characters that should be rendered so that all lines connect up with the appropriate

--- a/Terminal.Gui/Drawing/LineStyle.cs
+++ b/Terminal.Gui/Drawing/LineStyle.cs
@@ -41,7 +41,7 @@ public enum LineStyle
     RoundedDotted
 
     // TODO: Support Ruler
-    ///// <summary> 
+    ///// <summary>
     ///// The border is drawn as a diagnostic ruler ("|123456789...").
     ///// </summary>
     //Ruler

--- a/Terminal.Gui/FileServices/AllowedType.cs
+++ b/Terminal.Gui/FileServices/AllowedType.cs
@@ -33,7 +33,7 @@ public class AllowedTypeAny : IAllowedType
 public class AllowedType : IAllowedType
 {
     /// <summary>Initializes a new instance of the <see cref="AllowedType"/> class.</summary>
-    /// <param name="description">The human readable text to display.</param>
+    /// <param name="description">The human-readable text to display.</param>
     /// <param name="extensions">Extension(s) to match e.g. .csv.</param>
     public AllowedType (string description, params string [] extensions)
     {
@@ -46,7 +46,7 @@ public class AllowedType : IAllowedType
         Extensions = extensions;
     }
 
-    /// <summary>Gets or Sets the human readable description for the file type e.g. "Comma Separated Values".</summary>
+    /// <summary>Gets or Sets the human-readable description for the file type e.g. "Comma Separated Values".</summary>
     public string Description { get; set; }
 
     /// <summary>Gets or Sets the permitted file extension(s) (e.g. ".csv").</summary>

--- a/Terminal.Gui/FileServices/FileDialogState.cs
+++ b/Terminal.Gui/FileServices/FileDialogState.cs
@@ -54,7 +54,7 @@ internal class FileDialogState
                                    .ToList ();
             }
 
-            // if theres a UI filter in place too
+            // if there's a UI filter in place too
             if (Parent.CurrentFilter is { })
             {
                 children = children.Where (MatchesApiFilter).ToList ();

--- a/Terminal.Gui/FileServices/FileDialogStyle.cs
+++ b/Terminal.Gui/FileServices/FileDialogStyle.cs
@@ -24,7 +24,7 @@ public class FileDialogStyle
     public string CancelButtonText { get; set; } = Strings.btnCancel;
 
     /// <summary>
-    ///     Gets or sets the class thatis responsible for determining which color to use to represent files and
+    ///     Gets or sets the class that is responsible for determining which color to use to represent files and
     ///     directories when <see cref="UseColors"/> is <see langword="true"/>.
     /// </summary>
     public FileSystemColorProvider ColorProvider { get; set; } = new ();
@@ -100,7 +100,7 @@ public class FileDialogStyle
     /// <summary>Gets or sets the header text displayed in the Modified column of the files table.</summary>
     public string ModifiedColumnName { get; set; } = Strings.fdModified;
 
-    /// <summary>Gets or sets the text on the 'Ok' button.  Typically you may want to change this to "Open" or "Save" etc.</summary>
+    /// <summary>Gets or sets the text on the 'Ok' button.  Typically, you may want to change this to "Open" or "Save" etc.</summary>
     public string OkButtonText { get; set; } = Strings.btnOk;
 
     /// <summary>Gets or sets the text displayed in the 'Path' text box when user has not supplied any input yet.</summary>
@@ -163,7 +163,7 @@ public class FileDialogStyle
         }
         catch (Exception)
         {
-            // Cannot get the system disks thats fine
+            // Cannot get the system disks, that's fine
         }
 
         try
@@ -195,7 +195,7 @@ public class FileDialogStyle
         }
         catch (Exception)
         {
-            // Cannot get the special files for this OS oh well
+            // Cannot get the special files for this OS, oh well
         }
 
         return roots;

--- a/Terminal.Gui/Input/Command.cs
+++ b/Terminal.Gui/Input/Command.cs
@@ -113,7 +113,7 @@ public enum Command
     /// <summary>Move one page down.</summary>
     PageDown,
 
-    /// <summary>Move one page page extending the selection to cover revealed objects/characters.</summary>
+    /// <summary>Move one page down extending the selection to cover revealed objects/characters.</summary>
     PageDownExtend,
 
     /// <summary>Move one page up.</summary>
@@ -137,7 +137,7 @@ public enum Command
     /// <summary>Open the selected item.</summary>
     OpenSelectedItem,
 
-    /// <summary>Toggles the Expanded or collapsed state of a a list or item (with subitems).</summary>
+    /// <summary>Toggles the Expanded or collapsed state of a list or item (with subitems).</summary>
     ToggleExpandCollapse,
 
     /// <summary>Expands a list or item (with subitems).</summary>
@@ -224,13 +224,13 @@ public enum Command
     /// <summary>Quit a <see cref="Toplevel"/>.</summary>
     QuitToplevel,
 
-    /// <summary>Suspend a application (Only implemented in <see cref="CursesDriver"/>).</summary>
+    /// <summary>Suspend an application (Only implemented in <see cref="CursesDriver"/>).</summary>
     Suspend,
 
     /// <summary>Moves focus to the next view.</summary>
     NextView,
 
-    /// <summary>Moves focuss to the previous view.</summary>
+    /// <summary>Moves focus to the previous view.</summary>
     PreviousView,
 
     /// <summary>Moves focus to the next view or Toplevel (case of Overlapped).</summary>

--- a/Terminal.Gui/Input/Key.cs
+++ b/Terminal.Gui/Input/Key.cs
@@ -487,7 +487,7 @@ public class Key : EventArgs, IEquatable<Key>
 
     /// <summary>Formats a <see cref="KeyCode"/> as a string.</summary>
     /// <param name="key">The key to format.</param>
-    /// <param name="separator">The character to use as a separator between modifier keys and and the key itself.</param>
+    /// <param name="separator">The character to use as a separator between modifier keys and the key itself.</param>
     /// <returns>
     ///     The formatted string. If the key is a printable character, it will be returned as a string. Otherwise, the key
     ///     name will be returned.

--- a/Terminal.Gui/Input/MouseEventEventArgs.cs
+++ b/Terminal.Gui/Input/MouseEventEventArgs.cs
@@ -13,7 +13,7 @@ public class MouseEventEventArgs : EventArgs
 
     /// <summary>
     ///     Indicates if the current mouse event has already been processed and the driver should stop notifying any other
-    ///     event subscriber. Its important to set this value to true specially when updating any View's layout from inside the
+    ///     event subscriber. It's important to set this value to true specially when updating any View's layout from inside the
     ///     subscriber method.
     /// </summary>
     /// <remarks>

--- a/Terminal.Gui/Resources/config.json
+++ b/Terminal.Gui/Resources/config.json
@@ -1,7 +1,7 @@
 {
   // Specifies the "source of truth" for default values for all Terminal.Gui settings managed by
   // ConfigurationManager. It is automatically loaded, and applied, each time Application.Init
-  // is run (via the ConfiguraitonManager.Reset method). 
+  // is run (via the ConfigurationManager.Reset method).
   //
   // In other words, initial values set in the the codebase are always overwritten by the contents of this 
   // resource embedded in the Terminal.Gui.dll assembly.

--- a/Terminal.Gui/Resources/config.json
+++ b/Terminal.Gui/Resources/config.json
@@ -3,7 +3,7 @@
   // ConfigurationManager. It is automatically loaded, and applied, each time Application.Init
   // is run (via the ConfiguraitonManager.Reset method). 
   //
-  // In otherwords, initial values set in the the codebase are always overwritten by the contents of this 
+  // In other words, initial values set in the the codebase are always overwritten by the contents of this 
   // resource embedded in the Terminal.Gui.dll assembly.
   //
   // The Unit Test method "ConfigurationManagerTests.SaveDefaults" can be used to re-create the base of this file, but

--- a/Terminal.Gui/StackExtensions.cs
+++ b/Terminal.Gui/StackExtensions.cs
@@ -160,7 +160,7 @@ public static class StackExtensions
         }
     }
 
-    /// <summary>Replaces an stack object values that match with the value to replace.</summary>
+    /// <summary>Replaces a stack object values that match with the value to replace.</summary>
     /// <typeparam name="T">The stack object type.</typeparam>
     /// <param name="stack">The stack object.</param>
     /// <param name="valueToReplace">Value to replace.</param>

--- a/Terminal.Gui/Text/Autocomplete/AppendAutocomplete.cs
+++ b/Terminal.Gui/Text/Autocomplete/AppendAutocomplete.cs
@@ -105,7 +105,7 @@ public class AppendAutocomplete : AutocompleteBase
             return;
         }
 
-        // draw it like its selected even though its not
+        // draw it like it's selected, even though it's not
         Application.Driver.SetAttribute (
                                          new Attribute (
                                                         ColorScheme.Normal.Foreground,

--- a/Terminal.Gui/Text/Autocomplete/PopupAutocomplete.cs
+++ b/Terminal.Gui/Text/Autocomplete/PopupAutocomplete.cs
@@ -322,7 +322,7 @@ public abstract partial class PopupAutocomplete : AutocompleteBase
 
         if (PopupInsideContainer)
         {
-            // don't overspill horizontally, let's see if can be displayed on the left
+            // don't overspill horizontally, let's see if it can be displayed on the left
             if (width > HostControl.Viewport.Width - renderAt.X)
             {
                 // Verifies that the left limit available is greater than the right limit
@@ -339,7 +339,7 @@ public abstract partial class PopupAutocomplete : AutocompleteBase
         }
         else
         {
-            // don't overspill horizontally, let's see if can be displayed on the left
+            // don't overspill horizontally, let's see if it can be displayed on the left
             if (width > top.Viewport.Width - (renderAt.X + HostControl.Frame.X))
             {
                 // Verifies that the left limit available is greater than the right limit
@@ -408,7 +408,7 @@ public abstract partial class PopupAutocomplete : AutocompleteBase
 
     /// <summary>
     ///     Called when the user confirms a selection at the current cursor location in the <see cref="HostControl"/>. The
-    ///     <paramref name="accepted"/> string is the full autocomplete word to be inserted. Typically a host will have to
+    ///     <paramref name="accepted"/> string is the full autocomplete word to be inserted. Typically, a host will have to
     ///     remove some characters such that the <paramref name="accepted"/> string completes the word instead of simply being
     ///     appended.
     /// </summary>

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -1743,7 +1743,7 @@ public class TextFormatter
     ///     (uses <see cref="StringExtensions.GetColumns"/>). <paramref name="text"/> if it contains newlines.
     /// </summary>
     /// <remarks>
-    ///     This API will return incorrect results if the text includes glyphs who's width is dependent on surrounding
+    ///     This API will return incorrect results if the text includes glyphs whose width is dependent on surrounding
     ///     glyphs (e.g. Arabic).
     /// </remarks>
     /// <param name="text">Text, may contain newlines.</param>
@@ -1761,7 +1761,7 @@ public class TextFormatter
     ///     <paramref name="length"/>.
     /// </summary>
     /// <remarks>
-    ///     This API will return incorrect results if the text includes glyphs who's width is dependent on surrounding
+    ///     This API will return incorrect results if the text includes glyphs whose width is dependent on surrounding
     ///     glyphs (e.g. Arabic).
     /// </remarks>
     /// <param name="text">The text.</param>
@@ -1786,7 +1786,7 @@ public class TextFormatter
 
     /// <summary>Gets the number of the Runes in the text that will fit in <paramref name="width"/>.</summary>
     /// <remarks>
-    ///     This API will return incorrect results if the text includes glyphs who's width is dependent on surrounding
+    ///     This API will return incorrect results if the text includes glyphs whose width is dependent on surrounding
     ///     glyphs (e.g. Arabic).
     /// </remarks>
     /// <param name="text">The text.</param>
@@ -1801,7 +1801,7 @@ public class TextFormatter
 
     /// <summary>Gets the number of the Runes in a list of Runes that will fit in <paramref name="width"/>.</summary>
     /// <remarks>
-    ///     This API will return incorrect results if the text includes glyphs who's width is dependent on surrounding
+    ///     This API will return incorrect results if the text includes glyphs whose width is dependent on surrounding
     ///     glyphs (e.g. Arabic).
     /// </remarks>
     /// <param name="runes">The list of runes.</param>
@@ -1856,7 +1856,7 @@ public class TextFormatter
 
     /// <summary>Gets the index position from the list based on the <paramref name="width"/>.</summary>
     /// <remarks>
-    ///     This API will return incorrect results if the text includes glyphs who's width is dependent on surrounding
+    ///     This API will return incorrect results if the text includes glyphs whose width is dependent on surrounding
     ///     glyphs (e.g. Arabic).
     /// </remarks>
     /// <param name="lines">The lines.</param>
@@ -1889,7 +1889,7 @@ public class TextFormatter
 
     /// <summary>Calculates the rectangle required to hold text, assuming no word wrapping or alignment.</summary>
     /// <remarks>
-    ///     This API will return incorrect results if the text includes glyphs who's width is dependent on surrounding
+    ///     This API will return incorrect results if the text includes glyphs whose width is dependent on surrounding
     ///     glyphs (e.g. Arabic).
     /// </remarks>
     /// <param name="x">The x location of the rectangle</param>

--- a/Terminal.Gui/View/Adornment/Border.cs
+++ b/Terminal.Gui/View/Adornment/Border.cs
@@ -74,7 +74,7 @@ public class Border : Adornment
     public override void BeginInit ()
     {
 #if HOVER
-        // TOOD: Hack - make Arragnement overidable
+        // TOOD: Hack - make Arrangement overridable
         if ((Parent?.Arrangement & ViewArrangement.Movable) != 0)
         {
             HighlightStyle |= HighlightStyle.Hover;

--- a/Terminal.Gui/View/Layout/ViewLayout.cs
+++ b/Terminal.Gui/View/Layout/ViewLayout.cs
@@ -554,7 +554,7 @@ public partial class View
     ///         The position and dimensions of the view are indeterminate until the view has been initialized. Therefore, the
     ///         behavior of this method is indeterminate if <see cref="IsInitialized"/> is <see langword="false"/>.
     ///     </para>
-    ///     <para>Raises the <see cref="LayoutComplete"/> event) before it returns.</para>
+    ///     <para>Raises the <see cref="LayoutComplete"/> event before it returns.</para>
     /// </remarks>
     public virtual void LayoutSubviews ()
     {
@@ -644,7 +644,7 @@ public partial class View
         // TODO: Identify a real-world use-case where this API should be virtual. 
         // TODO: Until then leave it `internal` and non-virtual
 
-        // Determine our container's ContentSize - 
+        // Determine our container's ContentSize -
         //  First try SuperView.Viewport, then Application.Top, then Driver.Viewport.
         //  Finally, if none of those are valid, use int.MaxValue (for Unit tests).
         Size superViewContentSize = SuperView is { IsInitialized: true } ? SuperView.GetContentSize () :

--- a/Terminal.Gui/View/View.cs
+++ b/Terminal.Gui/View/View.cs
@@ -268,7 +268,7 @@ public partial class View : Responder, ISupportInitializeNotification
 
         EndInitAdornments ();
 
-        // TODO: Move these into ViewText.cs as EndInit_Text() to consolodate.
+        // TODO: Move these into ViewText.cs as EndInit_Text() to consolidate.
         // TODO: Verify UpdateTextDirection really needs to be called here.
         // These calls were moved from BeginInit as they access Viewport which is indeterminate until EndInit is called.
         UpdateTextDirection (TextDirection);

--- a/Terminal.Gui/View/ViewEventArgs.cs
+++ b/Terminal.Gui/View/ViewEventArgs.cs
@@ -67,7 +67,7 @@ public class FocusEventArgs : EventArgs
 
     /// <summary>
     ///     Indicates if the current focus event has already been processed and the driver should stop notifying any other
-    ///     event subscriber. Its important to set this value to true specially when updating any View's layout from inside the
+    ///     event subscriber. It's important to set this value to true specially when updating any View's layout from inside the
     ///     subscriber method.
     /// </summary>
     public bool Handled { get; set; }

--- a/Terminal.Gui/View/ViewKeyboard.cs
+++ b/Terminal.Gui/View/ViewKeyboard.cs
@@ -57,8 +57,7 @@ public partial class View
     ///     Gets or sets the hot key defined for this view. Pressing the hot key on the keyboard while this view has focus will
     ///     invoke the <see cref="Command.HotKey"/> and <see cref="Command.Accept"/> commands. <see cref="Command.HotKey"/>
     ///     causes the view to be focused and <see cref="Command.Accept"/> does nothing. By default, the HotKey is
-    ///     automatically set to the first character of <see cref="Text"/> that is prefixed with with
-    ///     <see cref="HotKeySpecifier"/>.
+    ///     automatically set to the first character of <see cref="Text"/> that is prefixed with <see cref="HotKeySpecifier"/>.
     ///     <para>
     ///         A HotKey is a keypress that selects a visible UI item. For selecting items across <see cref="View"/>`s (e.g.a
     ///         <see cref="Button"/> in a <see cref="Dialog"/>) the keypress must include the <see cref="Key.WithAlt"/>
@@ -741,11 +740,11 @@ public partial class View
         return false;
     }
 
-    // TODO: This is a "prototype" debug check. It may be too annyoing vs. useful.
-    // TODO: A better approach would be have Application hold a list of bound Hotkeys, similar to
+    // TODO: This is a "prototype" debug check. It may be too annoying vs. useful.
+    // TODO: A better approach would be to have Application hold a list of bound Hotkeys, similar to
     // TODO: how Application holds a list of Application Scoped key bindings and then check that list.
     /// <summary>
-    /// Returns true if Key is bound in this view heirarchy. For debugging
+    /// Returns true if Key is bound in this view hierarchy. For debugging
     /// </summary>
     /// <param name="key">The key to test.</param>
     /// <param name="boundView">Returns the view the key is bound to.</param>
@@ -808,8 +807,8 @@ public partial class View
             Debug.WriteLine ($"WARNING: InvokeKeyBindings ({key}) - An Application scope binding exists for this key. The registered view will not invoke Command.{commandBinding.Commands [0]}: {boundView}.");
         }
 
-        // TODO: This is a "prototype" debug check. It may be too annyoing vs. useful.
-        // Scour the bindings up our View heirarchy
+        // TODO: This is a "prototype" debug check. It may be too annoying vs. useful.
+        // Scour the bindings up our View hierarchy
         // to ensure that the key is not already bound to a different set of commands.
         if (SuperView?.IsHotKeyKeyBound (key, out View previouslyBoundView) ?? false)
         {

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -118,10 +118,10 @@ public class ComboBox : View, IDesignable
         set => _hideDropdownListOnClick = _listview.HideDropdownListOnClick = value;
     }
 
-    /// <summary>Gets the drop down list state, expanded or collapsed.</summary>
+    /// <summary>Gets the drop-down list state, expanded or collapsed.</summary>
     public bool IsShow { get; private set; }
 
-    /// <summary>If set to true its not allow any changes in the text.</summary>
+    /// <summary>If set to true, no changes to the text will be allowed.</summary>
     public bool ReadOnly
     {
         get => _search.ReadOnly;
@@ -200,7 +200,7 @@ public class ComboBox : View, IDesignable
     }
 
     /// <summary>
-    ///     Collapses the drop down list.  Returns true if the state chagned or false if it was already collapsed and no
+    ///     Collapses the drop-down list.  Returns true if the state changed or false if it was already collapsed and no
     ///     action was taken
     /// </summary>
     public virtual bool Collapse ()
@@ -220,7 +220,7 @@ public class ComboBox : View, IDesignable
     public event EventHandler Collapsed;
 
     /// <summary>
-    ///     Expands the drop down list.  Returns true if the state chagned or false if it was already expanded and no
+    ///     Expands the drop-down list.  Returns true if the state changed or false if it was already expanded and no
     ///     action was taken
     /// </summary>
     public virtual bool Expand ()
@@ -398,7 +398,7 @@ public class ComboBox : View, IDesignable
 
     /// <summary>Internal height of dynamic search list</summary>
     /// <returns></returns>
-    private int CalculatetHeight ()
+    private int CalculateHeight ()
     {
         if (!IsInitialized || Viewport.Height == 0)
         {
@@ -617,7 +617,7 @@ public class ComboBox : View, IDesignable
             || (_autoHide && Viewport.Width > 0 && _search.Frame.Width != Viewport.Width - 1))
         {
             _search.Width = _listview.Width = _autoHide ? Viewport.Width - 1 : Viewport.Width;
-            _listview.Height = CalculatetHeight ();
+            _listview.Height = CalculateHeight ();
             _search.SetRelativeLayout (GetContentSize ());
             _listview.SetRelativeLayout (GetContentSize ());
         }
@@ -634,7 +634,7 @@ public class ComboBox : View, IDesignable
         ResetSearchSet ();
 
         _listview.SetSource (_searchSet);
-        _listview.Height = CalculatetHeight ();
+        _listview.Height = CalculateHeight ();
 
         if (Subviews.Count > 0 && HasFocus)
         {
@@ -769,7 +769,7 @@ public class ComboBox : View, IDesignable
 
     private void SetValue (object text, bool isFromSelectedItem = false)
     {
-        // TOOD: THe fact we have to suspend events to change the text makes this feel very hacky.
+        // TOOD: The fact we have to suspend events to change the text makes this feel very hacky.
         _search.TextChanged -= Search_Changed;
         // Note we set _text, to avoid set_Text from setting _search.Text again
         _text = _search.Text = text.ToString ();
@@ -792,7 +792,7 @@ public class ComboBox : View, IDesignable
         _listview.ResumeSuspendCollectionChangedEvent ();
 
         _listview.Clear ();
-        _listview.Height = CalculatetHeight ();
+        _listview.Height = CalculateHeight ();
         SuperView?.BringSubviewToFront (this);
     }
 

--- a/Terminal.Gui/Views/DateField.cs
+++ b/Terminal.Gui/Views/DateField.cs
@@ -201,10 +201,10 @@ public class DateField : TextField
             }
 
             spaces += FormatLength;
-            string trimedText = e.NewValue [..spaces];
+            string trimmedText = e.NewValue [..spaces];
             spaces -= FormatLength;
-            trimedText = trimedText.Replace (new string (' ', spaces), " ");
-            var date = Convert.ToDateTime (trimedText).ToString (_format.Trim ());
+            trimmedText = trimmedText.Replace (new string (' ', spaces), " ");
+            var date = Convert.ToDateTime (trimmedText).ToString (_format.Trim ());
 
             if ($" {date}" != e.NewValue)
             {
@@ -542,8 +542,8 @@ public class DateField : TextField
         return true;
     }
 
-    // Converts various date formats to a uniform 10-character format. 
-    // This aids in simplifying the handling of single-digit months and days, 
+    // Converts various date formats to a uniform 10-character format.
+    // This aids in simplifying the handling of single-digit months and days,
     // and reduces the number of distinct date formats to maintain.
     private static string StandardizeDateFormat (string format)
     {

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -587,7 +587,7 @@ public class FileDialog : Dialog
     {
         FileSystemInfoStats [] stats = State?.Children ?? new FileSystemInfoStats[0];
 
-        // This portion is never reordered (aways .. at top then folders)
+        // This portion is never reordered (always .. at top then folders)
         IOrderedEnumerable<FileSystemInfoStats> forcedOrder = stats
                                                               .OrderByDescending (f => f.IsParent)
                                                               .ThenBy (f => f.IsDir ? -1 : 100);
@@ -667,7 +667,7 @@ public class FileDialog : Dialog
             return;
         }
 
-        // Don't include ".." (IsParent) in multiselections
+        // Don't include ".." (IsParent) in multi-selections
         MultiSelected = toMultiAccept
                         .Where (s => !s.IsParent)
                         .Select (s => s.FileSystemInfo.FullName)

--- a/Terminal.Gui/Views/GraphView/Axis.cs
+++ b/Terminal.Gui/Views/GraphView/Axis.cs
@@ -80,7 +80,7 @@ public abstract class Axis
     private string DefaultLabelGetter (AxisIncrementToRender toRender) { return toRender.Value.ToString ("N0"); }
 }
 
-/// <summary>The horizontal (x axis) of a <see cref="GraphView"/></summary>
+/// <summary>The horizontal (x-axis) of a <see cref="GraphView"/></summary>
 public class HorizontalAxis : Axis
 {
     /// <summary>
@@ -132,7 +132,7 @@ public class HorizontalAxis : Axis
         }
     }
 
-    /// <summary>Draws the horizontal x axis labels and <see cref="Axis.Increment"/> ticks</summary>
+    /// <summary>Draws the horizontal x-axis labels and <see cref="Axis.Increment"/> ticks</summary>
     public override void DrawAxisLabels (GraphView graph)
     {
         if (!Visible || Increment == 0)
@@ -180,10 +180,10 @@ public class HorizontalAxis : Axis
 
         int y = GetAxisYPosition (graph);
 
-        // start the x axis at left of screen (either 0 or margin)
+        // start the x-axis at left of screen (either 0 or margin)
         var xStart = (int)graph.MarginLeft;
 
-        // but if the x axis has a minmum (minimum is in graph space units)
+        // but if the x-axis has a minimum (minimum is in graph space units)
         if (Minimum.HasValue)
         {
             // start at the screen location of the minimum
@@ -257,7 +257,7 @@ public class HorizontalAxis : Axis
             // Not every increment has to have a label
             if (ShowLabelsEvery != 0)
             {
-                // if this increment does also needs a label
+                // if this increment also needs a label
                 if (labels++ % ShowLabelsEvery == 0)
                 {
                     toRender.Text = LabelGetter (toRender);
@@ -403,7 +403,7 @@ public class VerticalAxis : Axis
         // draw down the screen (0 is top of screen)
         // end at the bottom of the screen
 
-        //unless there is a minimum 
+        //unless there is a minimum
         if (Minimum.HasValue)
         {
             return graph.GraphSpaceToScreen (new PointF (0, Minimum.Value)).Y;

--- a/Terminal.Gui/Views/GraphView/Series.cs
+++ b/Terminal.Gui/Views/GraphView/Series.cs
@@ -51,7 +51,7 @@ public class MultiBarSeries : ISeries
 
     /// <summary>Creates a new series of clustered bars.</summary>
     /// <param name="numberOfBarsPerCategory">Each category has this many bars</param>
-    /// <param name="barsEvery">How far appart to put each category (in graph space)</param>
+    /// <param name="barsEvery">How far apart to put each category (in graph space)</param>
     /// <param name="spacing">
     ///     How much spacing between bars in a category (should be less than <paramref name="barsEvery"/>/
     ///     <paramref name="numberOfBarsPerCategory"/>)
@@ -97,7 +97,7 @@ public class MultiBarSeries : ISeries
 
     /// <summary>
     ///     Sub collections.  Each series contains the bars for a different category.  Thus SubSeries[0].Bars[0] is the
-    ///     first bar on the axis and SubSeries[1].Bars[0] is the second etc
+    ///     first bar on the axis and SubSeries[1].Bars[0] is the second etc.
     /// </summary>
     public IReadOnlyCollection<BarSeries> SubSeries => new ReadOnlyCollection<BarSeries> (subSeries);
 
@@ -191,7 +191,7 @@ public class BarSeries : ISeries
             {
                 screenStart.X = graph.AxisY.GetAxisXPosition (graph);
 
-                // dont draw bar off the right of the control
+                // don't draw bar off the right of the control
                 screenEnd.X = Math.Min (graph.Viewport.Width - 1, screenEnd.X);
 
                 // if bar is off the screen
@@ -205,7 +205,7 @@ public class BarSeries : ISeries
                 // Start the axis
                 screenStart.Y = graph.AxisX.GetAxisYPosition (graph);
 
-                // dont draw bar up above top of control
+                // don't draw bar up above top of control
                 screenEnd.Y = Math.Max (0, screenEnd.Y);
 
                 // if bar is off the screen

--- a/Terminal.Gui/Views/HexView.cs
+++ b/Terminal.Gui/Views/HexView.cs
@@ -130,7 +130,7 @@ public class HexView : View
     }
 
     /// <summary>
-    ///     Sets or gets the offset into the <see cref="Stream"/> that will displayed at the top of the
+    ///     Sets or gets the offset into the <see cref="Stream"/> that will be displayed at the top of the
     ///     <see cref="HexView"/>
     /// </summary>
     /// <value>The display start.</value>
@@ -557,9 +557,9 @@ public class HexView : View
     }
 
     //
-    // This is used to support editing of the buffer on a peer List<>, 
+    // This is used to support editing of the buffer on a peer List<>,
     // the offset corresponds to an offset relative to DisplayStart, and
-    // the buffer contains the contents of a screenful of data, so the 
+    // the buffer contains the contents of a screenful of data, so the
     // offset is relative to the buffer.
     //
     // 

--- a/Terminal.Gui/Views/Menu/ContextMenu.cs
+++ b/Terminal.Gui/Views/Menu/ContextMenu.cs
@@ -18,7 +18,7 @@
 ///         Callers can cause the ContextMenu to be activated on a right-mouse click (or other interaction) by calling
 ///         <see cref="Show()"/>.
 ///     </para>
-///     <para>ContextMenus are located using screen using screen coordinates and appear above all other Views.</para>
+///     <para>ContextMenus are located using screen coordinates and appear above all other Views.</para>
 /// </summary>
 public sealed class ContextMenu : IDisposable
 {

--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -282,7 +282,7 @@ internal sealed class Menu : View
             return true;
         }
 
-        // TODO: Determine if there's a cleaner way to handle this
+        // TODO: Determine if there's a cleaner way to handle this.
         // This supports the case where the menu bar is a context menu
         return _host.OnInvokingKeyBindings (keyEvent, scope);
     }

--- a/Terminal.Gui/Views/Menu/MenuBar.cs
+++ b/Terminal.Gui/Views/Menu/MenuBar.cs
@@ -317,7 +317,7 @@ public class MenuBar : View, IDesignable
 
     /// <summary>Virtual method that will invoke the <see cref="MenuClosing"/>.</summary>
     /// <param name="currentMenu">The current menu to be closed.</param>
-    /// <param name="reopen">Whether the current menu will be reopen.</param>
+    /// <param name="reopen">Whether the current menu will be reopened.</param>
     /// <param name="isSubMenu">Whether is a sub-menu or not.</param>
     public virtual MenuClosingEventArgs OnMenuClosing (MenuBarItem currentMenu, bool reopen, bool isSubMenu)
     {

--- a/Terminal.Gui/Views/MessageBox.cs
+++ b/Terminal.Gui/Views/MessageBox.cs
@@ -435,7 +435,7 @@ public static class MessageBox
             }
         }
 
-        // Run the modal; do not shutdown the mainloop driver when done
+        // Run the modal; do not shut down the mainloop driver when done
         Application.Run (d);
         d.Dispose ();
 

--- a/Terminal.Gui/Views/SelectedItemChangedArgs.cs
+++ b/Terminal.Gui/Views/SelectedItemChangedArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace Terminal.Gui;
 
-/// <summary>Event arguments for the SelectedItemChagned event.</summary>
+/// <summary>Event arguments for the SelectedItemChanged event.</summary>
 public class SelectedItemChangedArgs : EventArgs
 {
     /// <summary>Initializes a new <see cref="SelectedItemChangedArgs"/> class.</summary>

--- a/Terminal.Gui/Views/Slider.cs
+++ b/Terminal.Gui/Views/Slider.cs
@@ -396,7 +396,7 @@ public class Slider<T> : View
     /// <summary>Causes the specified option to be set and be focused.</summary>
     public bool SetOption (int optionIndex)
     {
-        // TODO: Handle range type.			
+        // TODO: Handle range type.
         // Note: Maybe return false only when optionIndex doesn't exist, otherwise true.
 
         if (!_setOptions.Contains (optionIndex) && optionIndex >= 0 && optionIndex < _options.Count)
@@ -1285,9 +1285,9 @@ public class Slider<T> : View
     protected internal override bool OnMouseEvent (MouseEvent mouseEvent)
     {
         // Note(jmperricone): Maybe we click to focus the cursor, and on next click we set the option.
-        //                    That will makes OptionFocused Event more relevant.
+        //                    That will make OptionFocused Event more relevant.
         // (tig: I don't think so. Maybe an option if someone really wants it, but for now that
-        //       adss to much friction to UI.
+        //       adds too much friction to UI.
         // TODO(jmperricone): Make Range Type work with mouse.
 
         if (!(mouseEvent.Flags.HasFlag (MouseFlags.Button1Clicked)
@@ -1325,7 +1325,7 @@ public class Slider<T> : View
             var success = false;
             var option = 0;
 
-            // how far has user dragged from original location?						
+            // how far has user dragged from original location?
             if (Orientation == Orientation.Horizontal)
             {
                 success = TryGetOptionByPosition (mouseEvent.Position.X, 0, Math.Max (0, _config._cachedInnerSpacing / 2), out option);

--- a/Terminal.Gui/Views/SliderOption.cs
+++ b/Terminal.Gui/Views/SliderOption.cs
@@ -15,7 +15,7 @@ public class SliderOption<T>
         Data = data;
     }
 
-    /// <summary>Event fired when the an option has changed.</summary>
+    /// <summary>Event fired when an option has changed.</summary>
     public event EventHandler<SliderOptionEventArgs> Changed;
 
     /// <summary>Custom data of the option.</summary>

--- a/Terminal.Gui/Views/Tab.cs
+++ b/Terminal.Gui/Views/Tab.cs
@@ -5,7 +5,7 @@ public class Tab : View
 {
     private string _displayText;
 
-    /// <summary>Creates a new unamed tab with no controls inside.</summary>
+    /// <summary>Creates a new unnamed tab with no controls inside.</summary>
     public Tab ()
     {
         BorderStyle = LineStyle.Rounded;
@@ -16,7 +16,7 @@ public class Tab : View
     /// <value></value>
     public string DisplayText
     {
-        get => _displayText ?? "Unamed";
+        get => _displayText ?? "Unnamed";
         set => _displayText = value;
     }
 

--- a/Terminal.Gui/Views/TabView.cs
+++ b/Terminal.Gui/Views/TabView.cs
@@ -1296,7 +1296,7 @@ public class TabView : View
                 {
                     if (_host.Focused == this)
                     {
-                        // if focus is the tab bar ourself then show that they can switch tabs
+                        // if focus is the tab bar itself then show that they can switch tabs
                         prevAttr = ColorScheme.HotFocus;
                     }
                     else

--- a/Terminal.Gui/Views/TableView/EnumerableTableSource.cs
+++ b/Terminal.Gui/Views/TableView/EnumerableTableSource.cs
@@ -5,7 +5,7 @@
 public class EnumerableTableSource<T> : IEnumerableTableSource<T>
 {
     private readonly T [] data;
-    private readonly Dictionary<string, Func<T, object>> lamdas;
+    private readonly Dictionary<string, Func<T, object>> lambdas;
 
     /// <summary>Creates a new instance of the class that presents <paramref name="data"/> collection as a table.</summary>
     /// <remarks>
@@ -29,14 +29,14 @@ public class EnumerableTableSource<T> : IEnumerableTableSource<T>
     {
         this.data = data.ToArray ();
         ColumnNames = columnDefinitions.Keys.ToArray ();
-        lamdas = columnDefinitions;
+        lambdas = columnDefinitions;
     }
 
     /// <summary>Gets the object collection hosted by this wrapper.</summary>
     public IReadOnlyCollection<T> Data => data.AsReadOnly ();
 
     /// <inheritdoc/>
-    public object this [int row, int col] => lamdas [ColumnNames [col]] (data [row]);
+    public object this [int row, int col] => lambdas [ColumnNames [col]] (data [row]);
 
     /// <inheritdoc/>
     public int Rows => data.Length;

--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -1438,13 +1438,13 @@ public class TableView : View
                     // is there enough space to meet the MinAcceptableWidth
                     availableHorizontalSpace - usedSpace >= colStyle.MinAcceptableWidth)
                 {
-                    // show column and use use whatever space is 
+                    // show column and use whatever space is
                     // left for rendering it
                     showColumn = true;
                     colWidth = availableHorizontalSpace - usedSpace;
                 }
 
-                // If its the only column we are able to render then
+                // If it's the only column we are able to render then
                 // accept it anyway (that must be one massively wide column!)
                 if (first)
                 {
@@ -1674,7 +1674,7 @@ public class TableView : View
                 }
                 else if (Style.ExpandLastColumn == false && columnsToRender.Any (r => r.IsVeryLast && r.X + r.Width - 1 == c))
                 {
-                    // if the next console column is the lastcolumns end
+                    // if the next console column is the last column's end
                     rune = Glyphs.BottomTee;
                 }
             }
@@ -1748,7 +1748,7 @@ public class TableView : View
                     rune = Glyphs.URCorner;
                 }
 
-                // if the next console column is the lastcolumns end
+                // if the next console column is the last column's end
                 else if (Style.ExpandLastColumn == false && columnsToRender.Any (r => r.IsVeryLast && r.X + r.Width - 1 == c))
                 {
                     rune = Glyphs.TopTee;
@@ -1841,7 +1841,7 @@ public class TableView : View
                     }
                 }
 
-                // if the next console column is the lastcolumns end
+                // if the next console column is the last column's end
                 else if (Style.ExpandLastColumn == false && columnsToRender.Any (r => r.IsVeryLast && r.X + r.Width - 1 == c))
                 {
                     rune = Style.ShowVerticalCellLines ? Glyphs.Cross : Glyphs.BottomTee;

--- a/Terminal.Gui/Views/TableView/TreeTableSource.cs
+++ b/Terminal.Gui/Views/TableView/TreeTableSource.cs
@@ -4,7 +4,7 @@ namespace Terminal.Gui;
 /// <typeparam name="T"></typeparam>
 public class TreeTableSource<T> : IEnumerableTableSource<T>, IDisposable where T : class
 {
-    private readonly Dictionary<string, Func<T, object>> _lamdas;
+    private readonly Dictionary<string, Func<T, object>> _lambdas;
     private readonly TableView _tableView;
     private readonly TreeView<T> _tree;
 
@@ -47,7 +47,7 @@ public class TreeTableSource<T> : IEnumerableTableSource<T>, IDisposable where T
 
         ColumnNames = colList.ToArray ();
 
-        _lamdas = subsequentColumns;
+        _lambdas = subsequentColumns;
     }
 
     /// <inheritdoc/>
@@ -60,13 +60,13 @@ public class TreeTableSource<T> : IEnumerableTableSource<T>, IDisposable where T
 
     /// <inheritdoc/>
     public object this [int row, int col] =>
-        col == 0 ? GetColumnZeroRepresentationFromTree (row) : _lamdas [ColumnNames [col]] (RowToObject (row));
+        col == 0 ? GetColumnZeroRepresentationFromTree (row) : _lambdas [ColumnNames [col]] (RowToObject (row));
 
     /// <inheritdoc/>
     public int Rows => _tree.BuildLineMap ().Count;
 
     /// <inheritdoc/>
-    public int Columns => _lamdas.Count + 1;
+    public int Columns => _lambdas.Count + 1;
 
     /// <inheritdoc/>
     public string [] ColumnNames { get; }

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -1105,7 +1105,7 @@ public class TextField : View
     }
 
     /// <summary>Virtual method that invoke the <see cref="TextChanging"/> event if it's defined.</summary>
-    /// <param name="args">The event arguments..</param>
+    /// <param name="args">The event arguments.</param>
     /// <returns><see langword="true"/> if the event was cancelled.</returns>
     public bool OnTextChanging (CancelEventArgs<string> args)
     {

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -334,7 +334,7 @@ internal class TextModel
                         {
                             lastValidCol = nCol;
 
-                            if (runeType == RuneType.IsWhiteSpace || runeType == RuneType.IsUnknow)
+                            if (runeType == RuneType.IsWhiteSpace || runeType == RuneType.IsUnknown)
                             {
                                 runeType = GetRuneType (nRune);
                             }
@@ -1063,7 +1063,7 @@ internal class TextModel
             return RuneType.IsPunctuation;
         }
 
-        return RuneType.IsUnknow;
+        return RuneType.IsUnknown;
     }
 
     private bool IsSameRuneType (Rune newRune, RuneType runeType)
@@ -1255,7 +1255,7 @@ internal class TextModel
         IsWhiteSpace,
         IsLetterOrDigit,
         IsPunctuation,
-        IsUnknow
+        IsUnknown
     }
 }
 
@@ -1772,8 +1772,8 @@ internal class WordWrapManager
         nCol = 0;
         nStartRow = 0;
         nStartCol = 0;
-        bool isRowAndColSetted = row == 0 && col == 0;
-        bool isStartRowAndColSetted = startRow == 0 && startCol == 0;
+        bool isRowAndColSet = row == 0 && col == 0;
+        bool isStartRowAndColSet = startRow == 0 && startCol == 0;
         List<WrappedLine> wModelLines = new ();
 
         for (var i = 0; i < Model.Count; i++)
@@ -1796,7 +1796,7 @@ internal class WordWrapManager
             {
                 List<RuneCell> wrapLine = wrappedLines [j];
 
-                if (!isRowAndColSetted && modelRow == i)
+                if (!isRowAndColSet && modelRow == i)
                 {
                     if (nCol + wrapLine.Count <= modelCol)
                     {
@@ -1806,12 +1806,12 @@ internal class WordWrapManager
                         if (nCol == modelCol)
                         {
                             nCol = wrapLine.Count;
-                            isRowAndColSetted = true;
+                            isRowAndColSet = true;
                         }
                         else if (j == wrappedLines.Count - 1)
                         {
                             nCol = wrapLine.Count - j + modelCol - nCol;
-                            isRowAndColSetted = true;
+                            isRowAndColSet = true;
                         }
                     }
                     else
@@ -1819,11 +1819,11 @@ internal class WordWrapManager
                         int offset = nCol + wrapLine.Count - modelCol;
                         nCol = wrapLine.Count - offset;
                         nRow = lines;
-                        isRowAndColSetted = true;
+                        isRowAndColSet = true;
                     }
                 }
 
-                if (!isStartRowAndColSetted && modelStartRow == i)
+                if (!isStartRowAndColSet && modelStartRow == i)
                 {
                     if (nStartCol + wrapLine.Count <= modelStartCol)
                     {
@@ -1833,12 +1833,12 @@ internal class WordWrapManager
                         if (nStartCol == modelStartCol)
                         {
                             nStartCol = wrapLine.Count;
-                            isStartRowAndColSetted = true;
+                            isStartRowAndColSet = true;
                         }
                         else if (j == wrappedLines.Count - 1)
                         {
                             nStartCol = wrapLine.Count - j + modelStartCol - nStartCol;
-                            isStartRowAndColSetted = true;
+                            isStartRowAndColSet = true;
                         }
                     }
                     else
@@ -1846,7 +1846,7 @@ internal class WordWrapManager
                         int offset = nStartCol + wrapLine.Count - modelStartCol;
                         nStartCol = wrapLine.Count - offset;
                         nStartRow = lines;
-                        isStartRowAndColSetted = true;
+                        isStartRowAndColSet = true;
                     }
                 }
 
@@ -2547,14 +2547,14 @@ public class TextView : View
 
             if (_allowsReturn && !_multiline)
             {
-                // BUGBUG: Seting properties should not have side-effects like this. Multiline and AllowsReturn should be independent.
+                // BUGBUG: Setting properties should not have side-effects like this. Multiline and AllowsReturn should be independent.
                 Multiline = true;
             }
 
             if (!_allowsReturn && _multiline)
             {
                 Multiline = false;
-                // BUGBUG: Seting properties should not have side-effects like this. Multiline and AlowsTab should be independent.
+                // BUGBUG: Setting properties should not have side-effects like this. Multiline and AllowsTab should be independent.
                 AllowsTab = false;
             }
 

--- a/Terminal.Gui/Views/TileView.cs
+++ b/Terminal.Gui/Views/TileView.cs
@@ -935,7 +935,7 @@ public class TileView : View
             {
                 // Continue Drag
 
-                // how far has user dragged from original location?						
+                // how far has user dragged from original location?
                 if (Orientation == Orientation.Horizontal)
                 {
                     int dy = mouseEvent.Position.Y - dragPosition.Value.Y;

--- a/Terminal.Gui/Views/TimeField.cs
+++ b/Terminal.Gui/Views/TimeField.cs
@@ -449,13 +449,13 @@ public class TimeField : TextField
             }
 
             spaces += FieldLength;
-            string trimedText = e.NewValue [..spaces];
+            string trimmedText = e.NewValue [..spaces];
             spaces -= FieldLength;
-            trimedText = trimedText.Replace (new string (' ', spaces), " ");
+            trimmedText = trimmedText.Replace (new string (' ', spaces), " ");
 
-            if (trimedText != e.NewValue)
+            if (trimmedText != e.NewValue)
             {
-                e.NewValue = trimedText;
+                e.NewValue = trimmedText;
             }
 
             if (!TimeSpan.TryParseExact (

--- a/Terminal.Gui/Views/TreeView/Branch.cs
+++ b/Terminal.Gui/Views/TreeView/Branch.cs
@@ -93,7 +93,7 @@ internal class Branch<T> where T : class
 
         tree.Move (0, y);
 
-        // if we have scrolled to the right then bits of the prefix will have dispeared off the screen
+        // if we have scrolled to the right then bits of the prefix will have disappeared off the screen
         int toSkip = tree.ScrollOffsetHorizontal;
         Attribute attr = symbolColor;
 
@@ -329,7 +329,7 @@ internal class Branch<T> where T : class
             Parent?.Refresh (true);
         }
 
-        // we don't want to loose the state of our children so lets be selective about how we refresh
+        // we don't want to lose the state of our children so lets be selective about how we refresh
         //if we don't know about any children yet just use the normal method
         if (ChildBranches is null)
         {
@@ -347,7 +347,7 @@ internal class Branch<T> where T : class
             {
                 ChildBranches.Remove (toRemove);
 
-                //also if the user has this node selected (its disapearing) so lets change selection to us (the parent object) to be helpful
+                //also if the user has this node selected (its disappearing) so lets change selection to us (the parent object) to be helpful
                 if (Equals (tree.SelectedObject, toRemove))
                 {
                     tree.SelectedObject = Model;
@@ -357,14 +357,14 @@ internal class Branch<T> where T : class
             // New children need to be added
             foreach (T newChild in newChildren)
             {
-                // If we don't know about the child yet we need a new branch
+                // If we don't know about the child, yet we need a new branch
                 if (!ChildBranches.ContainsKey (newChild))
                 {
                     ChildBranches.Add (newChild, new Branch<T> (tree, this, newChild));
                 }
                 else
                 {
-                    //we already have this object but update the reference anyway incase Equality match but the references are new
+                    //we already have this object but update the reference anyway in case Equality match but the references are new
                     ChildBranches [newChild].Model = newChild;
                 }
             }
@@ -486,7 +486,7 @@ internal class Branch<T> where T : class
         {
             if (IsExpanded)
             {
-                //if we are expanded we need to updatethe visible children
+                // if we are expanded we need to update the visible children
                 foreach (KeyValuePair<T, Branch<T>> child in ChildBranches)
                 {
                     child.Value.Rebuild ();
@@ -515,7 +515,7 @@ internal class Branch<T> where T : class
     }
 
     /// <summary>
-    ///     Returns true if this branch has parents and it is the last node of it's parents branches (or last root of the
+    ///     Returns true if this branch has parents, and it is the last node of its parents branches (or last root of the
     ///     tree).
     /// </summary>
     /// <returns></returns>

--- a/Terminal.Gui/Views/TreeView/DrawTreeViewLineEventArgs.cs
+++ b/Terminal.Gui/Views/TreeView/DrawTreeViewLineEventArgs.cs
@@ -19,7 +19,7 @@ public class DrawTreeViewLineEventArgs<T> where T : class
 
     /// <summary>
     ///     The notional index in <see cref="RuneCells"/> which contains the first character of the
-    ///     <see cref="TreeView{T}.AspectGetter"/> text (i.e. after all branch lines and expansion/collapse sybmols).
+    ///     <see cref="TreeView{T}.AspectGetter"/> text (i.e. after all branch lines and expansion/collapse symbols).
     /// </summary>
     /// <remarks>May be negative or outside of bounds of <see cref="RuneCells"/> if the view has been scrolled horizontally.</remarks>
     public int IndexOfModelText { get; init; }

--- a/Terminal.Gui/Views/TreeView/TreeNode.cs
+++ b/Terminal.Gui/Views/TreeView/TreeNode.cs
@@ -1,7 +1,7 @@
 ﻿namespace Terminal.Gui;
 
 /// <summary>
-///     Interface to implement when you want the regular (non generic) <see cref="TreeView"/> to automatically
+///     Interface to implement when you want the regular (non-generic) <see cref="TreeView"/> to automatically
 ///     determine children for your class (without having to specify an <see cref="ITreeBuilder{T}"/>)
 /// </summary>
 public interface ITreeNode
@@ -17,7 +17,7 @@ public interface ITreeNode
     string Text { get; set; }
 }
 
-/// <summary>Simple class for representing nodes, use with regular (non generic) <see cref="TreeView"/>.</summary>
+/// <summary>Simple class for representing nodes, use with regular (non-generic) <see cref="TreeView"/>.</summary>
 public class TreeNode : ITreeNode
 {
     /// <summary>Initialises a new instance with no <see cref="Text"/></summary>
@@ -39,5 +39,5 @@ public class TreeNode : ITreeNode
 
     /// <summary>returns <see cref="Text"/></summary>
     /// <returns></returns>
-    public override string ToString () { return Text ?? "Unamed Node"; }
+    public override string ToString () { return Text ?? "Unnamed Node"; }
 }

--- a/Terminal.Gui/Views/TreeView/TreeStyle.cs
+++ b/Terminal.Gui/Views/TreeView/TreeStyle.cs
@@ -29,7 +29,7 @@ public class TreeStyle
     public bool InvertExpandSymbolColors { get; set; }
 
     /// <summary>
-    ///     <see langword="true"/> to leave the last row of the control free for overwritting (e.g. by a scrollbar) When
+    ///     <see langword="true"/> to leave the last row of the control free for overwriting (e.g. by a scrollbar) When
     ///     <see langword="true"/> scrolling will be triggered on the second last row of the control rather than. the last.
     /// </summary>
     /// <value></value>

--- a/Terminal.Gui/Views/TreeView/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView/TreeView.cs
@@ -35,7 +35,7 @@ public class TreeView : TreeView<ITreeNode>
     public TreeView ()
     {
         TreeBuilder = new TreeNodeBuilder ();
-        AspectGetter = o => o is null ? "Null" : o.Text ?? o?.ToString () ?? "Unamed Node";
+        AspectGetter = o => o is null ? "Null" : o.Text ?? o?.ToString () ?? "Unnamed Node";
     }
 }
 
@@ -72,7 +72,7 @@ public class TreeView<T> : View, ITreeView where T : class
     private T selectedObject;
 
     /// <summary>
-    ///     Creates a new tree view with absolute positioning. Use <see cref="AddObjects(IEnumerable{T})"/> to set set
+    ///     Creates a new tree view with absolute positioning. Use <see cref="AddObjects(IEnumerable{T})"/> to set
     ///     root objects for the tree. Children will not be rendered until you set <see cref="TreeBuilder"/>.
     /// </summary>
     public TreeView ()
@@ -299,7 +299,7 @@ public class TreeView<T> : View, ITreeView where T : class
 
     /// <summary>
     ///     Initialises <see cref="TreeBuilder"/>.Creates a new tree view with absolute positioning. Use
-    ///     <see cref="AddObjects(IEnumerable{T})"/> to set set root objects for the tree.
+    ///     <see cref="AddObjects(IEnumerable{T})"/> to set root objects for the tree.
     /// </summary>
     public TreeView (ITreeBuilder<T> builder) : this () { TreeBuilder = builder; }
 
@@ -315,7 +315,7 @@ public class TreeView<T> : View, ITreeView where T : class
     public AspectGetterDelegate<T> AspectGetter { get; set; } = o => o.ToString () ?? "";
 
     /// <summary>
-    ///     Delegate for multi colored tree views. Return the <see cref="ColorScheme"/> to use for each passed object or
+    ///     Delegate for multi-colored tree views. Return the <see cref="ColorScheme"/> to use for each passed object or
     ///     null to use the default.
     /// </summary>
     public Func<T, ColorScheme> ColorGetter { get; set; }
@@ -374,7 +374,7 @@ public class TreeView<T> : View, ITreeView where T : class
 
     /// <summary>The amount of tree view that has been scrolled off the top of the screen (by the user scrolling down).</summary>
     /// <remarks>
-    ///     Setting a value of less than 0 will result in a offset of 0. To see changes in the UI call
+    ///     Setting a value of less than 0 will result in an offset of 0. To see changes in the UI call
     ///     <see cref="View.SetNeedsDisplay()"/>.
     /// </remarks>
     public int ScrollOffsetVertical
@@ -402,7 +402,7 @@ public class TreeView<T> : View, ITreeView where T : class
         }
     }
 
-    /// <summary>Determines how sub branches of the tree are dynamically built at runtime as the user expands root nodes.</summary>
+    /// <summary>Determines how sub-branches of the tree are dynamically built at runtime as the user expands root nodes.</summary>
     /// <value></value>
     public ITreeBuilder<T> TreeBuilder { get; set; }
 
@@ -500,7 +500,7 @@ public class TreeView<T> : View, ITreeView where T : class
     /// </param>
     public void AdjustSelection (int offset, bool expandSelection = false)
     {
-        // if it is not a shift click or we don't allow multi select
+        // if it is not a shift click, or we don't allow multi select
         if (!expandSelection || !MultiSelect)
         {
             multiSelectedRegions.Clear ();
@@ -518,7 +518,7 @@ public class TreeView<T> : View, ITreeView where T : class
 
             if (idx == -1)
             {
-                // The current selection has disapeared!
+                // The current selection has disappeared!
                 SelectedObject = roots.Keys.FirstOrDefault ();
             }
             else
@@ -1090,7 +1090,7 @@ public class TreeView<T> : View, ITreeView where T : class
             SelectedObject = clickedBranch.Model;
             SetNeedsDisplay ();
 
-            // trigger activation event				
+            // trigger activation event
             OnObjectActivated (new ObjectActivatedEventArgs<T> (this, clickedBranch.Model));
 
             // mouse event is handled.
@@ -1324,7 +1324,7 @@ public class TreeView<T> : View, ITreeView where T : class
 
     /// <summary>
     ///     Implementation of <see cref="Collapse(T)"/> and <see cref="CollapseAll(T)"/>. Performs operation and updates
-    ///     selection if disapeared.
+    ///     selection if disappeared.
     /// </summary>
     /// <param name="toCollapse"></param>
     /// <param name="all"></param>

--- a/Terminal.Gui/Views/Wizard/Wizard.cs
+++ b/Terminal.Gui/Views/Wizard/Wizard.cs
@@ -195,7 +195,7 @@ public class Wizard : Dialog
     }
 
     /// <summary>
-    ///     Raised when the user has cancelled the <see cref="Wizard"/> by pressin the Esc key. To prevent a modal (
+    ///     Raised when the user has cancelled the <see cref="Wizard"/> by pressing the Esc key. To prevent a modal (
     ///     <see cref="Wizard.Modal"/> is <c>true</c>) Wizard from closing, cancel the event by setting
     ///     <see cref="WizardButtonEventArgs.Cancel"/> to <c>true</c> before returning from the event handler.
     /// </summary>
@@ -302,7 +302,7 @@ public class Wizard : Dialog
     }
 
     /// <summary>
-    ///     Causes the wizad to move to the previous enabled step (or first step if <see cref="CurrentStep"/> is not set).
+    ///     Causes the wizard to move to the previous enabled step (or first step if <see cref="CurrentStep"/> is not set).
     ///     If there is no previous step, does nothing.
     /// </summary>
     public void GoBack ()
@@ -316,7 +316,7 @@ public class Wizard : Dialog
     }
 
     /// <summary>
-    ///     Causes the wizad to move to the next enabled step (or last step if <see cref="CurrentStep"/> is not set). If
+    ///     Causes the wizard to move to the next enabled step (or last step if <see cref="CurrentStep"/> is not set). If
     ///     there is no previous step, does nothing.
     /// </summary>
     public void GoNext ()
@@ -388,7 +388,7 @@ public class Wizard : Dialog
     ///     <see cref="Wizard"/> is derived from <see cref="Dialog"/> and Dialog causes <c>Esc</c> to call
     ///     <see cref="Application.RequestStop(Toplevel)"/>, closing the Dialog. Wizard overrides
     ///     <see cref="OnProcessKeyDown"/> to instead fire the <see cref="Cancelled"/> event when Wizard is being used as a
-    ///     non-modal (see <see cref="Wizard.Modal"/>.
+    ///     non-modal (see <see cref="Wizard.Modal"/>).
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>

--- a/UnitTests/Views/TabTests.cs
+++ b/UnitTests/Views/TabTests.cs
@@ -6,7 +6,7 @@ public class TabTests
     public void Constructor_Defaults ()
     {
         var tab = new Tab ();
-        Assert.Equal ("Unamed", tab.DisplayText);
+        Assert.Equal ("Unnamed", tab.DisplayText);
         Assert.Null (tab.View);
         Assert.Equal (LineStyle.Rounded, tab.BorderStyle);
         Assert.True (tab.CanFocus);


### PR DESCRIPTION
## Fixes

- Fixes various typos I noticed while getting familiar with the project.

## Proposed Changes/Todos

The only change in behavior should be some string literals changing from "Unamed" to "Unnamed" (e.g. default text for a couple of controls). Otherwise, there's a couple of private fields and local variables that were renamed, one private method, and the rest of the changes are just modified comments.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
