### PR TITLE
Fixes #3682. CanFocus true for Label works only for keyboard and not mouse.

### DIFF
--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -28,6 +28,11 @@ public class Label : View
 
     private void Label_MouseClick (object sender, MouseEventEventArgs e)
     {
+        if (CanFocus)
+        {
+            return;
+        }
+
         e.Handled = InvokeCommand (Command.HotKey) == true;
     }
 

--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -28,12 +28,10 @@ public class Label : View
 
     private void Label_MouseClick (object sender, MouseEventEventArgs e)
     {
-        if (CanFocus)
+        if (!CanFocus)
         {
-            return;
+            e.Handled = InvokeCommand (Command.HotKey) == true;
         }
-
-        e.Handled = InvokeCommand (Command.HotKey) == true;
     }
 
     private void Label_TitleChanged (object sender, EventArgs<string> e)

--- a/UnitTests/Views/LabelTests.cs
+++ b/UnitTests/Views/LabelTests.cs
@@ -1315,4 +1315,49 @@ e
         Assert.Equal (expectedLabelBounds, label.Viewport);
         super.Dispose ();
     }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void Label_CanFocus_True_Get_Focus_By_Keyboard_And_Mouse ()
+    {
+        Label label = new () { Text = "label" };
+        View view = new () { Y = 2, Width = 10, Height = 1, Text = "view", CanFocus = true };
+        Toplevel top = new ();
+        top.Add (label, view);
+        Application.Begin (top);
+
+        Assert.Equal (new (0, 0, 5, 1), label.Frame);
+        Assert.Equal (new (0, 2, 10, 1), view.Frame);
+        Assert.Equal (view, top.MostFocused);
+        Assert.False (label.CanFocus);
+        Assert.False (label.HasFocus);
+        Assert.True (view.CanFocus);
+        Assert.True (view.HasFocus);
+
+        Assert.True (Application.OnKeyDown (Key.Tab));
+        Assert.False (label.HasFocus);
+        Assert.True (view.HasFocus);
+
+        Application.OnMouseEvent (new () { Position = new (0, 0), Flags = MouseFlags.Button1Clicked });
+        Assert.False (label.HasFocus);
+        Assert.True (view.HasFocus);
+
+        // Set label CanFocus to true
+        label.CanFocus = true;
+        Assert.True (Application.OnKeyDown (Key.Tab));
+        Assert.True (label.HasFocus);
+        Assert.False (view.HasFocus);
+
+        Assert.True (Application.OnKeyDown (Key.Tab));
+        Assert.False (label.HasFocus);
+        Assert.True (view.HasFocus);
+
+        Application.OnMouseEvent (new () { Position = new (0, 0), Flags = MouseFlags.Button1Clicked });
+        Assert.True (label.HasFocus);
+        Assert.False (view.HasFocus);
+
+        Application.OnMouseEvent (new () { Position = new (0, 2), Flags = MouseFlags.Button1Clicked });
+        Assert.False (label.HasFocus);
+        Assert.True (view.HasFocus);
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3682

## Proposed Changes/Todos

- [x] Only call InvokeCommand (Command.HotKey) if Label CanFocus is false by mouse

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
