### PR TITLE
Fixes  #3661 Autocomplete TextField drawing fix

### DIFF
--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -1016,8 +1016,7 @@ public class TextField : View
 
         RenderCaption ();
 
-        ProcessAutocomplete ();
-
+        DrawAutocomplete ();
         _isDrawing = false;
     }
 
@@ -1767,8 +1766,21 @@ public class TextField : View
             return;
         }
 
-        // draw autocomplete
         GenerateSuggestions ();
+    }
+
+    private void DrawAutocomplete ()
+    {
+
+        if (SelectedLength > 0)
+        {
+            return;
+        }
+
+        if (Autocomplete?.Context == null)
+        {
+            return;
+        }
 
         var renderAt = new Point (
                                   Autocomplete.Context.CursorPosition,


### PR DESCRIPTION
## Fixes

- Fixes #3661 

Split processing autocomplete suggestion processing and drawing

![append-auto-working](https://github.com/user-attachments/assets/58d8dd12-29f0-48e2-b79e-023bd9ec2767)


Previously there was a single method `ProcessAutocomplete`  that did everything.  It changed the suggestions to new ones and it did the drawing.

It is especially confusing because there was a call to `ProcessAutocomplete` in draw content despite a pre-check in that method for:

```csharp
if (_isDrawing)
{
    return;
}
```

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
