### PR TITLE
Fixes #3635. Focus gets confused with ContextMenu.

### DIFF
--- a/Terminal.Gui/Application/Application.Mouse.cs
+++ b/Terminal.Gui/Application/Application.Mouse.cs
@@ -160,13 +160,13 @@ public static partial class Application // Mouse handling
                 Position = frameLoc,
                 Flags = mouseEvent.Flags,
                 ScreenPosition = mouseEvent.Position,
-                View = MouseGrabView
+                View = view ?? MouseGrabView
             };
 
             if ((MouseGrabView.Viewport with { Location = Point.Empty }).Contains (viewRelativeMouseEvent.Position) is false)
             {
                 // The mouse has moved outside the bounds of the view that grabbed the mouse
-                MouseEnteredView?.NewMouseLeaveEvent (mouseEvent);
+                MouseGrabView?.NewMouseLeaveEvent (mouseEvent);
             }
 
             //System.Diagnostics.Debug.WriteLine ($"{nme.Flags};{nme.X};{nme.Y};{mouseGrabView}");

--- a/Terminal.Gui/Views/Menu/MenuBar.cs
+++ b/Terminal.Gui/Views/Menu/MenuBar.cs
@@ -1504,8 +1504,7 @@ public class MenuBar : View, IDesignable
                     return false;
                 }
             }
-            else if (!_isContextMenuLoading
-                     && !(me.View is MenuBar || me.View is Menu)
+            else if (!(me.View is MenuBar || me.View is Menu)
                      && me.Flags != MouseFlags.ReportMousePosition
                      && me.Flags != 0)
             {

--- a/UnitTests/Views/ContextMenuTests.cs
+++ b/UnitTests/Views/ContextMenuTests.cs
@@ -1359,4 +1359,38 @@ public class ContextMenuTests (ITestOutputHelper output)
                                         )
         };
     }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void Handling_TextField_With_Opened_ContextMenu_By_Mouse_HasFocus ()
+    {
+        var tf1 = new TextField { Width = 10, Text = "TextField 1" };
+        var tf2 = new TextField { Y = 2, Width = 10, Text = "TextField 2" };
+        var win = new Window ();
+        win.Add (tf1, tf2);
+        var rs = Application.Begin (win);
+
+        Assert.True (tf1.HasFocus);
+        Assert.False (tf2.HasFocus);
+        Assert.Equal (2, win.Subviews.Count);
+
+        Application.OnMouseEvent (new () { Position = new (1, 3), Flags = MouseFlags.Button3Clicked });
+        Assert.False (tf1.HasFocus);
+        Assert.False (tf2.HasFocus);
+        Assert.Equal (3, win.Subviews.Count);
+        Assert.True (tf2.ContextMenu.MenuBar.IsMenuOpen);
+        Assert.True (win.Focused is Menu);
+        Assert.True (Application.MouseGrabView is MenuBar);
+
+        Application.OnMouseEvent (new () { Position = new (1, 1), Flags = MouseFlags.Button1Clicked });
+        Assert.True (tf1.HasFocus);
+        Assert.False (tf2.HasFocus);
+        Assert.Equal (2, win.Subviews.Count);
+        Assert.Null (tf2.ContextMenu.MenuBar);
+        Assert.Equal (win.Focused, tf1);
+        Assert.Null (Application.MouseGrabView);
+
+        Application.End (rs);
+        win.Dispose ();
+    }
 }

--- a/UnitTests/Views/ContextMenuTests.cs
+++ b/UnitTests/Views/ContextMenuTests.cs
@@ -1373,7 +1373,9 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (tf1.HasFocus);
         Assert.False (tf2.HasFocus);
         Assert.Equal (2, win.Subviews.Count);
+        Assert.Null (Application.MouseEnteredView);
 
+        // Right click on tf2 to open context menu
         Application.OnMouseEvent (new () { Position = new (1, 3), Flags = MouseFlags.Button3Clicked });
         Assert.False (tf1.HasFocus);
         Assert.False (tf2.HasFocus);
@@ -1381,7 +1383,9 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (tf2.ContextMenu.MenuBar.IsMenuOpen);
         Assert.True (win.Focused is Menu);
         Assert.True (Application.MouseGrabView is MenuBar);
+        Assert.Equal (tf2, Application.MouseEnteredView);
 
+        // Click on tf1 to focus it, which cause context menu being closed
         Application.OnMouseEvent (new () { Position = new (1, 1), Flags = MouseFlags.Button1Clicked });
         Assert.True (tf1.HasFocus);
         Assert.False (tf2.HasFocus);
@@ -1389,6 +1393,17 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.Null (tf2.ContextMenu.MenuBar);
         Assert.Equal (win.Focused, tf1);
         Assert.Null (Application.MouseGrabView);
+        Assert.Equal (tf1, Application.MouseEnteredView);
+
+        // Click on tf2 to focus it
+        Application.OnMouseEvent (new () { Position = new (1, 3), Flags = MouseFlags.Button1Clicked });
+        Assert.False (tf1.HasFocus);
+        Assert.True (tf2.HasFocus);
+        Assert.Equal (2, win.Subviews.Count);
+        Assert.Null (tf2.ContextMenu.MenuBar);
+        Assert.Equal (win.Focused, tf2);
+        Assert.Null (Application.MouseGrabView);
+        Assert.Equal (tf2, Application.MouseEnteredView);
 
         Application.End (rs);
         win.Dispose ();

--- a/docfx/docs/migratingfromv1.md
+++ b/docfx/docs/migratingfromv1.md
@@ -167,6 +167,7 @@ The API for handling keyboard input is significantly improved. See [Keyboard API
 * The preferred way to enable Application-wide or View-heirarchy-dependent keystrokes is to use the [Shortcut](~/api/Terminal.Gui.Shortcut.yml) View or the built-in View's that utilize it, such as the [Bar](~/api/Terminal.Gui.Bar.yml)-based views.
 * The preferred way to handle single keystrokes is to use **Key Bindings**. Key Bindings map a key press to a [Command](~/api/Terminal.Gui.Command.yml). A view can declare which commands it supports, and provide a lambda that implements the functionality of the command, using `View.AddCommand()`. Use the [View.Keybindings](~/api/Terminal.Gui.View.Keybindings.yml) to configure the key bindings.
 * For better consistency and user experience, the default key for closing an app or `Toplevel` is now `Esc` (it was previously `Ctrl+Q`).
+* The `Application.RootKeyEvent` method has been replaced with `Application.KeyDown`
 
 ### How to Fix
 
@@ -175,6 +176,12 @@ The API for handling keyboard input is significantly improved. See [Keyboard API
 * Use [View.Keybindings](~/api/Terminal.Gui.View.Keybindings.yml) to configure key bindings to `Command`s.
 * It should be very uncommon for v2 code to override `OnKeyPressed` etc... 
 * Anywhere `Ctrl+Q` was hard-coded as the "quit key", replace with `Application.QuitKey`.
+* Replace `Application.RootKeyEvent` with `Application.KeyDown`.  If the reason for subscribing to RootKeyEvent was to enable an application-wide action based on a key-press, consider using Application.KeyBindings instead.
+
+```diff
+- Application.RootKeyEvent(KeyEvent arg)
++ Application.KeyDown(object? sender, Key e)
+```
 
 ## Updated Mouse API
 
@@ -185,6 +192,7 @@ The API for mouse input is now internally consistent and easier to use.
 * Views can use the [View.Highlight](~/api/Terminal.Gui.View.Highlight.yml) event to have the view be visibly highlighted on various mouse events.
 * Views can set `View.WantContinousButtonPresses = true` to have their [Command.Accept](~/api/Terminal.Gui.Command.Accept.yml) command be invoked repeatedly as the user holds a mouse button down on the view.
 * Mouse and draw events now provide coordinates relative to the `Viewport` not the `Screen`.
+* The `Application.RootMouseEvent` method has been replaced with `Application.MouseEvent`
 
 ### How to Fix
 
@@ -192,6 +200,12 @@ The API for mouse input is now internally consistent and easier to use.
 * Use the [View.Highlight](~/api/Terminal.Gui.View.Highlight.yml) event to have the view be visibly highlighted on various mouse events.
 * Set `View.WantContinousButtonPresses = true` to have the [Command.Accept](~/api/Terminal.Gui.Command.Accept.yml) command be invoked repeatedly as the user holds a mouse button down on the view.
 * Update any code that assumed mouse events provided coordinates relative to the `Screen`.
+* Replace `Application.RootMouseEvent` with `Application.MouseEvent`.  
+
+```diff
+- Application.RootMouseEvent(KeyEvent arg)
++ Application.MouseEvent(object? sender, MouseEvent mouseEvent)
+```
 
 ## Cursor and Focus
 
@@ -203,6 +217,21 @@ The cursor and focus system has been redesigned in v2 to be more consistent and 
 * Use [View.CursorPosition](~/api/Terminal.Gui.View.CursorPosition.yml) to set the cursor position in a view. Set [View.CursorPosition](~/api/Terminal.Gui.View.CursorPosition.yml) to `null` to hide the cursor.
 * Set [View.CursorVisibility](~/api/Terminal.Gui.View.CursorVisibility.yml) to the cursor style you want to use.
 * Remove any overrides of `OnEnter` and `OnLeave` that explicitly change the cursor.
+
+## Button.Clicked Event Renamed
+
+The `Button.Clicked` event has been renamed `Button.Accept`
+
+## How to Fix
+
+Rename all instances of `Button.Clicked` to `Button.Accept`.  Note the signature change to mouse events below.
+
+```diff
+- btnLogin.Clicked 
++ btnLogin.Accept
+```
+
+Alternatively, if you want to have key events as well as mouse events to fire an event, use `Button.Accept`.
 
 ## Events now use `object sender, EventArgs args` signature
 
@@ -236,8 +265,9 @@ If you previously had a lamda expression, you can simply add the extra arguments
 
 ```diff
 - btnLogin.Clicked += () => { /*do something*/ };
-+ btnLogin.Clicked += (s,e) => { /*do something*/ };
++ btnLogin.Accept += (s,e) => { /*do something*/ };
 ```
+Note that the event name has also changed as noted above.
 
 If you have used a named method instead of a lamda you will need to update the signature e.g.
 
@@ -326,3 +356,15 @@ Additionally the `Toggle` event was renamed `CheckStateChanging` and made cancel
 +preventChange = false;
 +cb.AdvanceCheckState ();
 ```
+
+## `MainLoop` is no longer accessible from `Application`
+
+In v1, you could add timeouts via `Application.MainLoop.AddTimeout` among other things.  In v2, the `MainLoop` object is internal to `Application` and methods previously accessed via `MainLoop` can now be accessed directly via `Application`
+
+### How to Fix
+
+```diff
+- Application.MainLoop.AddTimeout (TimeSpan time, Func<MainLoop, bool> callback)
++ Application.AddTimeout (TimeSpan time, Func<bool> callback)
+```
+


### PR DESCRIPTION
## Fixes

- Fixes #3635

## Proposed Changes/Todos

- [x] It's needed to pass the view that has the mouse and not the `MouseGrabView` in the `MouseEvent`
- [x] Let the the view that grabbed the mouse call his `NewMouseLeaveEvent` and not the `MouseEnteredView`
- [x] If the `MenuBar` or any `Menu` is opened and isn't in the view that has the mouse, then it's needed to close all menus
- [x] Added unit test to ensure that this situation doesn't happen again

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
