### PR TITLE
Fixes #3679. WantContinuousButtonPressed mustn't force calling GrabMouse.

### DIFF
--- a/Terminal.Gui/View/View.Mouse.cs
+++ b/Terminal.Gui/View/View.Mouse.cs
@@ -87,7 +87,7 @@ public partial class View // Mouse APIs
             return mouseEvent.Handled = true;
         }
 
-        if (HighlightStyle != HighlightStyle.None || WantContinuousButtonPressed)
+        if (HighlightStyle != HighlightStyle.None || (WantContinuousButtonPressed && WantMousePositionReports))
         {
             if (HandlePressed (mouseEvent))
             {

--- a/UnitTests/View/MouseTests.cs
+++ b/UnitTests/View/MouseTests.cs
@@ -232,7 +232,7 @@ public class MouseTests (ITestOutputHelper output) : TestsAllViews
     [InlineData (MouseFlags.Button2Pressed, MouseFlags.Button2Released)]
     [InlineData (MouseFlags.Button3Pressed, MouseFlags.Button3Released)]
     [InlineData (MouseFlags.Button4Pressed, MouseFlags.Button4Released)]
-    public void WantContinuousButtonPressed_True_Button_Press_Release_Clicks (MouseFlags pressed, MouseFlags released)
+    public void WantContinuousButtonPressed_True_And_WantMousePositionReports_True_Button_Press_Release_Clicks (MouseFlags pressed, MouseFlags released)
     {
         var me = new MouseEvent ();
 
@@ -240,7 +240,8 @@ public class MouseTests (ITestOutputHelper output) : TestsAllViews
         {
             Width = 1,
             Height = 1,
-            WantContinuousButtonPressed = true
+            WantContinuousButtonPressed = true,
+            WantMousePositionReports = true
         };
 
         var clickedCount = 0;
@@ -263,7 +264,7 @@ public class MouseTests (ITestOutputHelper output) : TestsAllViews
     [InlineData (MouseFlags.Button2Pressed, MouseFlags.Button2Released, MouseFlags.Button2Clicked)]
     [InlineData (MouseFlags.Button3Pressed, MouseFlags.Button3Released, MouseFlags.Button3Clicked)]
     [InlineData (MouseFlags.Button4Pressed, MouseFlags.Button4Released, MouseFlags.Button4Clicked)]
-    public void WantContinuousButtonPressed_True_Button_Press_Release_Clicks_Repeatedly (MouseFlags pressed, MouseFlags released, MouseFlags clicked)
+    public void WantContinuousButtonPressed_True_And_WantMousePositionReports_True_Button_Press_Release_Clicks_Repeatedly (MouseFlags pressed, MouseFlags released, MouseFlags clicked)
     {
         var me = new MouseEvent ();
 
@@ -271,7 +272,8 @@ public class MouseTests (ITestOutputHelper output) : TestsAllViews
         {
             Width = 1,
             Height = 1,
-            WantContinuousButtonPressed = true
+            WantContinuousButtonPressed = true,
+            WantMousePositionReports = true
         };
 
         var clickedCount = 0;
@@ -301,7 +303,7 @@ public class MouseTests (ITestOutputHelper output) : TestsAllViews
     }
 
     [Fact]
-    public void WantContinuousButtonPressed_True_Move_InViewport_OutOfViewport_Keeps_Counting ()
+    public void WantContinuousButtonPressed_True_And_WantMousePositionReports_True_Move_InViewport_OutOfViewport_Keeps_Counting ()
     {
         var me = new MouseEvent ();
 
@@ -309,7 +311,8 @@ public class MouseTests (ITestOutputHelper output) : TestsAllViews
         {
             Width = 1,
             Height = 1,
-            WantContinuousButtonPressed = true
+            WantContinuousButtonPressed = true,
+            WantMousePositionReports = true
         };
 
         var clickedCount = 0;


### PR DESCRIPTION
## Fixes

- Fixes #3679

## Proposed Changes/Todos

- [x] Add WantMousePositionReports to the condition

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
