### PR TITLE
Fixes #3523. `MessageBox` buttons centered by default.

### DIFF
--- a/Terminal.Gui/Resources/config.json
+++ b/Terminal.Gui/Resources/config.json
@@ -29,8 +29,9 @@
         "Dialog.DefaultButtonAlignmentModes": "AddSpaceBetweenItems",
         "FrameView.DefaultBorderStyle": "Single",
         "Window.DefaultBorderStyle": "Single",
-        "Dialog.DefaultBorderStyle": "Single",
-        "MessageBox.DefaultBorderStyle": "Double",
+        "Dialog.DefaultBorderStyle": "Heavy",
+        "MessageBox.DefaultButtonAlignment": "Center",
+        "MessageBox.DefaultBorderStyle": "Heavy",
         "Button.DefaultShadow": "None",
         "ColorSchemes": [
           {

--- a/Terminal.Gui/Views/Dialog.cs
+++ b/Terminal.Gui/Views/Dialog.cs
@@ -20,7 +20,7 @@ public class Dialog : Window
     /// <remarks>This property can be set in a Theme.</remarks>
     [SerializableConfigurationProperty (Scope = typeof (ThemeScope))]
     [JsonConverter (typeof (JsonStringEnumConverter<Alignment>))]
-    public static Alignment DefaultButtonAlignment { get; set; } = Alignment.End;
+    public static Alignment DefaultButtonAlignment { get; set; } = Alignment.End; // Default is set in config.json
 
     /// <summary>The default <see cref="Alignment"/> for <see cref="Dialog"/>.</summary>
     /// <remarks>This property can be set in a Theme.</remarks>
@@ -48,7 +48,7 @@ public class Dialog : Window
     /// </summary>
     [SerializableConfigurationProperty (Scope = typeof (ThemeScope))]
     [JsonConverter (typeof (JsonStringEnumConverter<ShadowStyle>))]
-    public new static ShadowStyle DefaultShadow { get; set; } = ShadowStyle.None;
+    public new static ShadowStyle DefaultShadow { get; set; } = ShadowStyle.None; // Default is set in config.json
 
     /// <summary>
     ///     Defines the default border styling for <see cref="Dialog"/>. Can be configured via
@@ -57,7 +57,7 @@ public class Dialog : Window
 
     [SerializableConfigurationProperty (Scope = typeof (ThemeScope))]
     [JsonConverter (typeof (JsonStringEnumConverter<LineStyle>))]
-    public new static LineStyle DefaultBorderStyle { get; set; } = LineStyle.Single;
+    public new static LineStyle DefaultBorderStyle { get; set; } = LineStyle.Single; // Default is set in config.json
 
     private readonly List<Button> _buttons = new ();
 

--- a/Terminal.Gui/Views/MessageBox.cs
+++ b/Terminal.Gui/Views/MessageBox.cs
@@ -33,7 +33,13 @@ public static class MessageBox
     /// </summary>
     [SerializableConfigurationProperty (Scope = typeof (ThemeScope))]
     [JsonConverter (typeof (JsonStringEnumConverter<LineStyle>))]
-    public static LineStyle DefaultBorderStyle { get; set; } = LineStyle.Single;
+    public static LineStyle DefaultBorderStyle { get; set; } = LineStyle.Single; // Default is set in config.json
+
+    /// <summary>The default <see cref="Alignment"/> for <see cref="Dialog"/>.</summary>
+    /// <remarks>This property can be set in a Theme.</remarks>
+    [SerializableConfigurationProperty (Scope = typeof (ThemeScope))]
+    [JsonConverter (typeof (JsonStringEnumConverter<Alignment>))]
+    public static Alignment DefaultButtonAlignment { get; set; } = Alignment.Center; // Default is set in config.json
 
     /// <summary>
     ///     Defines the default minimum MessageBox width, as a percentage of the screen width. Can be configured via
@@ -365,10 +371,10 @@ public static class MessageBox
         var d = new Dialog
         {
             Title = title,
-            Buttons = buttonList.ToArray (),
-            ButtonAlignment = Alignment.Center,
+            ButtonAlignment = MessageBox.DefaultButtonAlignment,
             ButtonAlignmentModes = AlignmentModes.StartToEnd | AlignmentModes.AddSpaceBetweenItems,
             BorderStyle = MessageBox.DefaultBorderStyle,
+            Buttons = buttonList.ToArray (),
         };
 
         d.Width = Dim.Auto (DimAutoStyle.Auto,

--- a/UnitTests/Dialogs/DialogTests.cs
+++ b/UnitTests/Dialogs/DialogTests.cs
@@ -26,6 +26,10 @@ public class DialogTests
         int width = $@"{CM.Glyphs.VLine} {btn1} {btn2} {CM.Glyphs.VLine}".Length;
         d.SetBufferSize (width, 1);
 
+        // Override CM
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         // Default (center)
         var dlg = new Dialog
         {
@@ -150,6 +154,7 @@ public class DialogTests
         var buttonRow = $"{CM.Glyphs.VLine} {btn1} {btn2} {btn3} {btn4} {CM.Glyphs.VLine}";
         int width = buttonRow.Length;
         d.SetBufferSize (buttonRow.Length, 3);
+
 
         // Default - Center
         (runstate, Dialog dlg) = RunButtonTestDialog (
@@ -874,6 +879,11 @@ public class DialogTests
     {
         ((FakeDriver)Driver).SetBufferSize (20, 5);
 
+        // Override CM
+        Window.DefaultBorderStyle = LineStyle.Single;
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         var win = new Window ();
 
         var iterations = 0;
@@ -889,7 +899,6 @@ public class DialogTests
 
         win.Loaded += (s, a) =>
                       {
-                          Dialog.DefaultButtonAlignment = Alignment.Center;
                           var dlg = new Dialog { Width = 18, Height = 3, Buttons = [new () { Text = "Ok" }] };
 
                           dlg.Loaded += (s, a) =>
@@ -975,7 +984,10 @@ public class DialogTests
         var win = new Window ();
 
         int iterations = -1;
+
+        // Override CM
         Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
 
         Iteration += (s, a) =>
                      {
@@ -1012,7 +1024,10 @@ public class DialogTests
     public void Dialog_Opened_From_Another_Dialog ()
     {
         ((FakeDriver)Driver).SetBufferSize (30, 10);
+
+        // Override CM
         Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
 
         var btn1 = new Button { Text = "press me 1" };
         Button btn2 = null;
@@ -1159,6 +1174,11 @@ public class DialogTests
     [AutoInitShutdown]
     public void Location_When_Application_Top_Not_Default ()
     {
+        // Override CM
+        Window.DefaultBorderStyle = LineStyle.Single;
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         var expected = 5;
         var d = new Dialog { X = expected, Y = expected, Height = 5, Width = 5 };
         Begin (d);
@@ -1187,6 +1207,11 @@ public class DialogTests
         top.BorderStyle = LineStyle.Double;
 
         int iterations = -1;
+
+        // Override CM
+        Window.DefaultBorderStyle = LineStyle.Single;
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
 
         Iteration += (s, a) =>
                      {
@@ -1361,6 +1386,10 @@ public class DialogTests
         params Button [] btns
     )
     {
+        // Override CM
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         var dlg = new Dialog
         {
             Title = title,

--- a/UnitTests/Dialogs/MessageBoxTests.cs
+++ b/UnitTests/Dialogs/MessageBoxTests.cs
@@ -174,6 +174,10 @@ public class MessageBoxTests
         var btn =
             $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
 
+        // Override CM
+        MessageBox.DefaultButtonAlignment = Alignment.End;
+        MessageBox.DefaultBorderStyle = LineStyle.Double;
+
         Application.Iteration += (s, a) =>
                                  {
                                      iterations++;
@@ -238,6 +242,10 @@ public class MessageBoxTests
 
         var btn =
             $"{CM.Glyphs.LeftBracket}{CM.Glyphs.LeftDefaultIndicator} btn {CM.Glyphs.RightDefaultIndicator}{CM.Glyphs.RightBracket}";
+
+        // Override CM
+        MessageBox.DefaultButtonAlignment = Alignment.End;
+        MessageBox.DefaultBorderStyle = LineStyle.Double;
 
         Application.Iteration += (s, a) =>
                                  {
@@ -414,6 +422,10 @@ public class MessageBoxTests
     {
         int iterations = -1;
         ((FakeDriver)Application.Driver).SetBufferSize (70, 15);
+
+        // Override CM
+        MessageBox.DefaultButtonAlignment = Alignment.End;
+        MessageBox.DefaultBorderStyle = LineStyle.Double;
 
         Application.Iteration += (s, a) =>
                                  {

--- a/UnitTests/FileServices/FileDialogTests.cs
+++ b/UnitTests/FileServices/FileDialogTests.cs
@@ -571,6 +571,11 @@ public class FileDialogTests (ITestOutputHelper output)
 
     private FileDialog GetInitializedFileDialog ()
     {
+
+        Window.DefaultBorderStyle = LineStyle.Single;
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         var dlg = new FileDialog ();
         Begin (dlg);
 
@@ -579,6 +584,10 @@ public class FileDialogTests (ITestOutputHelper output)
 
     private FileDialog GetLinuxDialog ()
     {
+        Window.DefaultBorderStyle = LineStyle.Single;
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         // Arrange
         var fileSystem = new MockFileSystem (new Dictionary<string, MockFileData> (), "/");
         fileSystem.MockTime (() => new (2010, 01, 01, 11, 12, 43));

--- a/UnitTests/FileServices/FileDialogTests.cs
+++ b/UnitTests/FileServices/FileDialogTests.cs
@@ -622,6 +622,11 @@ public class FileDialogTests (ITestOutputHelper output)
 
     private FileDialog GetWindowsDialog ()
     {
+        // Override CM
+        Window.DefaultBorderStyle = LineStyle.Single;
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         // Arrange
         var fileSystem = new MockFileSystem (new Dictionary<string, MockFileData> (), @"c:\");
         fileSystem.MockTime (() => new (2010, 01, 01, 11, 12, 43));

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -362,6 +362,11 @@ public class MenuBarTests (ITestOutputHelper output)
     [AutoInitShutdown]
     public void Draw_A_Menu_Over_A_Dialog ()
     {
+        // Override CM
+        Window.DefaultBorderStyle = LineStyle.Single;
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         Toplevel top = new ();
         var win = new Window ();
         top.Add (win);
@@ -590,6 +595,11 @@ public class MenuBarTests (ITestOutputHelper output)
     [AutoInitShutdown]
     public void Draw_A_Menu_Over_A_Top_Dialog ()
     {
+        // Override CM
+        Window.DefaultBorderStyle = LineStyle.Single;
+        Dialog.DefaultButtonAlignment = Alignment.Center;
+        Dialog.DefaultBorderStyle = LineStyle.Single;
+
         ((FakeDriver)Application.Driver).SetBufferSize (40, 15);
 
         Assert.Equal (new (0, 0, 40, 15), Application.Driver.Clip);


### PR DESCRIPTION
## Fixes

- Fixes #3523 
- Adds `MessageBox.DefaultButtonAlignment` config property
- Defaults are now:

![image](https://github.com/user-attachments/assets/4204d3e1-cadb-47d9-909b-c6ac35d70b8a)

