### PR TITLE
Fixes #3632. Automate getting cultures from the embedded resources strings for self-contained app.

### DIFF
--- a/SelfContained/Program.cs
+++ b/SelfContained/Program.cs
@@ -18,12 +18,8 @@ public static class Program
 
         if (Equals (Thread.CurrentThread.CurrentUICulture, CultureInfo.InvariantCulture) && Application.SupportedCultures.Count == 0)
         {
+            // Only happens if the project has <InvariantGlobalization>true</InvariantGlobalization>
             Debug.Assert (Application.SupportedCultures.Count == 0);
-        }
-        else
-        {
-            Debug.Assert (Application.SupportedCultures.Count == 4);
-            Debug.Assert (Equals (CultureInfo.CurrentCulture, Thread.CurrentThread.CurrentUICulture));
         }
 
         #endregion

--- a/SelfContained/Program.cs
+++ b/SelfContained/Program.cs
@@ -21,6 +21,11 @@ public static class Program
             // Only happens if the project has <InvariantGlobalization>true</InvariantGlobalization>
             Debug.Assert (Application.SupportedCultures.Count == 0);
         }
+        else
+        {
+            Debug.Assert (Application.SupportedCultures.Count > 0);
+            Debug.Assert (Equals (CultureInfo.CurrentCulture, Thread.CurrentThread.CurrentUICulture));
+        }
 
         #endregion
 

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualBasic;
+﻿using System.Globalization;
+using Microsoft.VisualBasic;
 using Xunit.Abstractions;
 
 // Alias Console to MockConsole so we don't accidentally use Console
@@ -193,7 +194,7 @@ public class ApplicationTests
             // Internal properties
             Assert.False (Application._initialized);
             Assert.Equal (Application.GetSupportedCultures (), Application.SupportedCultures);
-            Assert.Equal (4, Application.SupportedCultures.Count);
+            Assert.Equal (Application.GetAvailableCulturesFromEmbeddedResources(), Application.SupportedCultures);
             Assert.False (Application._forceFakeConsole);
             Assert.Equal (-1, Application._mainThreadId);
             Assert.Empty (Application._topLevels);

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-using Microsoft.VisualBasic;
-using Xunit.Abstractions;
+﻿using Xunit.Abstractions;
 
 // Alias Console to MockConsole so we don't accidentally use Console
 


### PR DESCRIPTION
## Fixes

- Fixes #3632

## Proposed Changes/Todos

- [ ] Added new internal GetAvailableCulturesFromEmbeddedResources method.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
