### PR TITLE
May Fix #272. Enables TG apps to run in terminal `StatusLine`

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -121,6 +121,7 @@ public static class EscSeqUtils
     /// </remarks>
     public static readonly string CSI_SaveCursorAndActivateAltBufferNoBackscroll = CSI + "?1049h";
 
+
     //private static bool isButtonReleased;
     private static bool isButtonClicked;
 
@@ -1372,6 +1373,23 @@ public static class EscSeqUtils
     ///     size in chars.
     /// </summary>
     public const string CSI_ReportTerminalSizeInChars_ResponseValue = "8";
+
+    public static readonly string CSI_StatusLine_Disable = CSI + "0$~";
+
+    public static readonly string CSI_StatusLine_Enable_Indicator = CSI + "1$~";
+
+    public static readonly string CSI_StatusLine_Enable_Host_Writable = CSI + "2$~";
+
+    /// <summary>
+    ///     ESC [ 2$~;N$~ - enable host-writable status area, N lines
+    /// </summary>
+    /// <param name="lines">The number of lines</param>
+    /// <returns></returns>
+    public static string CSI_StatusLine_Enable_Host_Writable_N_Lines (int lines) { return $"{CSI}{CSI_StatusLine_Enable_Host_Writable};{lines}$~"; }
+
+    public static string CSI_StatusLine_Select_Normal_Display = CSI + "0$}";
+
+    public static string CSI_StatusLine_Select_Status_Line = CSI + "1$}";
 
     #endregion
 }


### PR DESCRIPTION
## Fixes

- Partially Fixes #272

# Background

See: https://github.com/mintty/mintty/blob/master/wiki/CtrlSeqs.md#status-line--area

![image](https://github.com/user-attachments/assets/bc163fe5-a704-4566-bcda-ed0e5c98737a)

It should be possible to add support for this. Add a `Application.RunAsTerminalStatusLine` and `Application.TerminalStatusLineHeight`. When set, upon `Init` we would emit `#"^[[2;{Application.TerminalStatusLineHeight}$~"`. On `Shutdown`, we would emit `^[[0$~`.

I believe this would automatically constrain the TUI app to the bottom `TerminalStatusLineHeight` of the terminal.

## Proposed Changes/Todos

- [x] Add appropriate CSIs
- [ ] Experiment with `WindowsDriver`

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
