### PR TITLE
Fixes #3693. HistoryTextItem derived from EventArgs doesn't follow the name rule convention.

### DIFF
--- a/Terminal.Gui/Views/HistoryTextItemEventArgs.cs
+++ b/Terminal.Gui/Views/HistoryTextItemEventArgs.cs
@@ -4,23 +4,23 @@ namespace Terminal.Gui;
 
 internal partial class HistoryText
 {
-    public class HistoryTextItem : EventArgs
+    public class HistoryTextItemEventArgs : EventArgs
     {
         public Point CursorPosition;
         public Point FinalCursorPosition;
         public bool IsUndoing;
         public List<List<RuneCell>> Lines;
         public LineStatus LineStatus;
-        public HistoryTextItem RemovedOnAdded;
+        public HistoryTextItemEventArgs RemovedOnAdded;
 
-        public HistoryTextItem (List<List<RuneCell>> lines, Point curPos, LineStatus linesStatus)
+        public HistoryTextItemEventArgs (List<List<RuneCell>> lines, Point curPos, LineStatus linesStatus)
         {
             Lines = lines;
             CursorPosition = curPos;
             LineStatus = linesStatus;
         }
 
-        public HistoryTextItem (HistoryTextItem historyTextItem)
+        public HistoryTextItemEventArgs (HistoryTextItemEventArgs historyTextItem)
         {
             Lines = new List<List<RuneCell>> (historyTextItem.Lines);
             CursorPosition = new Point (historyTextItem.CursorPosition.X, historyTextItem.CursorPosition.Y);

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -585,7 +585,7 @@ public class TextField : View
         SetNeedsDisplay ();
     }
 
-    /// <summary>Allows clearing the <see cref="HistoryText.HistoryTextItem"/> items updating the original text.</summary>
+    /// <summary>Allows clearing the <see cref="HistoryText.HistoryTextItemEventArgs"/> items updating the original text.</summary>
     public void ClearHistoryChanges () { _historyText.Clear (Text); }
 
     /// <summary>Copy the selected text to the clipboard.</summary>
@@ -1382,7 +1382,7 @@ public class TextField : View
         return new Attribute (cs.Disabled.Foreground, cs.Focus.Background);
     }
 
-    private void HistoryText_ChangeText (object sender, HistoryText.HistoryTextItem obj)
+    private void HistoryText_ChangeText (object sender, HistoryText.HistoryTextItemEventArgs obj)
     {
         if (obj is null)
         {

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1269,7 +1269,7 @@ internal partial class HistoryText
         Added
     }
 
-    private readonly List<HistoryTextItem> _historyTextItems = new ();
+    private readonly List<HistoryTextItemEventArgs> _historyTextItems = new ();
     private int _idxHistoryText = -1;
     private string? _originalText;
     public bool HasHistoryChanges => _idxHistoryText > -1;
@@ -1304,7 +1304,7 @@ internal partial class HistoryText
         _idxHistoryText++;
     }
 
-    public event EventHandler<HistoryTextItem>? ChangeText;
+    public event EventHandler<HistoryTextItemEventArgs>? ChangeText;
 
     public void Clear (string text)
     {
@@ -1324,7 +1324,7 @@ internal partial class HistoryText
 
             _idxHistoryText++;
 
-            var historyTextItem = new HistoryTextItem (_historyTextItems [_idxHistoryText]) { IsUndoing = false };
+            var historyTextItem = new HistoryTextItemEventArgs (_historyTextItems [_idxHistoryText]) { IsUndoing = false };
 
             ProcessChanges (ref historyTextItem);
 
@@ -1334,7 +1334,7 @@ internal partial class HistoryText
 
     public void ReplaceLast (List<List<RuneCell>> lines, Point curPos, LineStatus lineStatus)
     {
-        HistoryTextItem? found = _historyTextItems.FindLast (x => x.LineStatus == lineStatus);
+        HistoryTextItemEventArgs? found = _historyTextItems.FindLast (x => x.LineStatus == lineStatus);
 
         if (found is { })
         {
@@ -1351,7 +1351,7 @@ internal partial class HistoryText
 
             _idxHistoryText--;
 
-            var historyTextItem = new HistoryTextItem (_historyTextItems [_idxHistoryText]) { IsUndoing = true };
+            var historyTextItem = new HistoryTextItemEventArgs (_historyTextItems [_idxHistoryText]) { IsUndoing = true };
 
             ProcessChanges (ref historyTextItem);
 
@@ -1359,9 +1359,9 @@ internal partial class HistoryText
         }
     }
 
-    private void OnChangeText (HistoryTextItem? lines) { ChangeText?.Invoke (this, lines!); }
+    private void OnChangeText (HistoryTextItemEventArgs? lines) { ChangeText?.Invoke (this, lines!); }
 
-    private void ProcessChanges (ref HistoryTextItem historyTextItem)
+    private void ProcessChanges (ref HistoryTextItemEventArgs historyTextItem)
     {
         if (historyTextItem.IsUndoing)
         {
@@ -2859,7 +2859,7 @@ public class TextView : View
     }
 
 
-    /// <summary>Allows clearing the <see cref="HistoryText.HistoryTextItem"/> items updating the original text.</summary>
+    /// <summary>Allows clearing the <see cref="HistoryText.HistoryTextItemEventArgs"/> items updating the original text.</summary>
     public void ClearHistoryChanges () { _historyText?.Clear (Text); }
 
     /// <summary>Closes the contents of the stream into the <see cref="TextView"/>.</summary>
@@ -4655,7 +4655,7 @@ public class TextView : View
         return new ValueTuple<int, int> (line, col);
     }
 
-    private void HistoryText_ChangeText (object sender, HistoryText.HistoryTextItem obj)
+    private void HistoryText_ChangeText (object sender, HistoryText.HistoryTextItemEventArgs obj)
     {
         SetWrapModel ();
 


### PR DESCRIPTION
## Fixes

- Fixes #3693

## Proposed Changes/Todos

- [x] Change to HistoryTextItemEventArgs

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
