### PR TITLE
Fixes #3641. `CheckBox.State` -> `CheckBox.CheckState`

### DIFF
--- a/Terminal.Gui/Views/CheckBox.cs
+++ b/Terminal.Gui/Views/CheckBox.cs
@@ -5,7 +5,7 @@ namespace Terminal.Gui;
 public class CheckBox : View
 {
     private bool _allowNone;
-    private CheckState _checked = CheckState.UnChecked;
+    private CheckState _checkedState = CheckState.UnChecked;
 
     /// <summary>
     ///     Initializes a new instance of <see cref="CheckBox"/>.
@@ -18,8 +18,8 @@ public class CheckBox : View
         CanFocus = true;
 
         // Things this view knows how to do
-        AddCommand (Command.Accept, OnToggle);
-        AddCommand (Command.HotKey, OnToggle);
+        AddCommand (Command.Accept, OnCheckedStateChanging);
+        AddCommand (Command.HotKey, OnCheckedStateChanging);
 
         // Default keybindings for this view
         KeyBindings.Add (Key.Space, Command.Accept);
@@ -32,7 +32,7 @@ public class CheckBox : View
 
     private void CheckBox_MouseClick (object? sender, MouseEventEventArgs e)
     {
-        e.Handled = OnToggle () == true;
+        e.Handled = OnCheckedStateChanging () == true;
     }
 
     private void Checkbox_TitleChanged (object? sender, EventArgs<string> e)
@@ -56,7 +56,7 @@ public class CheckBox : View
     }
 
     /// <summary>
-    ///     If <see langword="true"/> allows <see cref="State"/> to be <see cref="CheckState.None"/>.
+    ///     If <see langword="true"/> allows <see cref="CheckedState"/> to be <see cref="CheckState.None"/>.
     /// </summary>
     public bool AllowCheckStateNone
     {
@@ -69,9 +69,9 @@ public class CheckBox : View
             }
             _allowNone = value;
 
-            if (State == CheckState.None)
+            if (CheckedState == CheckState.None)
             {
-                State = CheckState.UnChecked;
+                CheckedState = CheckState.UnChecked;
             }
         }
     }
@@ -93,35 +93,35 @@ public class CheckBox : View
     ///        will display the <c>ConfigurationManager.Glyphs.CheckStateChecked</c> character (☑).
     ///     </para>
     /// </remarks>
-    public CheckState State
+    public CheckState CheckedState
     {
-        get => _checked;
+        get => _checkedState;
         set
         {
-            if (_checked == value || (value is CheckState.None && !AllowCheckStateNone))
+            if (_checkedState == value || (value is CheckState.None && !AllowCheckStateNone))
             {
                 return;
             }
 
-            _checked = value;
+            _checkedState = value;
             UpdateTextFormatterText ();
             OnResizeNeeded ();
         }
     }
 
-    /// <summary>Called when the <see cref="State"/> property changes. Invokes the cancelable <see cref="Toggle"/> event.</summary>
+    /// <summary>Called when the <see cref="CheckedState"/> property changes. Invokes the cancelable <see cref="CheckedStateChanging"/> event.</summary>
     /// <remarks>
     /// </remarks>
-    /// <returns>If <see langword="true"/> the <see cref="Toggle"/> event was canceled.</returns>
+    /// <returns>If <see langword="true"/> the <see cref="CheckedStateChanging"/> event was canceled.</returns>
     /// <remarks>
     ///     Toggling cycles through the states <see cref="CheckState.None"/>, <see cref="CheckState.Checked"/>, and <see cref="CheckState.UnChecked"/>.
     /// </remarks>
-    public bool? OnToggle ()
+    public bool? OnCheckedStateChanging ()
     {
-        CheckState oldValue = State;
-        CancelEventArgs<CheckState> e = new (ref _checked, ref oldValue);
+        CheckState oldValue = CheckedState;
+        CancelEventArgs<CheckState> e = new (ref _checkedState, ref oldValue);
 
-        switch (State)
+        switch (CheckedState)
         {
             case CheckState.None:
                 e.NewValue = CheckState.Checked;
@@ -144,7 +144,7 @@ public class CheckBox : View
                 break;
         }
 
-        Toggle?.Invoke (this, e);
+        CheckedStateChanging?.Invoke (this, e);
         if (e.Cancel)
         {
             return e.Cancel;
@@ -156,7 +156,7 @@ public class CheckBox : View
             return true;
         }
 
-        State = e.NewValue;
+        CheckedState = e.NewValue;
 
         return true;
     }
@@ -167,7 +167,7 @@ public class CheckBox : View
     ///    This event can be cancelled. If cancelled, the <see cref="CheckBox"/> will not change its state.
     /// </para>
     /// </remarks>
-    public event EventHandler<CancelEventArgs<CheckState>>? Toggle;
+    public event EventHandler<CancelEventArgs<CheckState>>? CheckedStateChanging;
 
     /// <inheritdoc/>
     protected override void UpdateTextFormatterText ()
@@ -190,7 +190,7 @@ public class CheckBox : View
 
     private Rune GetCheckedGlyph ()
     {
-        return State switch
+        return CheckedState switch
         {
             CheckState.Checked => Glyphs.CheckStateChecked,
             CheckState.UnChecked => Glyphs.CheckStateUnChecked,

--- a/Terminal.Gui/Views/CheckBox.cs
+++ b/Terminal.Gui/Views/CheckBox.cs
@@ -1,12 +1,9 @@
 ﻿#nullable enable
 namespace Terminal.Gui;
 
-/// <summary>Shows a check box that can be toggled.</summary>
+/// <summary>Shows a check box that can be cycled between three states.</summary>
 public class CheckBox : View
 {
-    private bool _allowNone;
-    private CheckState _checkedState = CheckState.UnChecked;
-
     /// <summary>
     ///     Initializes a new instance of <see cref="CheckBox"/>.
     /// </summary>
@@ -18,8 +15,8 @@ public class CheckBox : View
         CanFocus = true;
 
         // Things this view knows how to do
-        AddCommand (Command.Accept, OnCheckedStateChanging);
-        AddCommand (Command.HotKey, OnCheckedStateChanging);
+        AddCommand (Command.Accept, AdvanceCheckState);
+        AddCommand (Command.HotKey, AdvanceCheckState);
 
         // Default keybindings for this view
         KeyBindings.Add (Key.Space, Command.Accept);
@@ -32,7 +29,7 @@ public class CheckBox : View
 
     private void CheckBox_MouseClick (object? sender, MouseEventEventArgs e)
     {
-        e.Handled = OnCheckedStateChanging () == true;
+        e.Handled = AdvanceCheckState () == true;
     }
 
     private void Checkbox_TitleChanged (object? sender, EventArgs<string> e)
@@ -55,8 +52,10 @@ public class CheckBox : View
         set => TextFormatter.HotKeySpecifier = base.HotKeySpecifier = value;
     }
 
+    private bool _allowNone = false;
+
     /// <summary>
-    ///     If <see langword="true"/> allows <see cref="CheckedState"/> to be <see cref="CheckState.None"/>.
+    ///     If <see langword="true"/> allows <see cref="CheckedState"/> to be <see cref="CheckState.None"/>. The default is <see langword="false"/>.
     /// </summary>
     public bool AllowCheckStateNone
     {
@@ -75,6 +74,8 @@ public class CheckBox : View
             }
         }
     }
+
+    private CheckState _checkedState = CheckState.UnChecked;
 
     /// <summary>
     ///     The state of the <see cref="CheckBox"/>.
@@ -109,17 +110,24 @@ public class CheckBox : View
         }
     }
 
-    /// <summary>Called when the <see cref="CheckedState"/> property changes. Invokes the cancelable <see cref="CheckedStateChanging"/> event.</summary>
+    /// <summary>
+    ///     Advances <see cref="CheckedState"/> to the next value. Invokes the cancelable <see cref="CheckedStateChanging"/> event.
+    /// </summary>
     /// <remarks>
     /// </remarks>
     /// <returns>If <see langword="true"/> the <see cref="CheckedStateChanging"/> event was canceled.</returns>
     /// <remarks>
-    ///     Toggling cycles through the states <see cref="CheckState.None"/>, <see cref="CheckState.Checked"/>, and <see cref="CheckState.UnChecked"/>.
+    /// <para>
+    ///     Cycles through the states <see cref="CheckState.None"/>, <see cref="CheckState.Checked"/>, and <see cref="CheckState.UnChecked"/>.
+    /// </para>
+    /// <para>
+    ///     If the <see cref="CheckedStateChanging"/> event is not canceled, the <see cref="CheckedState"/> will be updated and the <see cref="Command.Accept"/> event will be raised.
+    /// </para>
     /// </remarks>
-    public bool? OnCheckedStateChanging ()
+    public bool? AdvanceCheckState ()
     {
         CheckState oldValue = CheckedState;
-        CancelEventArgs<CheckState> e = new (ref _checkedState, ref oldValue);
+        CancelEventArgs<CheckState> e = new (in _checkedState, ref oldValue);
 
         switch (CheckedState)
         {
@@ -150,7 +158,7 @@ public class CheckBox : View
             return e.Cancel;
         }
 
-        // By default, Command.Accept calls OnAccept, so we need to call it here to ensure that the event is fired.
+        // By default, Command.Accept calls OnAccept, so we need to call it here to ensure that the Accept event is fired.
         if (OnAccept () == true)
         {
             return true;
@@ -161,7 +169,7 @@ public class CheckBox : View
         return true;
     }
 
-    /// <summary>Toggle event, raised when the <see cref="CheckBox"/> is toggled.</summary>
+    /// <summary>Raised when the <see cref="CheckBox"/> state is changing.</summary>
     /// <remarks>
     /// <para>
     ///    This event can be cancelled. If cancelled, the <see cref="CheckBox"/> will not change its state.
@@ -172,7 +180,7 @@ public class CheckBox : View
     /// <inheritdoc/>
     protected override void UpdateTextFormatterText ()
     {
-        base.UpdateTextFormatterText();
+        base.UpdateTextFormatterText ();
         switch (TextAlignment)
         {
             case Alignment.Start:

--- a/UICatalog/Scenarios/AdornmentsEditor.cs
+++ b/UICatalog/Scenarios/AdornmentsEditor.cs
@@ -120,9 +120,9 @@ public class AdornmentsEditor : View
         Add (_paddingEditor);
 
         _diagPaddingCheckBox = new () { Text = "_Diagnostic Padding" };
-        _diagPaddingCheckBox.State = Diagnostics.FastHasFlags (ViewDiagnosticFlags.Padding) ? CheckState.Checked : CheckState.UnChecked;
+        _diagPaddingCheckBox.CheckedState = Diagnostics.FastHasFlags (ViewDiagnosticFlags.Padding) ? CheckState.Checked : CheckState.UnChecked;
 
-        _diagPaddingCheckBox.Toggle += (s, e) =>
+        _diagPaddingCheckBox.CheckedStateChanging += (s, e) =>
                                        {
                                            if (e.NewValue == CheckState.Checked)
                                            {
@@ -138,9 +138,9 @@ public class AdornmentsEditor : View
         _diagPaddingCheckBox.Y = Pos.Bottom (_paddingEditor);
 
         _diagRulerCheckBox = new () { Text = "_Diagnostic Ruler" };
-        _diagRulerCheckBox.State = Diagnostics.FastHasFlags (ViewDiagnosticFlags.Ruler) ? CheckState.Checked : CheckState.UnChecked;
+        _diagRulerCheckBox.CheckedState = Diagnostics.FastHasFlags (ViewDiagnosticFlags.Ruler) ? CheckState.Checked : CheckState.UnChecked;
 
-        _diagRulerCheckBox.Toggle += (s, e) =>
+        _diagRulerCheckBox.CheckedStateChanging += (s, e) =>
                                      {
                                          if (e.NewValue == CheckState.Checked)
                                          {

--- a/UICatalog/Scenarios/BorderEditor.cs
+++ b/UICatalog/Scenarios/BorderEditor.cs
@@ -20,9 +20,9 @@ public class BorderEditor : AdornmentEditor
 
     private void BorderEditor_AdornmentChanged (object sender, EventArgs e)
     {
-        _ckbTitle.State = ((Border)AdornmentToEdit).Settings.FastHasFlags (BorderSettings.Title) ? CheckState.Checked : CheckState.UnChecked;
+        _ckbTitle.CheckedState = ((Border)AdornmentToEdit).Settings.FastHasFlags (BorderSettings.Title) ? CheckState.Checked : CheckState.UnChecked;
         _rbBorderStyle.SelectedItem = (int)((Border)AdornmentToEdit).LineStyle;
-        _ckbGradient.State = ((Border)AdornmentToEdit).Settings.FastHasFlags (BorderSettings.Gradient) ? CheckState.Checked : CheckState.UnChecked;
+        _ckbGradient.CheckedState = ((Border)AdornmentToEdit).Settings.FastHasFlags (BorderSettings.Gradient) ? CheckState.Checked : CheckState.UnChecked;
     }
 
     private void BorderEditor_Initialized (object sender, EventArgs e)
@@ -51,13 +51,13 @@ public class BorderEditor : AdornmentEditor
             X = 0,
             Y = Pos.Bottom (_rbBorderStyle),
 
-            State = CheckState.Checked,
+            CheckedState = CheckState.Checked,
             SuperViewRendersLineCanvas = true,
             Text = "Title",
             Enabled = AdornmentToEdit is { }
         };
 
-        _ckbTitle.Toggle += OnCkbTitleOnToggle;
+        _ckbTitle.CheckedStateChanging += OnCkbTitleOnToggle;
         Add (_ckbTitle);
 
         _ckbGradient = new ()
@@ -65,13 +65,13 @@ public class BorderEditor : AdornmentEditor
             X = 0,
             Y = Pos.Bottom (_ckbTitle),
 
-            State = CheckState.Checked,
+            CheckedState = CheckState.Checked,
             SuperViewRendersLineCanvas = true,
             Text = "Gradient",
             Enabled = AdornmentToEdit is { }
         };
 
-        _ckbGradient.Toggle += OnCkbGradientOnToggle;
+        _ckbGradient.CheckedStateChanging += OnCkbGradientOnToggle;
         Add (_ckbGradient);
 
         return;

--- a/UICatalog/Scenarios/Buttons.cs
+++ b/UICatalog/Scenarios/Buttons.cs
@@ -383,9 +383,9 @@ public class Buttons : Scenario
             X = Pos.Right (repeatButton) + 1,
             Y = Pos.Top (repeatButton),
             Title = "Enabled",
-            State = CheckState.Checked
+            CheckedState = CheckState.Checked
         };
-        enableCB.Toggle += (s, e) => { repeatButton.Enabled = !repeatButton.Enabled; };
+        enableCB.CheckedStateChanging += (s, e) => { repeatButton.Enabled = !repeatButton.Enabled; };
         main.Add (label, repeatButton, enableCB);
 
         var decNumericUpDown = new NumericUpDown<int>

--- a/UICatalog/Scenarios/ContentScrolling.cs
+++ b/UICatalog/Scenarios/ContentScrolling.cs
@@ -135,8 +135,8 @@ public class ContentScrolling : Scenario
             Y = 0,
             CanFocus = false
         };
-        cbAllowNegativeX.State = view.ViewportSettings.HasFlag(ViewportSettings.AllowNegativeX) ? CheckState.Checked : CheckState.UnChecked;
-        cbAllowNegativeX.Toggle += AllowNegativeX_Toggle;
+        cbAllowNegativeX.CheckedState = view.ViewportSettings.HasFlag(ViewportSettings.AllowNegativeX) ? CheckState.Checked : CheckState.UnChecked;
+        cbAllowNegativeX.CheckedStateChanging += AllowNegativeX_Toggle;
 
         void AllowNegativeX_Toggle (object sender, CancelEventArgs<CheckState> e)
         {
@@ -159,8 +159,8 @@ public class ContentScrolling : Scenario
             Y = 0,
             CanFocus = false
         };
-        cbAllowNegativeY.State = view.ViewportSettings.HasFlag(ViewportSettings.AllowNegativeY) ? CheckState.Checked : CheckState.UnChecked;
-        cbAllowNegativeY.Toggle += AllowNegativeY_Toggle;
+        cbAllowNegativeY.CheckedState = view.ViewportSettings.HasFlag(ViewportSettings.AllowNegativeY) ? CheckState.Checked : CheckState.UnChecked;
+        cbAllowNegativeY.CheckedStateChanging += AllowNegativeY_Toggle;
 
         void AllowNegativeY_Toggle (object sender, CancelEventArgs<CheckState> e)
         {
@@ -182,8 +182,8 @@ public class ContentScrolling : Scenario
             Y = Pos.Bottom (cbAllowNegativeX),
             CanFocus = false
         };
-        cbAllowXGreaterThanContentWidth.State = view.ViewportSettings.HasFlag(ViewportSettings.AllowXGreaterThanContentWidth) ? CheckState.Checked : CheckState.UnChecked;
-        cbAllowXGreaterThanContentWidth.Toggle += AllowXGreaterThanContentWidth_Toggle;
+        cbAllowXGreaterThanContentWidth.CheckedState = view.ViewportSettings.HasFlag(ViewportSettings.AllowXGreaterThanContentWidth) ? CheckState.Checked : CheckState.UnChecked;
+        cbAllowXGreaterThanContentWidth.CheckedStateChanging += AllowXGreaterThanContentWidth_Toggle;
 
         void AllowXGreaterThanContentWidth_Toggle (object sender, CancelEventArgs<CheckState> e)
         {
@@ -206,8 +206,8 @@ public class ContentScrolling : Scenario
             Y = Pos.Bottom (cbAllowNegativeX),
             CanFocus = false
         };
-        cbAllowYGreaterThanContentHeight.State = view.ViewportSettings.HasFlag(ViewportSettings.AllowYGreaterThanContentHeight) ? CheckState.Checked : CheckState.UnChecked;
-        cbAllowYGreaterThanContentHeight.Toggle += AllowYGreaterThanContentHeight_Toggle;
+        cbAllowYGreaterThanContentHeight.CheckedState = view.ViewportSettings.HasFlag(ViewportSettings.AllowYGreaterThanContentHeight) ? CheckState.Checked : CheckState.UnChecked;
+        cbAllowYGreaterThanContentHeight.CheckedStateChanging += AllowYGreaterThanContentHeight_Toggle;
 
         void AllowYGreaterThanContentHeight_Toggle (object sender, CancelEventArgs<CheckState> e)
         {
@@ -284,8 +284,8 @@ public class ContentScrolling : Scenario
             Y = Pos.Top (labelContentSize),
             CanFocus = false
         };
-        cbClearOnlyVisible.State = view.ViewportSettings.HasFlag(ViewportSettings.ClearContentOnly) ? CheckState.Checked : CheckState.UnChecked;
-        cbClearOnlyVisible.Toggle += ClearVisibleContentOnly_Toggle;
+        cbClearOnlyVisible.CheckedState = view.ViewportSettings.HasFlag(ViewportSettings.ClearContentOnly) ? CheckState.Checked : CheckState.UnChecked;
+        cbClearOnlyVisible.CheckedStateChanging += ClearVisibleContentOnly_Toggle;
 
         void ClearVisibleContentOnly_Toggle (object sender, CancelEventArgs<CheckState> e)
         {
@@ -306,8 +306,8 @@ public class ContentScrolling : Scenario
             Y = Pos.Top (labelContentSize),
             CanFocus = false
         };
-        cbDoNotClipContent.State = view.ViewportSettings.HasFlag (ViewportSettings.ClipContentOnly) ? CheckState.Checked : CheckState.UnChecked;
-        cbDoNotClipContent.Toggle += ClipVisibleContentOnly_Toggle;
+        cbDoNotClipContent.CheckedState = view.ViewportSettings.HasFlag (ViewportSettings.ClipContentOnly) ? CheckState.Checked : CheckState.UnChecked;
+        cbDoNotClipContent.CheckedStateChanging += ClipVisibleContentOnly_Toggle;
 
         void ClipVisibleContentOnly_Toggle (object sender, CancelEventArgs<CheckState> e)
         {

--- a/UICatalog/Scenarios/Dialogs.cs
+++ b/UICatalog/Scenarios/Dialogs.cs
@@ -136,7 +136,7 @@ public class Dialogs : Scenario
             Y = Pos.Bottom (numButtonsLabel),
             TextAlignment = Alignment.End,
             Text = $"_Add {char.ConvertFromUtf32 (CODE_POINT)} to button text to stress wide char support",
-            State = CheckState.UnChecked
+            CheckedState = CheckState.UnChecked
         };
         frame.Add (glyphsNotWords);
 
@@ -235,7 +235,7 @@ public class Dialogs : Scenario
                 int buttonId = i;
                 Button button = null;
 
-                if (glyphsNotWords.State == CheckState.Checked)
+                if (glyphsNotWords.CheckedState == CheckState.Checked)
                 {
                     buttonId = i;
 
@@ -289,7 +289,7 @@ public class Dialogs : Scenario
                               int buttonId = buttons.Count;
                               Button button;
 
-                              if (glyphsNotWords.State == CheckState.Checked)
+                              if (glyphsNotWords.CheckedState == CheckState.Checked)
                               {
                                   button = new ()
                                   {

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -142,7 +142,7 @@ public class DynamicMenuBar : Scenario
             {
                 X = Pos.Left (_lblTitle),
                 Y = Pos.Bottom (CkbIsTopLevel),
-                State = (_menuItem == null ? !_hasParent : HasSubMenus (_menuItem)) ? CheckState.Checked : CheckState.UnChecked,
+                CheckedState = (_menuItem == null ? !_hasParent : HasSubMenus (_menuItem)) ? CheckState.Checked : CheckState.UnChecked,
                 Text = "Has sub-menus"
             };
             Add (CkbSubMenu);
@@ -249,36 +249,36 @@ public class DynamicMenuBar : Scenario
             _btnShortcut.Accept += (s, e) => { TextShortcut.Text = ""; };
             Add (_btnShortcut);
 
-            CkbIsTopLevel.Toggle += (s, e) =>
+            CkbIsTopLevel.CheckedStateChanging += (s, e) =>
                                      {
-                                         if ((_menuItem != null && _menuItem.Parent != null && CkbIsTopLevel.State == CheckState.Checked)
-                                             || (_menuItem == null && _hasParent && CkbIsTopLevel.State == CheckState.Checked))
+                                         if ((_menuItem != null && _menuItem.Parent != null && CkbIsTopLevel.CheckedState == CheckState.Checked)
+                                             || (_menuItem == null && _hasParent && CkbIsTopLevel.CheckedState == CheckState.Checked))
                                          {
                                              MessageBox.ErrorQuery (
                                                                     "Invalid IsTopLevel",
                                                                     "Only menu bar can have top level menu item!",
                                                                     "Ok"
                                                                    );
-                                             CkbIsTopLevel.State = CheckState.UnChecked;
+                                             CkbIsTopLevel.CheckedState = CheckState.UnChecked;
 
                                              return;
                                          }
 
-                                         if (CkbIsTopLevel.State == CheckState.Checked)
+                                         if (CkbIsTopLevel.CheckedState == CheckState.Checked)
                                          {
-                                             CkbSubMenu.State = CheckState.UnChecked;
+                                             CkbSubMenu.CheckedState = CheckState.UnChecked;
                                              CkbSubMenu.SetNeedsDisplay ();
                                              TextHelp.Enabled = true;
                                              TextAction.Enabled = true;
 
                                              TextShortcut.Enabled =
-                                                 CkbIsTopLevel.State == CheckState.UnChecked && CkbSubMenu.State == CheckState.UnChecked;
+                                                 CkbIsTopLevel.CheckedState == CheckState.UnChecked && CkbSubMenu.CheckedState == CheckState.UnChecked;
                                          }
                                          else
                                          {
                                              if ((_menuItem == null && !_hasParent) || _menuItem.Parent == null)
                                              {
-                                                 CkbSubMenu.State = CheckState.Checked;
+                                                 CkbSubMenu.CheckedState = CheckState.Checked;
                                                  CkbSubMenu.SetNeedsDisplay ();
                                                  TextShortcut.Enabled = false;
                                              }
@@ -290,11 +290,11 @@ public class DynamicMenuBar : Scenario
                                          }
                                      };
 
-            CkbSubMenu.Toggle += (s, e) =>
+            CkbSubMenu.CheckedStateChanging += (s, e) =>
                                   {
                                       if (e.NewValue == CheckState.Checked)
                                       {
-                                          CkbIsTopLevel.State = CheckState.UnChecked;
+                                          CkbIsTopLevel.CheckedState = CheckState.UnChecked;
                                           CkbIsTopLevel.SetNeedsDisplay ();
                                           TextHelp.Text = "";
                                           TextHelp.Enabled = false;
@@ -307,7 +307,7 @@ public class DynamicMenuBar : Scenario
                                       {
                                           if (!_hasParent)
                                           {
-                                              CkbIsTopLevel.State = CheckState.Checked;
+                                              CkbIsTopLevel.CheckedState = CheckState.Checked;
                                               CkbIsTopLevel.SetNeedsDisplay ();
                                               TextShortcut.Enabled = false;
                                           }
@@ -316,11 +316,11 @@ public class DynamicMenuBar : Scenario
                                           TextAction.Enabled = true;
 
                                           TextShortcut.Enabled =
-                                              CkbIsTopLevel.State == CheckState.UnChecked && CkbSubMenu.State == CheckState.UnChecked;
+                                              CkbIsTopLevel.CheckedState == CheckState.UnChecked && CkbSubMenu.CheckedState == CheckState.UnChecked;
                                       }
                                   };
 
-            CkbNullCheck.Toggle += (s, e) =>
+            CkbNullCheck.CheckedStateChanging += (s, e) =>
                                     {
                                         if (_menuItem != null)
                                         {
@@ -394,14 +394,14 @@ public class DynamicMenuBar : Scenario
             TextAction.Text = menuItem != null && menuItem.Action != null
                                   ? GetTargetAction (menuItem.Action)
                                   : string.Empty;
-            CkbIsTopLevel.State = IsTopLevel (menuItem) ? CheckState.Checked : CheckState.UnChecked;
-            CkbSubMenu.State = HasSubMenus (menuItem) ? CheckState.Checked : CheckState.UnChecked;
-            CkbNullCheck.State = menuItem.AllowNullChecked ? CheckState.Checked : CheckState.UnChecked;
-            TextHelp.Enabled = CkbSubMenu.State == CheckState.Checked;
-            TextAction.Enabled = CkbSubMenu.State == CheckState.Checked;
+            CkbIsTopLevel.CheckedState = IsTopLevel (menuItem) ? CheckState.Checked : CheckState.UnChecked;
+            CkbSubMenu.CheckedState = HasSubMenus (menuItem) ? CheckState.Checked : CheckState.UnChecked;
+            CkbNullCheck.CheckedState = menuItem.AllowNullChecked ? CheckState.Checked : CheckState.UnChecked;
+            TextHelp.Enabled = CkbSubMenu.CheckedState == CheckState.Checked;
+            TextAction.Enabled = CkbSubMenu.CheckedState == CheckState.Checked;
             RbChkStyle.SelectedItem = (int)(menuItem?.CheckType ?? MenuItemCheckStyle.NoCheck);
             TextShortcut.Text = menuItem?.ShortcutTag ?? "";
-            TextShortcut.Enabled = CkbIsTopLevel.State == CheckState.UnChecked && CkbSubMenu.State == CheckState.UnChecked;
+            TextShortcut.Enabled = CkbIsTopLevel.CheckedState == CheckState.UnChecked && CkbSubMenu.CheckedState == CheckState.UnChecked;
         }
 
         public DynamicMenuItem EnterMenuItem ()
@@ -414,9 +414,9 @@ public class DynamicMenuBar : Scenario
                 TextTitle.Text = m.Title;
                 TextHelp.Text = m.Help;
                 TextAction.Text = m.Action;
-                CkbIsTopLevel.State = CheckState.UnChecked;
-                CkbSubMenu.State = !_hasParent ? CheckState.Checked : CheckState.UnChecked;
-                CkbNullCheck.State = CheckState.UnChecked;
+                CkbIsTopLevel.CheckedState = CheckState.UnChecked;
+                CkbSubMenu.CheckedState = !_hasParent ? CheckState.Checked : CheckState.UnChecked;
+                CkbNullCheck.CheckedState = CheckState.UnChecked;
                 TextHelp.Enabled = _hasParent;
                 TextAction.Enabled = _hasParent;
                 TextShortcut.Enabled = _hasParent;
@@ -466,13 +466,13 @@ public class DynamicMenuBar : Scenario
                     Title = TextTitle.Text,
                     Help = TextHelp.Text,
                     Action = TextAction.Text,
-                    IsTopLevel = CkbIsTopLevel?.State == CheckState.Checked,
-                    HasSubMenu = CkbSubMenu?.State == CheckState.UnChecked,
+                    IsTopLevel = CkbIsTopLevel?.CheckedState == CheckState.Checked,
+                    HasSubMenu = CkbSubMenu?.CheckedState == CheckState.UnChecked,
                     CheckStyle = RbChkStyle.SelectedItem == 0 ? MenuItemCheckStyle.NoCheck :
                                  RbChkStyle.SelectedItem == 1 ? MenuItemCheckStyle.Checked :
                                  MenuItemCheckStyle.Radio,
                     Shortcut = TextShortcut.Text,
-                    AllowNullChecked = CkbNullCheck?.State == CheckState.Checked,
+                    AllowNullChecked = CkbNullCheck?.CheckedState == CheckState.Checked,
                 };
             }
 
@@ -515,8 +515,8 @@ public class DynamicMenuBar : Scenario
             TextTitle.Text = "";
             TextHelp.Text = "";
             TextAction.Text = "";
-            CkbIsTopLevel.State = CheckState.UnChecked;
-            CkbSubMenu.State = CheckState.UnChecked;
+            CkbIsTopLevel.CheckedState = CheckState.UnChecked;
+            CkbSubMenu.CheckedState = CheckState.UnChecked;
             RbChkStyle.SelectedItem = (int)MenuItemCheckStyle.NoCheck;
             TextShortcut.Text = "";
         }
@@ -835,8 +835,8 @@ public class DynamicMenuBar : Scenario
                                          Title = _frmMenuDetails.TextTitle.Text,
                                          Help = _frmMenuDetails.TextHelp.Text,
                                          Action = _frmMenuDetails.TextAction.Text,
-                                         IsTopLevel = _frmMenuDetails.CkbIsTopLevel?.State == CheckState.UnChecked,
-                                         HasSubMenu = _frmMenuDetails.CkbSubMenu?.State == CheckState.UnChecked,
+                                         IsTopLevel = _frmMenuDetails.CkbIsTopLevel?.CheckedState == CheckState.UnChecked,
+                                         HasSubMenu = _frmMenuDetails.CkbSubMenu?.CheckedState == CheckState.UnChecked,
                                          CheckStyle = _frmMenuDetails.RbChkStyle.SelectedItem == 0
                                                           ? MenuItemCheckStyle.NoCheck
                                                           : _frmMenuDetails.RbChkStyle.SelectedItem == 1

--- a/UICatalog/Scenarios/Editor.cs
+++ b/UICatalog/Scenarios/Editor.cs
@@ -895,16 +895,16 @@ public class Editor : Scenario
 
         var ckbMatchCase = new CheckBox
         {
-            X = 0, Y = Pos.Top (txtToFind) + 2, State = _matchCase ? CheckState.Checked : CheckState.UnChecked, Text = "Match c_ase"
+            X = 0, Y = Pos.Top (txtToFind) + 2, CheckedState = _matchCase ? CheckState.Checked : CheckState.UnChecked, Text = "Match c_ase"
         };
-        ckbMatchCase.Toggle += (s, e) => _matchCase = e.NewValue == CheckState.Checked;
+        ckbMatchCase.CheckedStateChanging += (s, e) => _matchCase = e.NewValue == CheckState.Checked;
         d.Add (ckbMatchCase);
 
         var ckbMatchWholeWord = new CheckBox
         {
-            X = 0, Y = Pos.Top (ckbMatchCase) + 1, State = _matchWholeWord ? CheckState.Checked : CheckState.UnChecked, Text = "Match _whole word"
+            X = 0, Y = Pos.Top (ckbMatchCase) + 1, CheckedState = _matchWholeWord ? CheckState.Checked : CheckState.UnChecked, Text = "Match _whole word"
         };
-        ckbMatchWholeWord.Toggle += (s, e) => _matchWholeWord = e.NewValue == CheckState.Checked;
+        ckbMatchWholeWord.CheckedStateChanging += (s, e) => _matchWholeWord = e.NewValue == CheckState.Checked;
         d.Add (ckbMatchWholeWord);
         return d;
     }
@@ -1153,16 +1153,16 @@ public class Editor : Scenario
 
         var ckbMatchCase = new CheckBox
         {
-            X = 0, Y = Pos.Top (txtToFind) + 2, State = _matchCase ? CheckState.Checked : CheckState.UnChecked, Text = "Match c_ase"
+            X = 0, Y = Pos.Top (txtToFind) + 2, CheckedState = _matchCase ? CheckState.Checked : CheckState.UnChecked, Text = "Match c_ase"
         };
-        ckbMatchCase.Toggle += (s, e) => _matchCase = e.NewValue == CheckState.Checked;
+        ckbMatchCase.CheckedStateChanging += (s, e) => _matchCase = e.NewValue == CheckState.Checked;
         d.Add (ckbMatchCase);
 
         var ckbMatchWholeWord = new CheckBox
         {
-            X = 0, Y = Pos.Top (ckbMatchCase) + 1, State = _matchWholeWord ? CheckState.Checked : CheckState.UnChecked, Text = "Match _whole word"
+            X = 0, Y = Pos.Top (ckbMatchCase) + 1, CheckedState = _matchWholeWord ? CheckState.Checked : CheckState.UnChecked, Text = "Match _whole word"
         };
-        ckbMatchWholeWord.Toggle += (s, e) => _matchWholeWord = e.NewValue == CheckState.Checked;
+        ckbMatchWholeWord.CheckedStateChanging += (s, e) => _matchWholeWord = e.NewValue == CheckState.Checked;
         d.Add (ckbMatchWholeWord);
 
         return d;

--- a/UICatalog/Scenarios/FileDialogExamples.cs
+++ b/UICatalog/Scenarios/FileDialogExamples.cs
@@ -33,25 +33,25 @@ public class FileDialogExamples : Scenario
         var x = 1;
         var win = new Window { Title = GetQuitKeyAndName () };
 
-        _cbMustExist = new CheckBox { State = CheckState.Checked, Y = y++, X = x, Text = "Must Exist" };
+        _cbMustExist = new CheckBox { CheckedState = CheckState.Checked, Y = y++, X = x, Text = "Must Exist" };
         win.Add (_cbMustExist);
 
-        _cbUseColors = new CheckBox { State = FileDialogStyle.DefaultUseColors ? CheckState.Checked : CheckState.UnChecked, Y = y++, X = x, Text = "Use Colors" };
+        _cbUseColors = new CheckBox { CheckedState = FileDialogStyle.DefaultUseColors ? CheckState.Checked : CheckState.UnChecked, Y = y++, X = x, Text = "Use Colors" };
         win.Add (_cbUseColors);
 
-        _cbCaseSensitive = new CheckBox { State = CheckState.UnChecked, Y = y++, X = x, Text = "Case Sensitive Search" };
+        _cbCaseSensitive = new CheckBox { CheckedState = CheckState.UnChecked, Y = y++, X = x, Text = "Case Sensitive Search" };
         win.Add (_cbCaseSensitive);
 
-        _cbAllowMultipleSelection = new CheckBox { State = CheckState.UnChecked, Y = y++, X = x, Text = "Multiple" };
+        _cbAllowMultipleSelection = new CheckBox { CheckedState = CheckState.UnChecked, Y = y++, X = x, Text = "Multiple" };
         win.Add (_cbAllowMultipleSelection);
 
-        _cbShowTreeBranchLines = new CheckBox { State = CheckState.Checked, Y = y++, X = x, Text = "Tree Branch Lines" };
+        _cbShowTreeBranchLines = new CheckBox { CheckedState = CheckState.Checked, Y = y++, X = x, Text = "Tree Branch Lines" };
         win.Add (_cbShowTreeBranchLines);
 
-        _cbAlwaysTableShowHeaders = new CheckBox { State = CheckState.Checked, Y = y++, X = x, Text = "Always Show Headers" };
+        _cbAlwaysTableShowHeaders = new CheckBox { CheckedState = CheckState.Checked, Y = y++, X = x, Text = "Always Show Headers" };
         win.Add (_cbAlwaysTableShowHeaders);
 
-        _cbDrivesOnlyInTree = new CheckBox { State = CheckState.UnChecked, Y = y++, X = x, Text = "Only Show Drives" };
+        _cbDrivesOnlyInTree = new CheckBox { CheckedState = CheckState.UnChecked, Y = y++, X = x, Text = "Only Show Drives" };
         win.Add (_cbDrivesOnlyInTree);
 
         y = 0;
@@ -151,8 +151,8 @@ public class FileDialogExamples : Scenario
             OpenMode = Enum.Parse<OpenMode> (
                                              _rgOpenMode.RadioLabels [_rgOpenMode.SelectedItem]
                                             ),
-            MustExist = _cbMustExist.State == CheckState.Checked,
-            AllowsMultipleSelection = _cbAllowMultipleSelection.State == CheckState.Checked
+            MustExist = _cbMustExist.CheckedState == CheckState.Checked,
+            AllowsMultipleSelection = _cbAllowMultipleSelection.CheckedState == CheckState.Checked
         };
 
         fd.Style.OkButtonText = _rgCaption.RadioLabels [_rgCaption.SelectedItem];
@@ -166,19 +166,19 @@ public class FileDialogExamples : Scenario
         fd.Style.IconProvider.UseUnicodeCharacters = _rgIcons.SelectedItem == 1;
         fd.Style.IconProvider.UseNerdIcons = _rgIcons.SelectedItem == 2;
 
-        if (_cbCaseSensitive.State == CheckState.Checked)
+        if (_cbCaseSensitive.CheckedState == CheckState.Checked)
         {
             fd.SearchMatcher = new CaseSensitiveSearchMatcher ();
         }
 
-        fd.Style.UseColors = _cbUseColors.State == CheckState.Checked;
+        fd.Style.UseColors = _cbUseColors.CheckedState == CheckState.Checked;
 
-        fd.Style.TreeStyle.ShowBranchLines = _cbShowTreeBranchLines.State == CheckState.Checked;
-        fd.Style.TableStyle.AlwaysShowHeaders = _cbAlwaysTableShowHeaders.State == CheckState.Checked;
+        fd.Style.TreeStyle.ShowBranchLines = _cbShowTreeBranchLines.CheckedState == CheckState.Checked;
+        fd.Style.TableStyle.AlwaysShowHeaders = _cbAlwaysTableShowHeaders.CheckedState == CheckState.Checked;
 
         IDirectoryInfoFactory dirInfoFactory = new FileSystem ().DirectoryInfo;
 
-        if (_cbDrivesOnlyInTree.State == CheckState.Checked)
+        if (_cbDrivesOnlyInTree.CheckedState == CheckState.Checked)
         {
             fd.Style.TreeRootGetter = () => { return Environment.GetLogicalDrives ().ToDictionary (dirInfoFactory.New, k => k); };
         }
@@ -203,7 +203,7 @@ public class FileDialogExamples : Scenario
             fd.Style.CancelButtonText = _tbCancelButton.Text;
         }
 
-        if (_cbFlipButtonOrder.State == CheckState.Checked)
+        if (_cbFlipButtonOrder.CheckedState == CheckState.Checked)
         {
             fd.Style.FlipOkCancelButtonLayoutOrder = true;
         }
@@ -225,7 +225,7 @@ public class FileDialogExamples : Scenario
                               "Ok"
                              );
         }
-        else if (_cbAllowMultipleSelection.State == CheckState.Checked)
+        else if (_cbAllowMultipleSelection.CheckedState == CheckState.Checked)
         {
             MessageBox.Query (
                               "Chosen!",

--- a/UICatalog/Scenarios/GraphViewExample.cs
+++ b/UICatalog/Scenarios/GraphViewExample.cs
@@ -202,7 +202,7 @@ public class GraphViewExample : Scenario
 
         if (sender is Shortcut shortcut && shortcut.CommandView is CheckBox checkBox)
         {
-            checkBox.State = _miDiags.Checked ?? false ? CheckState.Checked : CheckState.UnChecked;
+            checkBox.CheckedState = _miDiags.Checked ?? false ? CheckState.Checked : CheckState.UnChecked;
         }
     }
 

--- a/UICatalog/Scenarios/Images.cs
+++ b/UICatalog/Scenarios/Images.cs
@@ -29,7 +29,7 @@ public class Images : Scenario
         {
             X = Pos.Right (lblDriverName) + 2,
             Y = 0,
-            State = canTrueColor ? CheckState.Checked : CheckState.UnChecked,
+            CheckedState = canTrueColor ? CheckState.Checked : CheckState.UnChecked,
             CanFocus = false,
             Text = "supports true color "
         };
@@ -39,11 +39,11 @@ public class Images : Scenario
         {
             X = Pos.Right (cbSupportsTrueColor) + 2,
             Y = 0,
-            State = !Application.Force16Colors ? CheckState.Checked : CheckState.UnChecked,
+            CheckedState = !Application.Force16Colors ? CheckState.Checked : CheckState.UnChecked,
             Enabled = canTrueColor,
             Text = "Use true color"
         };
-        cbUseTrueColor.Toggle += (_, evt) => Application.Force16Colors = evt.NewValue == CheckState.UnChecked;
+        cbUseTrueColor.CheckedStateChanging += (_, evt) => Application.Force16Colors = evt.NewValue == CheckState.UnChecked;
         win.Add (cbUseTrueColor);
 
         var btnOpenImage = new Button { X = Pos.Right (cbUseTrueColor) + 2, Y = 0, Text = "Open Image" };

--- a/UICatalog/Scenarios/ListViewWithSelection.cs
+++ b/UICatalog/Scenarios/ListViewWithSelection.cs
@@ -34,24 +34,24 @@ public class ListViewWithSelection : Scenario
 
         _customRenderCB = new CheckBox { X = 0, Y = 0, Text = "Use custom rendering" };
         _appWindow.Add (_customRenderCB);
-        _customRenderCB.Toggle += _customRenderCB_Toggle;
+        _customRenderCB.CheckedStateChanging += _customRenderCB_Toggle;
 
         _allowMarkingCB = new CheckBox
         {
             X = Pos.Right (_customRenderCB) + 1, Y = 0, Text = "Allow Marking", AllowCheckStateNone = false
         };
         _appWindow.Add (_allowMarkingCB);
-        _allowMarkingCB.Toggle += AllowMarkingCB_Toggle;
+        _allowMarkingCB.CheckedStateChanging += AllowMarkingCB_Toggle;
 
         _allowMultipleCB = new CheckBox
         {
             X = Pos.Right (_allowMarkingCB) + 1,
             Y = 0,
-            Visible = _allowMarkingCB.State == CheckState.Checked,
+            Visible = _allowMarkingCB.CheckedState == CheckState.Checked,
             Text = "Allow Multi-Select"
         };
         _appWindow.Add (_allowMultipleCB);
-        _allowMultipleCB.Toggle += AllowMultipleCB_Toggle;
+        _allowMultipleCB.CheckedStateChanging += AllowMultipleCB_Toggle;
 
         _listView = new ListView
         {
@@ -108,9 +108,9 @@ public class ListViewWithSelection : Scenario
 
         var keepCheckBox = new CheckBox
         {
-            X = Pos.AnchorEnd (k.Length + 3), Y = 0, Text = k, State = scrollBar.AutoHideScrollBars ? CheckState.Checked : CheckState.UnChecked
+            X = Pos.AnchorEnd (k.Length + 3), Y = 0, Text = k, CheckedState = scrollBar.AutoHideScrollBars ? CheckState.Checked : CheckState.UnChecked
         };
-        keepCheckBox.Toggle += (s, e) => scrollBar.KeepContentAlwaysInViewport = e.NewValue == CheckState.Checked;
+        keepCheckBox.CheckedStateChanging += (s, e) => scrollBar.KeepContentAlwaysInViewport = e.NewValue == CheckState.Checked;
         _appWindow.Add (keepCheckBox);
 
         Application.Run (_appWindow);

--- a/UICatalog/Scenarios/Localization.cs
+++ b/UICatalog/Scenarios/Localization.cs
@@ -143,7 +143,7 @@ public class Localization : Scenario
         {
             X = Pos.Right (textField) + 1,
             Y = Pos.Bottom (textAndFileDialogLabel) + 1,
-            State = CheckState.UnChecked,
+            CheckedState = CheckState.UnChecked,
             Text = "Allow any"
         };
         win.Add (_allowAnyCheckBox);
@@ -190,7 +190,7 @@ public class Localization : Scenario
 
         dialog.AllowedTypes =
         [
-            _allowAnyCheckBox.State == CheckState.Checked
+            _allowAnyCheckBox.CheckedState == CheckState.Checked
                 ? new AllowedTypeAny ()
                 : new AllowedType ("Dynamic link library", ".dll"),
             new AllowedType ("Json", ".json"),

--- a/UICatalog/Scenarios/MessageBoxes.cs
+++ b/UICatalog/Scenarios/MessageBoxes.cs
@@ -190,7 +190,7 @@ public class MessageBoxes : Scenario
 
         var ckbWrapMessage = new CheckBox
         {
-            X = Pos.Right (label) + 1, Y = Pos.Bottom (styleRadioGroup), Text = "_Wrap Message", State = CheckState.Checked
+            X = Pos.Right (label) + 1, Y = Pos.Bottom (styleRadioGroup), Text = "_Wrap Message", CheckedState = CheckState.Checked
         };
         frame.Add (ckbWrapMessage);
 
@@ -241,7 +241,7 @@ public class MessageBoxes : Scenario
                                                                              titleEdit.Text,
                                                                              messageEdit.Text,
                                                                              defaultButton,
-                                                                             ckbWrapMessage.State == CheckState.Checked,
+                                                                             ckbWrapMessage.CheckedState == CheckState.Checked,
                                                                              btns.ToArray ()
                                                                             )}";
                                                }
@@ -254,7 +254,7 @@ public class MessageBoxes : Scenario
                                                                                   titleEdit.Text,
                                                                                   messageEdit.Text,
                                                                                   defaultButton,
-                                                                                  ckbWrapMessage.State == CheckState.Checked,
+                                                                                  ckbWrapMessage.CheckedState == CheckState.Checked,
                                                                                   btns.ToArray ()
                                                                                  )}";
                                                }

--- a/UICatalog/Scenarios/Mouse.cs
+++ b/UICatalog/Scenarios/Mouse.cs
@@ -67,7 +67,7 @@ public class Mouse : Scenario
             Y = Pos.Bottom (ml),
             Title = "_Want Continuous Button Pressed"
         };
-        cbWantContinuousPresses.Toggle += (s, e) => { win.WantContinuousButtonPressed = !win.WantContinuousButtonPressed; };
+        cbWantContinuousPresses.CheckedStateChanging += (s, e) => { win.WantContinuousButtonPressed = !win.WantContinuousButtonPressed; };
 
         win.Add (cbWantContinuousPresses);
 
@@ -77,9 +77,9 @@ public class Mouse : Scenario
             Y = Pos.Bottom (cbWantContinuousPresses),
             Title = "_Highlight on Press"
         };
-        cbHighlightOnPress.State = win.HighlightStyle == (HighlightStyle.Pressed | HighlightStyle.PressedOutside) ? CheckState.Checked : CheckState.UnChecked;
+        cbHighlightOnPress.CheckedState = win.HighlightStyle == (HighlightStyle.Pressed | HighlightStyle.PressedOutside) ? CheckState.Checked : CheckState.UnChecked;
 
-        cbHighlightOnPress.Toggle += (s, e) =>
+        cbHighlightOnPress.CheckedStateChanging += (s, e) =>
                                       {
                                           if (e.NewValue == CheckState.Checked)
                                           {

--- a/UICatalog/Scenarios/PosAlignDemo.cs
+++ b/UICatalog/Scenarios/PosAlignDemo.cs
@@ -87,18 +87,18 @@ public sealed class PosAlignDemo : Scenario
 
         if (dimension == Dimension.Width)
         {
-            endToStartCheckBox.State = _horizAligner.AlignmentModes.HasFlag (AlignmentModes.EndToStart) ? CheckState.Checked : CheckState.UnChecked;
+            endToStartCheckBox.CheckedState = _horizAligner.AlignmentModes.HasFlag (AlignmentModes.EndToStart) ? CheckState.Checked : CheckState.UnChecked;
             endToStartCheckBox.X = Pos.Align (_horizAligner.Alignment);
             endToStartCheckBox.Y = Pos.Top (alignRadioGroup);
         }
         else
         {
-            endToStartCheckBox.State = _vertAligner.AlignmentModes.HasFlag (AlignmentModes.EndToStart) ? CheckState.Checked : CheckState.UnChecked;
+            endToStartCheckBox.CheckedState = _vertAligner.AlignmentModes.HasFlag (AlignmentModes.EndToStart) ? CheckState.Checked : CheckState.UnChecked;
             endToStartCheckBox.X = Pos.Left (alignRadioGroup);
             endToStartCheckBox.Y = Pos.Align (_vertAligner.Alignment);
         }
 
-        endToStartCheckBox.Toggle += (s, e) =>
+        endToStartCheckBox.CheckedStateChanging += (s, e) =>
                                       {
                                           if (dimension == Dimension.Width)
                                           {
@@ -125,18 +125,18 @@ public sealed class PosAlignDemo : Scenario
 
         if (dimension == Dimension.Width)
         {
-            ignoreFirstOrLast.State = _horizAligner.AlignmentModes.HasFlag (AlignmentModes.IgnoreFirstOrLast) ? CheckState.Checked : CheckState.UnChecked;
+            ignoreFirstOrLast.CheckedState = _horizAligner.AlignmentModes.HasFlag (AlignmentModes.IgnoreFirstOrLast) ? CheckState.Checked : CheckState.UnChecked;
             ignoreFirstOrLast.X = Pos.Align (_horizAligner.Alignment);
             ignoreFirstOrLast.Y = Pos.Top (alignRadioGroup);
         }
         else
         {
-            ignoreFirstOrLast.State = _vertAligner.AlignmentModes.HasFlag (AlignmentModes.IgnoreFirstOrLast) ? CheckState.Checked : CheckState.UnChecked;
+            ignoreFirstOrLast.CheckedState = _vertAligner.AlignmentModes.HasFlag (AlignmentModes.IgnoreFirstOrLast) ? CheckState.Checked : CheckState.UnChecked;
             ignoreFirstOrLast.X = Pos.Left (alignRadioGroup);
             ignoreFirstOrLast.Y = Pos.Align (_vertAligner.Alignment);
         }
 
-        ignoreFirstOrLast.Toggle += (s, e) =>
+        ignoreFirstOrLast.CheckedStateChanging += (s, e) =>
                                      {
                                          if (dimension == Dimension.Width)
                                          {
@@ -163,18 +163,18 @@ public sealed class PosAlignDemo : Scenario
 
         if (dimension == Dimension.Width)
         {
-            addSpacesBetweenItems.State = _horizAligner.AlignmentModes.HasFlag (AlignmentModes.AddSpaceBetweenItems) ? CheckState.Checked : CheckState.UnChecked;
+            addSpacesBetweenItems.CheckedState = _horizAligner.AlignmentModes.HasFlag (AlignmentModes.AddSpaceBetweenItems) ? CheckState.Checked : CheckState.UnChecked;
             addSpacesBetweenItems.X = Pos.Align (_horizAligner.Alignment);
             addSpacesBetweenItems.Y = Pos.Top (alignRadioGroup);
         }
         else
         {
-            addSpacesBetweenItems.State = _vertAligner.AlignmentModes.HasFlag (AlignmentModes.AddSpaceBetweenItems) ? CheckState.Checked : CheckState.UnChecked;
+            addSpacesBetweenItems.CheckedState = _vertAligner.AlignmentModes.HasFlag (AlignmentModes.AddSpaceBetweenItems) ? CheckState.Checked : CheckState.UnChecked;
             addSpacesBetweenItems.X = Pos.Left (alignRadioGroup);
             addSpacesBetweenItems.Y = Pos.Align (_vertAligner.Alignment);
         }
 
-        addSpacesBetweenItems.Toggle += (s, e) =>
+        addSpacesBetweenItems.CheckedStateChanging += (s, e) =>
                                          {
                                              if (dimension == Dimension.Width)
                                              {
@@ -211,7 +211,7 @@ public sealed class PosAlignDemo : Scenario
             margin.Y = Pos.Align (_vertAligner.Alignment);
         }
 
-        margin.Toggle += (s, e) =>
+        margin.CheckedStateChanging += (s, e) =>
                           {
                               if (dimension == Dimension.Width)
                               {

--- a/UICatalog/Scenarios/ProgressBarStyles.cs
+++ b/UICatalog/Scenarios/ProgressBarStyles.cs
@@ -236,7 +236,7 @@ public class ProgressBarStyles : Scenario
             X = Pos.Center (),
             Y = Pos.Bottom (continuousPB),
             Text = "BidirectionalMarquee", 
-            State = CheckState.Checked
+            CheckedState = CheckState.Checked
         };
         container.Add (ckbBidirectional);
 
@@ -289,9 +289,9 @@ public class ProgressBarStyles : Scenario
                                               marqueesContinuousPB.ProgressBarFormat = (ProgressBarFormat)e.SelectedItem;
                                           };
 
-        ckbBidirectional.Toggle += (s, e) =>
+        ckbBidirectional.CheckedStateChanging += (s, e) =>
                                    {
-                                       ckbBidirectional.State = e.NewValue;
+                                       ckbBidirectional.CheckedState = e.NewValue;
                                        marqueesBlocksPB.BidirectionalMarquee =
                                                                   marqueesContinuousPB.BidirectionalMarquee = e.NewValue == CheckState.Checked;
                                    };

--- a/UICatalog/Scenarios/Scrolling.cs
+++ b/UICatalog/Scenarios/Scrolling.cs
@@ -148,7 +148,7 @@ public class Scrolling : Scenario
             X = Pos.X (scrollView),
             Y = Pos.Bottom (scrollView),
             Text = "Horizontal Scrollbar",
-            State = scrollView.ShowHorizontalScrollIndicator ? CheckState.Checked : CheckState.UnChecked
+            CheckedState = scrollView.ShowHorizontalScrollIndicator ? CheckState.Checked : CheckState.UnChecked
         };
         app.Add (hCheckBox);
 
@@ -157,7 +157,7 @@ public class Scrolling : Scenario
             X = Pos.Right (hCheckBox) + 3,
             Y = Pos.Bottom (scrollView),
             Text = "Vertical Scrollbar",
-            State = scrollView.ShowVerticalScrollIndicator ? CheckState.Checked : CheckState.UnChecked
+            CheckedState = scrollView.ShowVerticalScrollIndicator ? CheckState.Checked : CheckState.UnChecked
         };
         app.Add (vCheckBox);
 
@@ -165,50 +165,50 @@ public class Scrolling : Scenario
 
         var ahCheckBox = new CheckBox
         {
-            X = Pos.Left (scrollView), Y = Pos.Bottom (hCheckBox), Text = t, State = scrollView.AutoHideScrollBars ? CheckState.Checked : CheckState.UnChecked
+            X = Pos.Left (scrollView), Y = Pos.Bottom (hCheckBox), Text = t, CheckedState = scrollView.AutoHideScrollBars ? CheckState.Checked : CheckState.UnChecked
         };
         var k = "Keep Content Always In Viewport";
 
         var keepCheckBox = new CheckBox
         {
-            X = Pos.Left (scrollView), Y = Pos.Bottom (ahCheckBox), Text = k, State = scrollView.AutoHideScrollBars ? CheckState.Checked : CheckState.UnChecked
+            X = Pos.Left (scrollView), Y = Pos.Bottom (ahCheckBox), Text = k, CheckedState = scrollView.AutoHideScrollBars ? CheckState.Checked : CheckState.UnChecked
         };
 
-        hCheckBox.Toggle += (s, e) =>
+        hCheckBox.CheckedStateChanging += (s, e) =>
                              {
-                                 if (ahCheckBox.State == CheckState.UnChecked)
+                                 if (ahCheckBox.CheckedState == CheckState.UnChecked)
                                  {
                                      scrollView.ShowHorizontalScrollIndicator = e.NewValue == CheckState.Checked;
                                  }
                                  else
                                  {
-                                     hCheckBox.State = CheckState.Checked;
+                                     hCheckBox.CheckedState = CheckState.Checked;
                                      MessageBox.Query ("Message", "Disable Auto Hide Scrollbars first.", "Ok");
                                  }
                              };
 
-        vCheckBox.Toggle += (s, e) =>
+        vCheckBox.CheckedStateChanging += (s, e) =>
                              {
-                                 if (ahCheckBox.State == CheckState.UnChecked)
+                                 if (ahCheckBox.CheckedState == CheckState.UnChecked)
                                  {
                                      scrollView.ShowVerticalScrollIndicator = e.NewValue == CheckState.Checked;
                                  }
                                  else
                                  {
-                                     vCheckBox.State = CheckState.Checked;
+                                     vCheckBox.CheckedState = CheckState.Checked;
                                      MessageBox.Query ("Message", "Disable Auto Hide Scrollbars first.", "Ok");
                                  }
                              };
 
-        ahCheckBox.Toggle += (s, e) =>
+        ahCheckBox.CheckedStateChanging += (s, e) =>
                               {
                                   scrollView.AutoHideScrollBars = e.NewValue == CheckState.Checked;
-                                  hCheckBox.State = CheckState.Checked;
-                                  vCheckBox.State = CheckState.Checked;
+                                  hCheckBox.CheckedState = CheckState.Checked;
+                                  vCheckBox.CheckedState = CheckState.Checked;
                               };
         app.Add (ahCheckBox);
 
-        keepCheckBox.Toggle += (s, e) => scrollView.KeepContentAlwaysInViewport = e.NewValue == CheckState.Checked;
+        keepCheckBox.CheckedStateChanging += (s, e) => scrollView.KeepContentAlwaysInViewport = e.NewValue == CheckState.Checked;
         app.Add (keepCheckBox);
 
         var count = 0;

--- a/UICatalog/Scenarios/SendKeys.cs
+++ b/UICatalog/Scenarios/SendKeys.cs
@@ -89,9 +89,9 @@ public class SendKeys : Scenario
                 Application.Driver?.SendKeys (
                                              r,
                                              ck,
-                                             ckbShift.State == CheckState.Checked,
-                                             ckbAlt.State == CheckState.Checked,
-                                             ckbControl.State == CheckState.Checked
+                                             ckbShift.CheckedState == CheckState.Checked,
+                                             ckbAlt.CheckedState == CheckState.Checked,
+                                             ckbControl.CheckedState == CheckState.Checked
                                             );
             }
 

--- a/UICatalog/Scenarios/Shortcuts.cs
+++ b/UICatalog/Scenarios/Shortcuts.cs
@@ -107,7 +107,7 @@ public class Shortcuts : Scenario
             KeyBindingScope = KeyBindingScope.HotKey,
         };
 
-        ((CheckBox)vShortcut3.CommandView).Toggle += (s, e) =>
+        ((CheckBox)vShortcut3.CommandView).CheckedStateChanging += (s, e) =>
                                                       {
                                                           if (vShortcut3.CommandView is CheckBox cb)
                                                           {
@@ -166,7 +166,7 @@ public class Shortcuts : Scenario
             CommandView = new CheckBox { Text = "_CanFocus" },
         };
 
-        ((CheckBox)vShortcut5.CommandView).Toggle += (s, e) =>
+        ((CheckBox)vShortcut5.CommandView).CheckedStateChanging += (s, e) =>
                                                      {
                                                          if (vShortcut5.CommandView is CheckBox cb)
                                                          {

--- a/UICatalog/Scenarios/Sliders.cs
+++ b/UICatalog/Scenarios/Sliders.cs
@@ -236,7 +236,7 @@ public class Sliders : Scenario
             Y = Pos.Bottom (optionsSlider)
         };
 
-        dimAutoUsesMin.Toggle += (sender, e) =>
+        dimAutoUsesMin.CheckedStateChanging += (sender, e) =>
                                   {
                                       foreach (Slider s in app.Subviews.OfType<Slider> ())
                                       {

--- a/UICatalog/Scenarios/SpinnerStyles.cs
+++ b/UICatalog/Scenarios/SpinnerStyles.cs
@@ -53,7 +53,7 @@ public class SpinnerViewStyles : Scenario
             X = Pos.Center () - 7,
             Y = Pos.Bottom (preview),
             Enabled = false,
-            State = CheckState.Checked,
+            CheckedState = CheckState.Checked,
             Text = "Ascii Only"
         };
         app.Add (ckbAscii);
@@ -63,20 +63,20 @@ public class SpinnerViewStyles : Scenario
             X = Pos.Center () + 7,
             Y = Pos.Bottom (preview),
             Enabled = false,
-            State = CheckState.Checked,
+            CheckedState = CheckState.Checked,
             Text = "No Special"
         };
         app.Add (ckbNoSpecial);
 
         var ckbReverse = new CheckBox
         {
-            X = Pos.Center () - 22, Y = Pos.Bottom (preview) + 1, State = CheckState.UnChecked, Text = "Reverse"
+            X = Pos.Center () - 22, Y = Pos.Bottom (preview) + 1, CheckedState = CheckState.UnChecked, Text = "Reverse"
         };
         app.Add (ckbReverse);
 
         var ckbBounce = new CheckBox
         {
-            X = Pos.Right (ckbReverse) + 2, Y = Pos.Bottom (preview) + 1, State = CheckState.UnChecked, Text = "Bounce"
+            X = Pos.Right (ckbReverse) + 2, Y = Pos.Bottom (preview) + 1, CheckedState = CheckState.UnChecked, Text = "Bounce"
         };
         app.Add (ckbBounce);
 
@@ -157,16 +157,16 @@ public class SpinnerViewStyles : Scenario
                                               spinner.Visible = true;
                                               spinner.Style = (SpinnerStyle)Activator.CreateInstance (styleDict [e.Item].Value);
                                               delayField.Text = spinner.SpinDelay.ToString ();
-                                              ckbBounce.State = spinner.SpinBounce ? CheckState.Checked : CheckState.UnChecked;
-                                              ckbNoSpecial.State = !spinner.HasSpecialCharacters ? CheckState.Checked : CheckState.UnChecked;
-                                              ckbAscii.State = spinner.IsAsciiOnly ? CheckState.Checked : CheckState.UnChecked;
-                                              ckbReverse.State = CheckState.UnChecked;
+                                              ckbBounce.CheckedState = spinner.SpinBounce ? CheckState.Checked : CheckState.UnChecked;
+                                              ckbNoSpecial.CheckedState = !spinner.HasSpecialCharacters ? CheckState.Checked : CheckState.UnChecked;
+                                              ckbAscii.CheckedState = spinner.IsAsciiOnly ? CheckState.Checked : CheckState.UnChecked;
+                                              ckbReverse.CheckedState = CheckState.UnChecked;
                                           }
                                       };
 
-        ckbReverse.Toggle += (s, e) => { spinner.SpinReverse = e.NewValue == CheckState.Checked; };
+        ckbReverse.CheckedStateChanging += (s, e) => { spinner.SpinReverse = e.NewValue == CheckState.Checked; };
 
-        ckbBounce.Toggle += (s, e) => { spinner.SpinBounce = e.NewValue == CheckState.Checked; };
+        ckbBounce.CheckedStateChanging += (s, e) => { spinner.SpinBounce = e.NewValue == CheckState.Checked; };
 
         app.Unloaded += App_Unloaded;
 

--- a/UICatalog/Scenarios/Text.cs
+++ b/UICatalog/Scenarios/Text.cs
@@ -107,7 +107,7 @@ public class Text : Scenario
         // single-line mode.
         var chxMultiline = new CheckBox
         {
-            X = Pos.Left (textView), Y = Pos.Bottom (textView), State = textView.Multiline ? CheckState.Checked : CheckState.UnChecked, Text = "_Multiline"
+            X = Pos.Left (textView), Y = Pos.Bottom (textView), CheckedState = textView.Multiline ? CheckState.Checked : CheckState.UnChecked, Text = "_Multiline"
         };
         win.Add (chxMultiline);
 
@@ -115,10 +115,10 @@ public class Text : Scenario
         {
             X = Pos.Right (chxMultiline) + 2,
             Y = Pos.Top (chxMultiline),
-            State = textView.WordWrap ? CheckState.Checked : CheckState.UnChecked,
+            CheckedState = textView.WordWrap ? CheckState.Checked : CheckState.UnChecked,
             Text = "_Word Wrap"
         };
-        chxWordWrap.Toggle += (s, e) => textView.WordWrap = e.NewValue == CheckState.Checked;
+        chxWordWrap.CheckedStateChanging += (s, e) => textView.WordWrap = e.NewValue == CheckState.Checked;
         win.Add (chxWordWrap);
 
         // TextView captures Tabs (so users can enter /t into text) by default;
@@ -128,29 +128,29 @@ public class Text : Scenario
         {
             X = Pos.Right (chxWordWrap) + 2,
             Y = Pos.Top (chxWordWrap),
-            State = textView.AllowsTab ? CheckState.Checked : CheckState.UnChecked,
+            CheckedState = textView.AllowsTab ? CheckState.Checked : CheckState.UnChecked,
             Text = "_Capture Tabs"
         };
 
-        chxMultiline.Toggle += (s, e) =>
+        chxMultiline.CheckedStateChanging += (s, e) =>
                                 {
                                     textView.Multiline = e.NewValue == CheckState.Checked;
 
-                                    if (!textView.Multiline && chxWordWrap.State == CheckState.Checked)
+                                    if (!textView.Multiline && chxWordWrap.CheckedState == CheckState.Checked)
                                     {
-                                        chxWordWrap.State = CheckState.UnChecked;
+                                        chxWordWrap.CheckedState = CheckState.UnChecked;
                                     }
 
-                                    if (!textView.Multiline && chxCaptureTabs.State == CheckState.Checked)
+                                    if (!textView.Multiline && chxCaptureTabs.CheckedState == CheckState.Checked)
                                     {
-                                        chxCaptureTabs.State = CheckState.UnChecked;
+                                        chxCaptureTabs.CheckedState = CheckState.UnChecked;
                                     }
                                 };
 
         Key keyTab = textView.KeyBindings.GetKeyFromCommands (Command.Tab);
         Key keyBackTab = textView.KeyBindings.GetKeyFromCommands (Command.BackTab);
 
-        chxCaptureTabs.Toggle += (s, e) =>
+        chxCaptureTabs.CheckedStateChanging += (s, e) =>
                                   {
                                       if (e.NewValue == CheckState.Checked)
                                       {

--- a/UICatalog/Scenarios/TextAlignmentAndDirection.cs
+++ b/UICatalog/Scenarios/TextAlignmentAndDirection.cs
@@ -484,7 +484,7 @@ public class TextAlignmentAndDirection : Scenario
             Enabled = false
         };
 
-        justifyCheckbox.Toggle += (s, e) => ToggleJustify (e.NewValue != CheckState.Checked);
+        justifyCheckbox.CheckedStateChanging += (s, e) => ToggleJustify (e.NewValue != CheckState.Checked);
 
         justifyOptions.SelectedItemChanged += (s, e) => { ToggleJustify (false, true); };
 
@@ -500,9 +500,9 @@ public class TextAlignmentAndDirection : Scenario
             Height = 1,
             Text = "Word Wrap"
         };
-        wrapCheckbox.State = wrapCheckbox.TextFormatter.WordWrap ? CheckState.Checked : CheckState.UnChecked;
+        wrapCheckbox.CheckedState = wrapCheckbox.TextFormatter.WordWrap ? CheckState.Checked : CheckState.UnChecked;
 
-        wrapCheckbox.Toggle += (s, e) =>
+        wrapCheckbox.CheckedStateChanging += (s, e) =>
                                 {
                                     if (e.CurrentValue == CheckState.Checked)
                                     {
@@ -536,7 +536,7 @@ public class TextAlignmentAndDirection : Scenario
 
         directionOptions.SelectedItemChanged += (s, ev) =>
                                                 {
-                                                    bool justChecked = justifyCheckbox.State == CheckState.Checked;
+                                                    bool justChecked = justifyCheckbox.CheckedState == CheckState.Checked;
 
                                                     if (justChecked)
                                                     {

--- a/UICatalog/Scenarios/TextEffectsScenario.cs
+++ b/UICatalog/Scenarios/TextEffectsScenario.cs
@@ -70,7 +70,7 @@ public class TextEffectsScenario : Scenario
             Y = Pos.AnchorEnd (1)
         };
 
-        cbLooping.Toggle += (s, e) =>
+        cbLooping.CheckedStateChanging += (s, e) =>
                             {
                                 LoopingGradient = e.NewValue == CheckState.Checked;
                                 SetupGradientLineCanvas (w, w.Frame.Size);

--- a/UICatalog/Scenarios/TextFormatterDemo.cs
+++ b/UICatalog/Scenarios/TextFormatterDemo.cs
@@ -58,7 +58,7 @@ public class TextFormatterDemo : Scenario
             X = 0,
             Y = Pos.Bottom (blockText) + 1,
             Text = "Unicode",
-            State = app.HotKeySpecifier == (Rune)' ' ? CheckState.Checked : CheckState.UnChecked
+            CheckedState = app.HotKeySpecifier == (Rune)' ' ? CheckState.Checked : CheckState.UnChecked
         };
 
         app.Add (unicodeCheckBox);
@@ -121,7 +121,7 @@ public class TextFormatterDemo : Scenario
             label = multipleLines [i];
         }
 
-        unicodeCheckBox.Toggle += (s, e) =>
+        unicodeCheckBox.CheckedStateChanging += (s, e) =>
                                    {
                                        for (int i = 0; i < alignments.Count; i++)
                                        {

--- a/UICatalog/Scenarios/TileViewNesting.cs
+++ b/UICatalog/Scenarios/TileViewNesting.cs
@@ -35,16 +35,16 @@ public class TileViewNesting : Scenario
         _textField.TextChanged += (s, e) => SetupTileView ();
 
         _cbHorizontal = new() { X = Pos.Right (_textField) + 1, Text = "Horizontal" };
-        _cbHorizontal.Toggle += (s, e) => SetupTileView ();
+        _cbHorizontal.CheckedStateChanging += (s, e) => SetupTileView ();
 
         _cbBorder = new() { X = Pos.Right (_cbHorizontal) + 1, Text = "Border" };
-        _cbBorder.Toggle += (s, e) => SetupTileView ();
+        _cbBorder.CheckedStateChanging += (s, e) => SetupTileView ();
 
         _cbTitles = new() { X = Pos.Right (_cbBorder) + 1, Text = "Titles" };
-        _cbTitles.Toggle += (s, e) => SetupTileView ();
+        _cbTitles.CheckedStateChanging += (s, e) => SetupTileView ();
 
         _cbUseLabels = new() { X = Pos.Right (_cbTitles) + 1, Text = "Use Labels" };
-        _cbUseLabels.Toggle += (s, e) => SetupTileView ();
+        _cbUseLabels.CheckedStateChanging += (s, e) => SetupTileView ();
 
         _workArea = new() { X = 0, Y = 1, Width = Dim.Fill (), Height = Dim.Fill () };
 
@@ -101,7 +101,7 @@ public class TileViewNesting : Scenario
         }
     }
 
-    private View CreateContentControl (int number) { return _cbUseLabels.State == CheckState.Checked ? CreateLabelView (number) : CreateTextView (number); }
+    private View CreateContentControl (int number) { return _cbUseLabels.CheckedState == CheckState.Checked ? CreateLabelView (number) : CreateTextView (number); }
 
     private View CreateLabelView (int number)
     {
@@ -136,8 +136,8 @@ public class TileViewNesting : Scenario
             Orientation = orientation
         };
 
-        toReturn.Tiles.ElementAt (0).Title = _cbTitles.State == CheckState.Checked ? $"View {titleNumber}" : string.Empty;
-        toReturn.Tiles.ElementAt (1).Title = _cbTitles.State == CheckState.Checked ? $"View {titleNumber + 1}" : string.Empty;
+        toReturn.Tiles.ElementAt (0).Title = _cbTitles.CheckedState == CheckState.Checked ? $"View {titleNumber}" : string.Empty;
+        toReturn.Tiles.ElementAt (1).Title = _cbTitles.CheckedState == CheckState.Checked ? $"View {titleNumber + 1}" : string.Empty;
 
         return toReturn;
     }
@@ -158,9 +158,9 @@ public class TileViewNesting : Scenario
     {
         int numberOfViews = GetNumberOfViews ();
 
-        CheckState titles = _cbTitles.State;
-        CheckState border = _cbBorder.State;
-        CheckState startHorizontal = _cbHorizontal.State;
+        CheckState titles = _cbTitles.CheckedState;
+        CheckState border = _cbBorder.CheckedState;
+        CheckState startHorizontal = _cbHorizontal.CheckedState;
 
         foreach (View sub in _workArea.Subviews)
         {
@@ -177,9 +177,9 @@ public class TileViewNesting : Scenario
         TileView root = CreateTileView (1, startHorizontal == CheckState.Checked ? Orientation.Horizontal : Orientation.Vertical);
 
         root.Tiles.ElementAt (0).ContentView.Add (CreateContentControl (1));
-        root.Tiles.ElementAt (0).Title = _cbTitles.State == CheckState.Checked ? "View 1" : string.Empty;
+        root.Tiles.ElementAt (0).Title = _cbTitles.CheckedState == CheckState.Checked ? "View 1" : string.Empty;
         root.Tiles.ElementAt (1).ContentView.Add (CreateContentControl (2));
-        root.Tiles.ElementAt (1).Title = _cbTitles.State == CheckState.Checked ? "View 2" : string.Empty;
+        root.Tiles.ElementAt (1).Title = _cbTitles.CheckedState == CheckState.Checked ? "View 2" : string.Empty;
 
         root.LineStyle = border  == CheckState.Checked? LineStyle.Rounded : LineStyle.None;
 
@@ -225,7 +225,7 @@ public class TileViewNesting : Scenario
 
         // During splitting the old Title will have been migrated to View1 so we only need
         // to set the Title on View2 (the one that gets our new TextView)
-        newView.Tiles.ElementAt (1).Title = _cbTitles.State == CheckState.Checked ? $"View {_viewsCreated}" : string.Empty;
+        newView.Tiles.ElementAt (1).Title = _cbTitles.CheckedState == CheckState.Checked ? $"View {_viewsCreated}" : string.Empty;
 
         // Flip orientation
         newView.Orientation = to.Orientation == Orientation.Vertical

--- a/UICatalog/Scenarios/TrueColors.cs
+++ b/UICatalog/Scenarios/TrueColors.cs
@@ -32,7 +32,7 @@ public class TrueColors : Scenario
         {
             X = x,
             Y = y++,
-            State = canTrueColor ? CheckState.Checked : CheckState.UnChecked,
+            CheckedState = canTrueColor ? CheckState.Checked : CheckState.UnChecked,
             CanFocus = false,
             Enabled = false,
             Text = "Driver supports true color "
@@ -43,11 +43,11 @@ public class TrueColors : Scenario
         {
             X = x,
             Y = y++,
-            State = Application.Force16Colors ? CheckState.Checked : CheckState.UnChecked,
+            CheckedState = Application.Force16Colors ? CheckState.Checked : CheckState.UnChecked,
             Enabled = canTrueColor,
             Text = "Force 16 colors"
         };
-        cbUseTrueColor.Toggle += (_, evt) => { Application.Force16Colors = evt.NewValue == CheckState.Checked; };
+        cbUseTrueColor.CheckedStateChanging += (_, evt) => { Application.Force16Colors = evt.NewValue == CheckState.Checked; };
         app.Add (cbUseTrueColor);
 
         y += 2;

--- a/UICatalog/Scenarios/Wizards.cs
+++ b/UICatalog/Scenarios/Wizards.cs
@@ -198,7 +198,7 @@ public class Wizards : Scenario
                                            var thirdStepEnabledCeckBox = new CheckBox
                                            {
                                                Text = "Enable Step _3",
-                                               State = CheckState.UnChecked,
+                                               CheckedState = CheckState.UnChecked,
                                                X = Pos.Left (lastNameField),
                                                Y = Pos.Bottom (lastNameField)
                                            };
@@ -245,8 +245,8 @@ public class Wizards : Scenario
                                                X = Pos.Right (progLbl), Y = Pos.Top (progLbl), Width = 40, Fraction = 0.42F
                                            };
                                            thirdStep.Add (progLbl, progressBar);
-                                           thirdStep.Enabled = thirdStepEnabledCeckBox.State == CheckState.Checked;
-                                           thirdStepEnabledCeckBox.Toggle += (s, e) => { thirdStep.Enabled = thirdStepEnabledCeckBox.State == CheckState.Checked; };
+                                           thirdStep.Enabled = thirdStepEnabledCeckBox.CheckedState == CheckState.Checked;
+                                           thirdStepEnabledCeckBox.CheckedStateChanging += (s, e) => { thirdStep.Enabled = thirdStepEnabledCeckBox.CheckedState == CheckState.Checked; };
 
                                            // Add 4th step
                                            var fourthStep = new WizardStep { Title = "Step Four" };
@@ -323,7 +323,7 @@ public class Wizards : Scenario
                                                "The wizard is complete!\n\nPress the Finish button to continue.\n\nPressing ESC will cancel the wizard.";
 
                                            var finalFinalStepEnabledCeckBox =
-                                               new CheckBox { Text = "Enable _Final Final Step", State = CheckState.UnChecked, X = 0, Y = 1 };
+                                               new CheckBox { Text = "Enable _Final Final Step", CheckedState = CheckState.UnChecked, X = 0, Y = 1 };
                                            lastStep.Add (finalFinalStepEnabledCeckBox);
 
                                            // Add an optional FINAL last step
@@ -332,11 +332,11 @@ public class Wizards : Scenario
 
                                            finalFinalStep.HelpText =
                                                "This step only shows if it was enabled on the other last step.";
-                                           finalFinalStep.Enabled = thirdStepEnabledCeckBox.State == CheckState.Checked;
+                                           finalFinalStep.Enabled = thirdStepEnabledCeckBox.CheckedState == CheckState.Checked;
 
-                                           finalFinalStepEnabledCeckBox.Toggle += (s, e) =>
+                                           finalFinalStepEnabledCeckBox.CheckedStateChanging += (s, e) =>
                                                                                    {
-                                                                                       finalFinalStep.Enabled = finalFinalStepEnabledCeckBox.State == CheckState.Checked;
+                                                                                       finalFinalStep.Enabled = finalFinalStepEnabledCeckBox.CheckedState == CheckState.Checked;
                                                                                    };
 
                                            Application.Run (wizard);

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -492,14 +492,14 @@ public class UICatalogApp
                     CommandView = new CheckBox
                     {
                         Title = "16 color mode",
-                        State = Application.Force16Colors ? CheckState.Checked : CheckState.UnChecked,
+                        CheckedState = Application.Force16Colors ? CheckState.Checked : CheckState.UnChecked,
                         CanFocus = false
                     },
                     HelpText = "",
                     Key = Key.F6
                 };
 
-                ((CheckBox)ShForce16Colors.CommandView).Toggle += (sender, args) =>
+                ((CheckBox)ShForce16Colors.CommandView).CheckedStateChanging += (sender, args) =>
                                                                   {
                                                                       Application.Force16Colors = args.NewValue == CheckState.Checked;
                                                                       MiForce16Colors!.Checked = Application.Force16Colors;
@@ -1027,7 +1027,7 @@ public class UICatalogApp
                                       {
                                           MiForce16Colors.Checked = Application.Force16Colors = (bool)!MiForce16Colors.Checked!;
 
-                                          ((CheckBox)ShForce16Colors!.CommandView!).State =
+                                          ((CheckBox)ShForce16Colors!.CommandView!).CheckedState =
                                               Application.Force16Colors ? CheckState.Checked : CheckState.UnChecked;
                                           Application.Refresh ();
                                       };

--- a/UnitTests/Views/CheckBoxTests.cs
+++ b/UnitTests/Views/CheckBoxTests.cs
@@ -98,15 +98,15 @@ public class CheckBoxTests (ITestOutputHelper output)
     {
         var checkBox = new CheckBox { Text = "Check this out 你" };
 
-        Assert.Equal (CheckState.UnChecked, checkBox.State);
+        Assert.Equal (CheckState.UnChecked, checkBox.CheckedState);
         Assert.True (checkBox.NewKeyDownEvent (Key.Space));
-        Assert.Equal (CheckState.Checked, checkBox.State);
+        Assert.Equal (CheckState.Checked, checkBox.CheckedState);
         Assert.True (checkBox.NewMouseEvent (new () { Position = new (0, 0), Flags = MouseFlags.Button1Clicked }));
-        Assert.Equal (CheckState.UnChecked, checkBox.State);
+        Assert.Equal (CheckState.UnChecked, checkBox.CheckedState);
 
         checkBox.AllowCheckStateNone = true;
         Assert.True (checkBox.NewKeyDownEvent (Key.Space));
-        Assert.Equal (CheckState.None, checkBox.State);
+        Assert.Equal (CheckState.None, checkBox.CheckedState);
         checkBox.Draw ();
 
         TestHelpers.AssertDriverContentsWithFrameAre (
@@ -115,14 +115,14 @@ public class CheckBoxTests (ITestOutputHelper output)
                                                       output
                                                      );
         Assert.True (checkBox.NewMouseEvent (new () { Position = new (0, 0), Flags = MouseFlags.Button1Clicked }));
-        Assert.Equal (CheckState.Checked, checkBox.State);
+        Assert.Equal (CheckState.Checked, checkBox.CheckedState);
         Assert.True (checkBox.NewKeyDownEvent (Key.Space));
-        Assert.Equal (CheckState.UnChecked, checkBox.State);
+        Assert.Equal (CheckState.UnChecked, checkBox.CheckedState);
         Assert.True (checkBox.NewMouseEvent (new () { Position = new (0, 0), Flags = MouseFlags.Button1Clicked }));
-        Assert.Equal (CheckState.None, checkBox.State);
+        Assert.Equal (CheckState.None, checkBox.CheckedState);
 
         checkBox.AllowCheckStateNone = false;
-        Assert.Equal (CheckState.UnChecked, checkBox.State);
+        Assert.Equal (CheckState.UnChecked, checkBox.CheckedState);
     }
 
     [Fact]
@@ -131,17 +131,17 @@ public class CheckBoxTests (ITestOutputHelper output)
         var ckb = new CheckBox ();
         Assert.True (ckb.Width is DimAuto);
         Assert.True (ckb.Height is DimAuto);
-        Assert.Equal (CheckState.UnChecked, ckb.State);
+        Assert.Equal (CheckState.UnChecked, ckb.CheckedState);
         Assert.False (ckb.AllowCheckStateNone);
         Assert.Equal (string.Empty, ckb.Text);
         Assert.Equal ($"{CM.Glyphs.CheckStateUnChecked} ", ckb.TextFormatter.Text);
         Assert.True (ckb.CanFocus);
         Assert.Equal (new (0, 0, 2, 1), ckb.Frame);
 
-        ckb = new () { Text = "Test", State = CheckState.Checked };
+        ckb = new () { Text = "Test", CheckedState = CheckState.Checked };
         Assert.True (ckb.Width is DimAuto);
         Assert.True (ckb.Height is DimAuto);
-        Assert.Equal (CheckState.Checked, ckb.State);
+        Assert.Equal (CheckState.Checked, ckb.CheckedState);
         Assert.False (ckb.AllowCheckStateNone);
         Assert.Equal ("Test", ckb.Text);
         Assert.Equal ($"{CM.Glyphs.CheckStateChecked} Test", ckb.TextFormatter.Text);
@@ -151,17 +151,17 @@ public class CheckBoxTests (ITestOutputHelper output)
         ckb = new () { Text = "Test", X = 1, Y = 2 };
         Assert.True (ckb.Width is DimAuto);
         Assert.True (ckb.Height is DimAuto);
-        Assert.Equal (CheckState.UnChecked, ckb.State);
+        Assert.Equal (CheckState.UnChecked, ckb.CheckedState);
         Assert.False (ckb.AllowCheckStateNone);
         Assert.Equal ("Test", ckb.Text);
         Assert.Equal ($"{CM.Glyphs.CheckStateUnChecked} Test", ckb.TextFormatter.Text);
         Assert.True (ckb.CanFocus);
         Assert.Equal (new (1, 2, 6, 1), ckb.Frame);
 
-        ckb = new () { Text = "Test", X = 3, Y = 4, State = CheckState.Checked };
+        ckb = new () { Text = "Test", X = 3, Y = 4, CheckedState = CheckState.Checked };
         Assert.True (ckb.Width is DimAuto);
         Assert.True (ckb.Height is DimAuto);
-        Assert.Equal (CheckState.Checked, ckb.State);
+        Assert.Equal (CheckState.Checked, ckb.CheckedState);
         Assert.False (ckb.AllowCheckStateNone);
         Assert.Equal ("Test", ckb.Text);
         Assert.Equal ($"{CM.Glyphs.CheckStateChecked} Test", ckb.TextFormatter.Text);
@@ -174,16 +174,16 @@ public class CheckBoxTests (ITestOutputHelper output)
     {
         var toggled = false;
         var ckb = new CheckBox ();
-        ckb.Toggle += (s, e) => toggled = true;
+        ckb.CheckedStateChanging += (s, e) => toggled = true;
 
-        Assert.Equal (CheckState.UnChecked, ckb.State);
+        Assert.Equal (CheckState.UnChecked, ckb.CheckedState);
         Assert.False (toggled);
         Assert.Equal (Key.Empty, ckb.HotKey);
 
         ckb.Text = "_Test";
         Assert.Equal (Key.T, ckb.HotKey);
         Assert.True (ckb.NewKeyDownEvent (Key.T));
-        Assert.Equal (CheckState.Checked, ckb.State);
+        Assert.Equal (CheckState.Checked, ckb.CheckedState);
         Assert.True (toggled);
 
         ckb.Text = "T_est";
@@ -191,28 +191,28 @@ public class CheckBoxTests (ITestOutputHelper output)
         Assert.Equal (Key.E, ckb.HotKey);
         Assert.True (ckb.NewKeyDownEvent (Key.E.WithAlt));
         Assert.True (toggled);
-        Assert.Equal (CheckState.UnChecked, ckb.State);
+        Assert.Equal (CheckState.UnChecked, ckb.CheckedState);
 
         toggled = false;
         Assert.Equal (Key.E, ckb.HotKey);
         Assert.True (ckb.NewKeyDownEvent (Key.E));
         Assert.True (toggled);
-        Assert.Equal (CheckState.Checked, ckb.State);
+        Assert.Equal (CheckState.Checked, ckb.CheckedState);
 
         toggled = false;
         Assert.True (ckb.NewKeyDownEvent (Key.Space));
         Assert.True (toggled);
-        Assert.Equal (CheckState.UnChecked, ckb.State);
+        Assert.Equal (CheckState.UnChecked, ckb.CheckedState);
 
         toggled = false;
         Assert.True (ckb.NewKeyDownEvent (Key.Space));
         Assert.True (toggled);
-        Assert.Equal (CheckState.Checked, ckb.State);
+        Assert.Equal (CheckState.Checked, ckb.CheckedState);
 
         toggled = false;
         Assert.False (ckb.NewKeyDownEvent (Key.Enter));
         Assert.False (toggled);
-        Assert.Equal (CheckState.Checked, ckb.State);
+        Assert.Equal (CheckState.Checked, ckb.CheckedState);
     }
 
     [Fact]
@@ -271,7 +271,7 @@ public class CheckBoxTests (ITestOutputHelper output)
         Rectangle pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
         Assert.Equal (new (0, 0, 30, 5), pos);
 
-        checkBox.State = CheckState.Checked;
+        checkBox.CheckedState = CheckState.Checked;
         Application.Refresh ();
 
         expected = @$"
@@ -333,10 +333,10 @@ public class CheckBoxTests (ITestOutputHelper output)
         Rectangle pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
         Assert.Equal (new (0, 0, 30, 6), pos);
 
-        checkBox1.State = CheckState.Checked;
+        checkBox1.CheckedState = CheckState.Checked;
         Assert.Equal (new (1, 1, 25, 1), checkBox1.Frame);
         Assert.Equal (_size25x1, checkBox1.TextFormatter.ConstrainToSize);
-        checkBox2.State = CheckState.Checked;
+        checkBox2.CheckedState = CheckState.Checked;
         Assert.Equal (new (1, 2, 25, 1), checkBox2.Frame);
         Assert.Equal (_size25x1, checkBox2.TextFormatter.ConstrainToSize);
         Application.Refresh ();
@@ -389,7 +389,7 @@ public class CheckBoxTests (ITestOutputHelper output)
         Rectangle pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
         Assert.Equal (new (0, 0, 30, 5), pos);
 
-        checkBox.State = CheckState.Checked;
+        checkBox.CheckedState = CheckState.Checked;
         Application.Refresh ();
 
         expected = @$"
@@ -440,7 +440,7 @@ public class CheckBoxTests (ITestOutputHelper output)
         Rectangle pos = TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
         Assert.Equal (new (0, 0, 30, 5), pos);
 
-        checkBox.State = CheckState.Checked;
+        checkBox.CheckedState = CheckState.Checked;
         Application.Refresh ();
 
         expected = @$"
@@ -481,14 +481,14 @@ public class CheckBoxTests (ITestOutputHelper output)
         var ckb = new CheckBox { AllowCheckStateNone = true };
         var checkedInvoked = false;
 
-        ckb.Toggle += CheckBoxToggle;
+        ckb.CheckedStateChanging += CheckBoxToggle;
 
-        ckb.State = initialState;
-        Assert.Equal (initialState, ckb.State);
-        bool? ret = ckb.OnToggle ();
+        ckb.CheckedState = initialState;
+        Assert.Equal (initialState, ckb.CheckedState);
+        bool? ret = ckb.OnCheckedStateChanging ();
         Assert.True (ret);
         Assert.True (checkedInvoked);
-        Assert.Equal (initialState, ckb.State);
+        Assert.Equal (initialState, ckb.CheckedState);
 
         return;
 

--- a/UnitTests/Views/CheckBoxTests.cs
+++ b/UnitTests/Views/CheckBoxTests.cs
@@ -485,7 +485,7 @@ public class CheckBoxTests (ITestOutputHelper output)
 
         ckb.CheckedState = initialState;
         Assert.Equal (initialState, ckb.CheckedState);
-        bool? ret = ckb.OnCheckedStateChanging ();
+        bool? ret = ckb.AdvanceCheckState ();
         Assert.True (ret);
         Assert.True (checkedInvoked);
         Assert.Equal (initialState, ckb.CheckedState);

--- a/docfx/docs/migratingfromv1.md
+++ b/docfx/docs/migratingfromv1.md
@@ -301,7 +301,7 @@ The [Aligner](~/api/Terminal.Gui.Aligner.yml) class makes it easy to align eleme
 
 In v1 `CheckBox` used `bool?` to represent the 3 states. To support consistent behavior for the `Accept` event, `CheckBox` was refactored to use the new `CheckState` enum instead of `bool?`.
 
-Additionally the `Toggle` method was renamed to `AdvanceCheckState`.
+Additionally the `Toggle` event was renamed `CheckStateChanging` and made cancelable. The `Toggle` method was renamed to `AdvanceCheckState`.
 
 ### How to Fix
 

--- a/docfx/docs/migratingfromv1.md
+++ b/docfx/docs/migratingfromv1.md
@@ -296,3 +296,33 @@ The [Aligner](~/api/Terminal.Gui.Aligner.yml) class makes it easy to align eleme
 -                                      );
 + var statusBar = new StatusBar (new Shortcut [] { new (Application.QuitKey, "Quit", Quit) });
 ```
+
+## `CheckBox` - API renamed and simplified
+
+In v1 `CheckBox` used `bool?` to represent the 3 states. To support consistent behavior for the `Accept` event, `CheckBox` was refactored to use the new `CheckState` enum instead of `bool?`.
+
+Additionally the `Toggle` method was renamed to `AdvanceCheckState`.
+
+### How to Fix
+
+```diff
+-var cb = new CheckBox ("_Checkbox", true); {
+-				X = Pos.Right (label) + 1,
+-				Y = Pos.Top (label) + 2
+-			};
+-			cb.Toggled += (e) => {
+-			};
+-           cb.Toggle ();
++
++var cb = new CheckBox ()
++{ 
++	Title = "_Checkbox",
++	CheckState = CheckState.Checked
++}
++cb.CheckStateChanging += (s, e) =>
++{	
++	e.Cancel = preventChange;
++}
++preventChange = false;
++cb.AdvanceCheckState ();
+```


### PR DESCRIPTION
## Fixes

- Fixes #3641

## Proposed Changes/Todos

- [x] `State` -> `CheckedState`
- [x] `OnToggled()` -> `AdvanceCheckState()`
- [x] Improve API docs
- [x] Update migration guide 

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
