### PR TITLE
Fixes #3664. `Shortcut` crashes in `SetColors` 

### DIFF
--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -806,6 +806,8 @@ public class Shortcut : View, IOrientation, IDesignable
 
         if (HasFocus)
         {
+            base.ColorScheme ??= new (Attribute.Default);
+
             // When we have focus, we invert the colors
             base.ColorScheme = new (base.ColorScheme)
             {

--- a/UnitTests/Views/ShortcutTests.cs
+++ b/UnitTests/Views/ShortcutTests.cs
@@ -38,9 +38,6 @@ public class ShortcutTests
 
         Assert.IsType<DimAuto> (shortcut.Width);
         Assert.IsType<DimAuto> (shortcut.Height);
-        //shortcut.BeginInit();
-        //shortcut.EndInit ();
-       // shortcut.LayoutSubviews ();
         shortcut.SetRelativeLayout (new (100, 100));
 
         // |0123456789
@@ -254,19 +251,6 @@ public class ShortcutTests
         shortcut.Action.Invoke ();
 
         Assert.True (actionInvoked);
-    }
-
-    [Fact]
-    public void ColorScheme_SetsAndGetsCorrectly ()
-    {
-        var colorScheme = new ColorScheme ();
-
-        var shortcut = new Shortcut
-        {
-            ColorScheme = colorScheme
-        };
-
-        Assert.Same (colorScheme, shortcut.ColorScheme);
     }
 
     [Fact]
@@ -600,5 +584,35 @@ public class ShortcutTests
     }
 
 
+    [Fact]
+    public void ColorScheme_SetsAndGetsCorrectly ()
+    {
+        var colorScheme = new ColorScheme ();
+
+        var shortcut = new Shortcut
+        {
+            ColorScheme = colorScheme
+        };
+
+        Assert.Same (colorScheme, shortcut.ColorScheme);
+    }
+
+    // https://github.com/gui-cs/Terminal.Gui/issues/3664
+    [Fact]
+    public void ColorScheme_SetColorScheme_Does_Not_Fault_3664 ()
+    {
+        Application.Current = new Toplevel ();
+        Shortcut shortcut = new Shortcut ();
+
+        Application.Current.ColorScheme = null;
+
+        Assert.Null (shortcut.ColorScheme);
+
+        shortcut.HasFocus = true;
+
+        Assert.NotNull (shortcut.ColorScheme);
+
+        Application.Current.Dispose ();
+    }
 
 }


### PR DESCRIPTION
## Fixes

- Fixes #3664

## Proposed Changes/Todos

- [x] Added unit test
- [x]  Fixed bug

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
