### PR TITLE
Fixes #3628. SixLabors.ImageSharp prior to version 3.1.5 are vulnerable.

### DIFF
--- a/UICatalog/UICatalog.csproj
+++ b/UICatalog/UICatalog.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="[2024.2.0,)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="[1.21,2)" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="[3.1.4,4)" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="[3.1.5,4)" />
     <PackageReference Include="CsvHelper" Version="[33.0.1,34)" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="[3.1.6,4)" />
     <PackageReference Include="System.CommandLine" Version="[2.0.0-beta4.22272.1,3)" />


### PR DESCRIPTION
## Fixes

- Fixes #3628

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
