### PR TITLE
Fixes #3667. Null reference in v2 in FindDeepestView.

### DIFF
--- a/Terminal.Gui/Views/Toplevel.cs
+++ b/Terminal.Gui/Views/Toplevel.cs
@@ -69,73 +69,19 @@ public partial class Toplevel : View
     #region Subviews
 
     // TODO: Deprecate - Any view can host a menubar in v2
-    /// <summary>Gets or sets the menu for this Toplevel.</summary>
-    public MenuBar? MenuBar { get; set; }
+    /// <summary>Gets the latest <see cref="MenuBar"/> added into this Toplevel.</summary>
+    public MenuBar? MenuBar => (MenuBar?)Subviews?.LastOrDefault (s => s is MenuBar);
 
     // TODO: Deprecate - Any view can host a statusbar in v2
-    /// <summary>Gets or sets the status bar for this Toplevel.</summary>
-    public StatusBar? StatusBar { get; set; }
+    /// <summary>Gets the latest <see cref="StatusBar"/> added into this Toplevel.</summary>
+    public StatusBar? StatusBar => (StatusBar?)Subviews?.LastOrDefault (s => s is StatusBar);
 
     /// <inheritdoc/>
     public override View Add (View view)
     {
         CanFocus = true;
-        AddMenuStatusBar (view);
 
         return base.Add (view);
-    }
-
-    /// <inheritdoc/>
-    public override View Remove (View view)
-    {
-        if (this is Toplevel { MenuBar: { } })
-        {
-            RemoveMenuStatusBar (view);
-        }
-
-        return base.Remove (view);
-    }
-
-    /// <inheritdoc/>
-    public override void RemoveAll ()
-    {
-        if (this == Application.Top)
-        {
-            MenuBar?.Dispose ();
-            MenuBar = null;
-            StatusBar?.Dispose ();
-            StatusBar = null;
-        }
-
-        base.RemoveAll ();
-    }
-
-    internal void AddMenuStatusBar (View view)
-    {
-        if (view is MenuBar)
-        {
-            MenuBar = view as MenuBar;
-        }
-
-        if (view is StatusBar)
-        {
-            StatusBar = view as StatusBar;
-        }
-    }
-
-    internal void RemoveMenuStatusBar (View view)
-    {
-        if (view is MenuBar)
-        {
-            MenuBar?.Dispose ();
-            MenuBar = null;
-        }
-
-        if (view is StatusBar)
-        {
-            StatusBar?.Dispose ();
-            StatusBar = null;
-        }
     }
 
     // TODO: Overlapped - Rename to AllSubviewsClosed - Move to View?

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -408,7 +408,7 @@ public class UICatalogApp
             _themeMenuItems = CreateThemeMenuItems ();
             _themeMenuBarItem = new ("_Themes", _themeMenuItems);
 
-            MenuBar = new ()
+            MenuBar menuBar = new ()
             {
                 Menus =
                 [
@@ -462,13 +462,15 @@ public class UICatalogApp
                         )
                 ]
             };
+            Add (menuBar);
 
-            StatusBar = new ()
+            StatusBar statusBar = new ()
             {
                 Visible = ShowStatusBar,
                 AlignmentModes = AlignmentModes.IgnoreFirstOrLast,
                 CanFocus = false
             };
+            Add (statusBar);
 
             if (StatusBar is { })
             {
@@ -484,7 +486,11 @@ public class UICatalogApp
                     Title = "Show/Hide Status Bar",
                     CanFocus = false,
                 };
-                statusBarShortcut.Accept += (sender, args) => { StatusBar.Visible = !StatusBar.Visible; };
+                statusBarShortcut.Accept += (sender, args) =>
+                                            {
+                                                StatusBar.Visible = !StatusBar.Visible;
+                                                args.Handled = true;
+                                            };
 
                 ShForce16Colors = new ()
                 {


### PR DESCRIPTION
## Fixes

- Fixes #3667

## Proposed Changes/Todos

- [x] Make Toplevel's MenuBar and StatusBar properties read-only

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
