### PR TITLE
Fixes #3673. NativeAot project isn't using the correct release nuget package.

### DIFF
--- a/NativeAot/NativeAot.csproj
+++ b/NativeAot/NativeAot.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PackageReference Include="Terminal.Gui" Version="[2.0.0-pre.1788,3)" />
+    <PackageReference Include="Terminal.Gui" Version="[2.0.0-v2-develop.2189,3)" />
     <TrimmerRootAssembly Include="Terminal.Gui" />
   </ItemGroup>
 

--- a/NativeAot/Properties/launchSettings.json
+++ b/NativeAot/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "NativeAot": {
+      "commandName": "Project"
+    },
+    "WSL : UICatalog": {
+      "commandName": "Executable",
+      "executablePath": "wsl",
+      "commandLineArgs": "dotnet NativeAot.dll",
+      "distributionName": ""
+    }
+  }
+}


### PR DESCRIPTION
## Fixes

- Fixes #3673

## Proposed Changes/Todos

- [x] Added the https://www.nuget.org/packages/Terminal.Gui/2.0.0-v2-develop.2189 and up
- [x] Add configuration to launch WSL

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
