### PR TITLE
Fixes #3687. ColorPicker isn't respecting the current UI culture.

### DIFF
--- a/Terminal.Gui/Drawing/ColorStrings.cs
+++ b/Terminal.Gui/Drawing/ColorStrings.cs
@@ -21,7 +21,7 @@ public static class ColorStrings
     public static string? GetW3CColorName (Color color)
     {
         // Fetch the color name from the resource file
-        return _resourceManager.GetString ($"#{color.R:X2}{color.G:X2}{color.B:X2}", CultureInfo.CurrentCulture);
+        return _resourceManager.GetString ($"#{color.R:X2}{color.G:X2}{color.B:X2}", CultureInfo.CurrentUICulture);
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ public static class ColorStrings
     /// <returns></returns>
     public static IEnumerable<string> GetW3CColorNames ()
     {
-        foreach (DictionaryEntry entry in _resourceManager.GetResourceSet (CultureInfo.CurrentCulture, true, true)!)
+        foreach (DictionaryEntry entry in _resourceManager.GetResourceSet (CultureInfo.CurrentUICulture, true, true)!)
         {
             string keyName = entry.Key.ToString () ?? string.Empty;
 
@@ -50,7 +50,7 @@ public static class ColorStrings
     public static bool TryParseW3CColorName (string name, out Color color)
     {
         // Iterate through all resource entries to find the matching color name
-        foreach (DictionaryEntry entry in _resourceManager.GetResourceSet (CultureInfo.CurrentCulture, true, true)!)
+        foreach (DictionaryEntry entry in _resourceManager.GetResourceSet (CultureInfo.CurrentUICulture, true, true)!)
         {
             if (entry.Value is string colorName && colorName.Equals (name, StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
## Fixes

- Fixes #3687

## Proposed Changes/Todos

- [x] Replace with CurrentUICulture

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
