### PR TITLE
Fixes #3700. ContextMenu pollutes Toplevel.MenuBar's key bindings

### DIFF
--- a/Terminal.Gui/Views/ColorPicker.cs
+++ b/Terminal.Gui/Views/ColorPicker.cs
@@ -342,7 +342,7 @@ public class ColorPicker : View
         }
     }
 
-
+    /// <inheritdoc />
     protected override void Dispose (bool disposing)
     {
         DisposeOldViews ();

--- a/Terminal.Gui/Views/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialog.cs
@@ -1272,19 +1272,19 @@ public class FileDialog : Dialog
 
         var contextMenu = new ContextMenu
         {
-            Position = new Point (e.MouseEvent.Position.X + 1, e.MouseEvent.Position.Y + 1),
-            MenuItems = new MenuBarItem (
+            Position = new Point (e.MouseEvent.Position.X + 1, e.MouseEvent.Position.Y + 1)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem (Strings.fdCtxNew, string.Empty, New),
                                              new MenuItem (Strings.fdCtxRename, string.Empty, Rename),
                                              new MenuItem (Strings.fdCtxDelete, string.Empty, Delete)
                                          ]
-                                        )
-        };
-
+                                        );
         _tableView.SetSelection (clickedCell.Value.X, clickedCell.Value.Y, false);
 
-        contextMenu.Show ();
+        contextMenu.Show (menuItems);
     }
 
     private void ShowHeaderContextMenu (int clickedCol, MouseEventEventArgs e)
@@ -1293,8 +1293,10 @@ public class FileDialog : Dialog
 
         var contextMenu = new ContextMenu
         {
-            Position = new Point (e.MouseEvent.Position.X + 1, e.MouseEvent.Position.Y + 1),
-            MenuItems = new MenuBarItem (
+            Position = new Point (e.MouseEvent.Position.X + 1, e.MouseEvent.Position.Y + 1)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem (
                                                            string.Format (
@@ -1309,10 +1311,8 @@ public class FileDialog : Dialog
                                                            string.Empty,
                                                            () => SortColumn (clickedCol, isAsc))
                                          ]
-                                        )
-        };
-
-        contextMenu.Show ();
+                                        );
+        contextMenu.Show (menuItems);
     }
 
     private void SortColumn (int clickedCol)

--- a/Terminal.Gui/Views/Menu/ContextMenu.cs
+++ b/Terminal.Gui/Views/Menu/ContextMenu.cs
@@ -1,4 +1,6 @@
-﻿namespace Terminal.Gui;
+﻿#nullable enable
+
+namespace Terminal.Gui;
 
 /// <summary>
 ///     ContextMenu provides a pop-up menu that can be positioned anywhere within a <see cref="View"/>. ContextMenu is
@@ -16,15 +18,15 @@
 ///     </para>
 ///     <para>
 ///         Callers can cause the ContextMenu to be activated on a right-mouse click (or other interaction) by calling
-///         <see cref="Show()"/>.
+///         <see cref="Show"/>.
 ///     </para>
 ///     <para>ContextMenus are located using screen coordinates and appear above all other Views.</para>
 /// </summary>
 public sealed class ContextMenu : IDisposable
 {
-    private static MenuBar _menuBar;
+    private static MenuBar? _menuBar;
 
-    private Toplevel _container;
+    private Toplevel? _container;
     private Key _key = DefaultKey;
     private MouseFlags _mouseFlags = MouseFlags.Button3Clicked;
 
@@ -33,15 +35,9 @@ public sealed class ContextMenu : IDisposable
     {
         if (IsShow)
         {
-            if (_menuBar.SuperView is { })
-            {
-                Hide ();
-            }
-
+            Hide ();
             IsShow = false;
         }
-
-        MenuItems = new MenuBarItem ();
     }
 
     /// <summary>The default shortcut key for activating the context menu.</summary>
@@ -56,13 +52,13 @@ public sealed class ContextMenu : IDisposable
     public bool ForceMinimumPosToZero { get; set; } = true;
 
     /// <summary>The host <see cref="View "/> which position will be used, otherwise if it's null the container will be used.</summary>
-    public View Host { get; set; }
+    public View? Host { get; set; }
 
     /// <summary>Gets whether the ContextMenu is showing or not.</summary>
     public static bool IsShow { get; private set; }
 
     /// <summary>Specifies the key that will activate the context menu.</summary>
-    public Key Key
+    public new Key Key
     {
         get => _key;
         set
@@ -74,10 +70,10 @@ public sealed class ContextMenu : IDisposable
     }
 
     /// <summary>Gets the <see cref="MenuBar"/> that is hosting this context menu.</summary>
-    public MenuBar MenuBar => _menuBar;
+    public MenuBar? MenuBar => _menuBar;
 
     /// <summary>Gets or sets the menu items for this context menu.</summary>
-    public MenuBarItem MenuItems { get; set; }
+    public MenuBarItem? MenuItems { get; private set; }
 
     /// <summary><see cref="Gui.MouseFlags"/> specifies the mouse action used to activate the context menu by mouse.</summary>
     public MouseFlags MouseFlags
@@ -105,11 +101,10 @@ public sealed class ContextMenu : IDisposable
     /// <summary>Disposes the context menu object.</summary>
     public void Dispose ()
     {
-        if (_menuBar is null)
+        if (_menuBar is { })
         {
-            return;
+            _menuBar.MenuAllClosed -= MenuBar_MenuAllClosed;
         }
-        _menuBar.MenuAllClosed -= MenuBar_MenuAllClosed;
         Application.UngrabMouse ();
         _menuBar?.Dispose ();
         _menuBar = null;
@@ -126,18 +121,49 @@ public sealed class ContextMenu : IDisposable
     /// <summary>Hides (closes) the ContextMenu.</summary>
     public void Hide ()
     {
+        RemoveKeyBindings (MenuItems);
         _menuBar?.CleanUp ();
         IsShow = false;
     }
 
+    private void RemoveKeyBindings (MenuBarItem? menuBarItem)
+    {
+        if (menuBarItem is null)
+        {
+            return;
+        }
+
+        foreach (var menuItem in menuBarItem.Children!)
+        {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (menuItem is null)
+            {
+                continue;
+            }
+
+            if (menuItem is MenuBarItem barItem)
+            {
+                RemoveKeyBindings (barItem);
+            }
+            else
+            {
+                if (menuItem.ShortcutKey != Key.Empty)
+                {
+                    // Remove an existent ShortcutKey
+                    _menuBar?.KeyBindings.Remove (menuItem.ShortcutKey);
+                }
+            }
+        }
+    }
+
     /// <summary>Event invoked when the <see cref="ContextMenu.Key"/> is changed.</summary>
-    public event EventHandler<KeyChangedEventArgs> KeyChanged;
+    public event EventHandler<KeyChangedEventArgs>? KeyChanged;
 
     /// <summary>Event invoked when the <see cref="ContextMenu.MouseFlags"/> is changed.</summary>
-    public event EventHandler<MouseFlagsChangedEventArgs> MouseFlagsChanged;
+    public event EventHandler<MouseFlagsChangedEventArgs>? MouseFlagsChanged;
 
     /// <summary>Shows (opens) the ContextMenu, displaying the <see cref="MenuItem"/>s it contains.</summary>
-    public void Show ()
+    public void Show (MenuBarItem? menuItems)
     {
         if (_menuBar is { })
         {
@@ -145,6 +171,12 @@ public sealed class ContextMenu : IDisposable
             Dispose ();
         }
 
+        if (menuItems is null || menuItems.Children.Length == 0)
+        {
+            return;
+        }
+
+        MenuItems = menuItems;
         _container = Application.Current;
         _container!.Closing += Container_Closing;
         _container.Deactivate += Container_Deactivate;
@@ -155,7 +187,7 @@ public sealed class ContextMenu : IDisposable
         if (Host is { })
         {
             Point pos = Host.ViewportToScreen (frame).Location;
-            pos.Y += Host.Frame.Height - 1;
+            pos.Y += Host.Frame.Height > 0 ? Host.Frame.Height - 1 : 0;
 
             if (position != pos)
             {
@@ -224,9 +256,9 @@ public sealed class ContextMenu : IDisposable
         _menuBar.OpenMenu ();
     }
 
-    private void Container_Closing (object sender, ToplevelClosingEventArgs obj) { Hide (); }
-    private void Container_Deactivate (object sender, ToplevelEventArgs e) { Hide (); }
-    private void Container_Disposing (object sender, EventArgs e) { Dispose (); }
+    private void Container_Closing (object? sender, ToplevelClosingEventArgs obj) { Hide (); }
+    private void Container_Deactivate (object? sender, ToplevelEventArgs e) { Hide (); }
+    private void Container_Disposing (object? sender, EventArgs e) { Dispose (); }
 
-    private void MenuBar_MenuAllClosed (object sender, EventArgs e) { Hide (); }
+    private void MenuBar_MenuAllClosed (object? sender, EventArgs e) { Hide (); }
 }

--- a/Terminal.Gui/Views/Menu/ContextMenu.cs
+++ b/Terminal.Gui/Views/Menu/ContextMenu.cs
@@ -58,7 +58,7 @@ public sealed class ContextMenu : IDisposable
     public static bool IsShow { get; private set; }
 
     /// <summary>Specifies the key that will activate the context menu.</summary>
-    public new Key Key
+    public Key Key
     {
         get => _key;
         set
@@ -133,7 +133,7 @@ public sealed class ContextMenu : IDisposable
             return;
         }
 
-        foreach (var menuItem in menuBarItem.Children!)
+        foreach (MenuItem? menuItem in menuBarItem.Children!)
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (menuItem is null)
@@ -150,7 +150,7 @@ public sealed class ContextMenu : IDisposable
                 if (menuItem.ShortcutKey != Key.Empty)
                 {
                     // Remove an existent ShortcutKey
-                    _menuBar?.KeyBindings.Remove (menuItem.ShortcutKey);
+                    _menuBar?.KeyBindings.Remove (menuItem.ShortcutKey!);
                 }
             }
         }
@@ -171,7 +171,7 @@ public sealed class ContextMenu : IDisposable
             Dispose ();
         }
 
-        if (menuItems is null || menuItems.Children.Length == 0)
+        if (menuItems is null || menuItems.Children!.Length == 0)
         {
             return;
         }

--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -72,9 +72,8 @@ internal sealed class Menu : View
 
         if (_barItems.Children is { })
         {
-            foreach (MenuItem menuItem in _barItems.Children)
+            foreach (MenuItem? menuItem in _barItems.Children)
             {
-                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                 if (menuItem is { })
                 {
                     menuItem._menuBar = Host;
@@ -102,7 +101,7 @@ internal sealed class Menu : View
 
             for (var i = 0; i < _barItems.Children?.Length; i++)
             {
-                if (_barItems.Children [i].IsEnabled ())
+                if (_barItems.Children [i]!.IsEnabled ())
                 {
                     _currentChild = i;
 
@@ -126,12 +125,12 @@ internal sealed class Menu : View
                                         || (_barItems.Children is { Length: > 0 }
                                             && _currentChild > -1
                                             && _currentChild < _barItems.Children.Length
-                                            && _barItems.Children [_currentChild].IsFromSubMenu),
+                                            && _barItems.Children [_currentChild]!.IsFromSubMenu),
                                         _barItems.Children is { Length: > 0 }
                                         && _currentChild > -1
                                         && _host.UseSubMenusSingleFrame
                                         && _barItems.SubMenu (
-                                                              _barItems.Children [_currentChild]
+                                                              _barItems.Children [_currentChild]!
                                                              )
                                         != null!
                                        );
@@ -206,8 +205,9 @@ internal sealed class Menu : View
             return;
         }
 
-        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-        foreach (MenuItem menuItem in menuBarItem.Children.Where (m => m is { }))
+        IEnumerable<MenuItem> menuItems = menuBarItem.Children.Where (m => m is { })!;
+
+        foreach (MenuItem menuItem in menuItems)
         {
             KeyBinding keyBinding = new ([Command.ToggleExpandCollapse], KeyBindingScope.HotKey, menuItem);
 
@@ -228,8 +228,9 @@ internal sealed class Menu : View
             return;
         }
 
-        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-        foreach (MenuItem menuItem in menuBarItem.Children.Where (m => m is { }))
+        IEnumerable<MenuItem> menuItems = menuBarItem.Children.Where (m => m is { })!;
+
+        foreach (MenuItem menuItem in menuItems)
         {
             if (menuItem.HotKey != Key.Empty)
             {
@@ -267,7 +268,6 @@ internal sealed class Menu : View
             {
                 MenuItem? item = _barItems.Children [_currentChild];
 
-                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                 if (item is null)
                 {
                     return true;
@@ -415,7 +415,7 @@ internal sealed class Menu : View
                 break;
             }
 
-            MenuItem item = _barItems.Children [i];
+            MenuItem? item = _barItems.Children [i];
 
             Driver.SetAttribute (
                                  // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
@@ -459,7 +459,7 @@ internal sealed class Menu : View
                 }
 
                 // This `- 3` is left border + right border + one row in from right
-                else if (p == Frame.Width - 3 && _barItems?.SubMenu (_barItems.Children [i]) is { })
+                else if (p == Frame.Width - 3 && _barItems?.SubMenu (_barItems.Children [i]!) is { })
                 {
                     Driver.AddRune (Glyphs.RightArrow);
                 }
@@ -630,12 +630,12 @@ internal sealed class Menu : View
         {
             switch (_currentChild)
             {
-                case > -1 when _barItems.Children! [_currentChild].Action != null!:
-                    Run (_barItems.Children [_currentChild].Action);
+                case > -1 when _barItems.Children! [_currentChild]!.Action != null!:
+                    Run (_barItems.Children [_currentChild]?.Action);
 
                     break;
-                case 0 when _host.UseSubMenusSingleFrame && _barItems.Children [_currentChild].Parent!.Parent != null:
-                    _host.PreviousMenu (_barItems.Children [_currentChild].Parent!.IsFromSubMenu, true);
+                case 0 when _host.UseSubMenusSingleFrame && _barItems.Children [_currentChild]?.Parent!.Parent != null:
+                    _host.PreviousMenu (_barItems.Children [_currentChild]!.Parent!.IsFromSubMenu, true);
 
                     break;
                 case > -1 when _barItems.SubMenu (_barItems.Children [_currentChild]) != null!:
@@ -670,11 +670,10 @@ internal sealed class Menu : View
                 _currentChild = 0;
             }
 
-            // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
             if (this != _host.OpenCurrentMenu && _barItems?.Children? [_currentChild]?.IsFromSubMenu == true && _host._selectedSub > -1)
             {
                 _host.PreviousMenu (true);
-                _host.SelectEnabledItem (_barItems.Children, _currentChild, out _currentChild);
+                _host.SelectEnabledItem (_barItems.Children!, _currentChild, out _currentChild);
                 _host.OpenCurrentMenu = this;
             }
 
@@ -736,7 +735,7 @@ internal sealed class Menu : View
             if (_host.UseKeysUpDownAsKeysLeftRight && !_host.UseSubMenusSingleFrame)
             {
                 if ((_currentChild == -1 || this != _host.OpenCurrentMenu)
-                    && _barItems.Children! [_currentChild + 1].IsFromSubMenu
+                    && _barItems.Children! [_currentChild + 1]!.IsFromSubMenu
                     && _host._selectedSub > -1)
                 {
                     _currentChild++;
@@ -757,11 +756,11 @@ internal sealed class Menu : View
                 _currentChild = _barItems.Children!.Length - 1;
             }
 
-            if (!_host.SelectEnabledItem (_barItems.Children, _currentChild, out _currentChild, false))
+            if (!_host.SelectEnabledItem (_barItems.Children!, _currentChild, out _currentChild, false))
             {
                 _currentChild = 0;
 
-                if (!_host.SelectEnabledItem (_barItems.Children, _currentChild, out _currentChild) && !_host.CloseMenu ())
+                if (!_host.SelectEnabledItem (_barItems.Children!, _currentChild, out _currentChild) && !_host.CloseMenu ())
                 {
                     return false;
                 }
@@ -769,12 +768,12 @@ internal sealed class Menu : View
                 break;
             }
 
-            MenuItem item = _barItems.Children! [_currentChild];
+            MenuItem item = _barItems.Children! [_currentChild]!;
             disabled = item.IsEnabled () != true;
 
             if (_host.UseSubMenusSingleFrame
                 || !_host.UseKeysUpDownAsKeysLeftRight
-                || _barItems.SubMenu (_barItems.Children [_currentChild]) == null!
+                || _barItems.SubMenu (_barItems.Children [_currentChild]!) == null!
                 || disabled
                 || !_host.IsMenuOpen)
             {
@@ -788,7 +787,7 @@ internal sealed class Menu : View
 
             break;
         }
-        while (_barItems.Children? [_currentChild] is null || disabled);
+        while (_barItems.Children [_currentChild] is null || disabled);
 
         SetNeedsDisplay ();
         SetParentSetNeedsDisplay ();
@@ -839,7 +838,7 @@ internal sealed class Menu : View
                 return me.Handled = true;
             }
 
-            MenuItem item = _barItems.Children [me.Position.Y];
+            MenuItem item = _barItems.Children [me.Position.Y]!;
 
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (item is null || !item.IsEnabled ())
@@ -875,7 +874,7 @@ internal sealed class Menu : View
                 return me.Handled = true;
             }
 
-            MenuItem item = _barItems.Children [me.Position.Y];
+            MenuItem item = _barItems.Children [me.Position.Y]!;
 
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (item is null)
@@ -909,12 +908,12 @@ internal sealed class Menu : View
 
     internal bool CheckSubMenu ()
     {
-        if (_currentChild == -1 || _barItems!.Children? [_currentChild] is null)
+        if (_currentChild == -1 || _barItems?.Children? [_currentChild] is null)
         {
             return true;
         }
 
-        MenuBarItem? subMenu = _barItems.SubMenu (_barItems.Children [_currentChild]);
+        MenuBarItem? subMenu = _barItems.SubMenu (_barItems.Children [_currentChild]!);
 
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (subMenu is { })
@@ -936,7 +935,7 @@ internal sealed class Menu : View
 
             _host.Activate (_host._selected, pos, subMenu);
         }
-        else if (_host._openSubMenu?.Count == 0 || _host._openSubMenu?.Last ()._barItems!.IsSubMenuOf (_barItems.Children [_currentChild]) == false)
+        else if (_host._openSubMenu?.Count == 0 || _host._openSubMenu?.Last ()._barItems!.IsSubMenuOf (_barItems.Children [_currentChild]!) == false)
         {
             return _host.CloseMenu (false, true);
         }

--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -8,12 +8,12 @@ namespace Terminal.Gui;
 /// </summary>
 internal sealed class Menu : View
 {
-    private readonly MenuBarItem _barItems;
+    private readonly MenuBarItem? _barItems;
     private readonly MenuBar _host;
     internal int _currentChild;
-    internal View _previousSubFocused;
+    internal View? _previousSubFocused;
 
-    internal static Rectangle MakeFrame (int x, int y, MenuItem [] items, Menu? parent = null)
+    internal static Rectangle MakeFrame (int x, int y, MenuItem []? items, Menu? parent = null)
     {
         if (items is null || items.Length == 0)
         {
@@ -51,7 +51,7 @@ internal sealed class Menu : View
 
     internal required MenuBarItem BarItems
     {
-        get => _barItems;
+        get => _barItems!;
         init
         {
             ArgumentNullException.ThrowIfNull (value);
@@ -62,18 +62,19 @@ internal sealed class Menu : View
         }
     }
 
-    internal Menu Parent { get; init; }
+    internal Menu? Parent { get; init; }
 
     public override void BeginInit ()
     {
         base.BeginInit ();
 
-        Frame = MakeFrame (Frame.X, Frame.Y, _barItems?.Children, Parent);
+        Frame = MakeFrame (Frame.X, Frame.Y, _barItems!.Children!, Parent);
 
-        if (_barItems?.Children is { })
+        if (_barItems.Children is { })
         {
-            foreach (MenuItem menuItem in _barItems!.Children)
+            foreach (MenuItem menuItem in _barItems.Children)
             {
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                 if (menuItem is { })
                 {
                     menuItem._menuBar = Host;
@@ -82,8 +83,8 @@ internal sealed class Menu : View
                     {
                         KeyBinding keyBinding = new ([Command.Select], KeyBindingScope.HotKey, menuItem);
                         // Remove an existent ShortcutKey
-                        menuItem._menuBar?.KeyBindings.Remove (menuItem.ShortcutKey);
-                        menuItem._menuBar?.KeyBindings.Add (menuItem.ShortcutKey, keyBinding);
+                        menuItem._menuBar.KeyBindings.Remove (menuItem.ShortcutKey);
+                        menuItem._menuBar.KeyBindings.Add (menuItem.ShortcutKey, keyBinding);
                     }
                 }
             }
@@ -99,9 +100,9 @@ internal sealed class Menu : View
         {
             _currentChild = -1;
 
-            for (var i = 0; i < _barItems!.Children?.Length; i++)
+            for (var i = 0; i < _barItems.Children?.Length; i++)
             {
-                if (_barItems.Children [i]?.IsEnabled () == true)
+                if (_barItems.Children [i].IsEnabled ())
                 {
                     _currentChild = i;
 
@@ -122,19 +123,17 @@ internal sealed class Menu : View
                     {
                         _host.NextMenu (
                                         !_barItems.IsTopLevel
-                                        || (_barItems.Children != null
-                                            && _barItems!.Children.Length > 0
+                                        || (_barItems.Children is { Length: > 0 }
                                             && _currentChild > -1
                                             && _currentChild < _barItems.Children.Length
                                             && _barItems.Children [_currentChild].IsFromSubMenu),
-                                        _barItems!.Children != null
-                                        && _barItems.Children.Length > 0
+                                        _barItems.Children is { Length: > 0 }
                                         && _currentChild > -1
                                         && _host.UseSubMenusSingleFrame
                                         && _barItems.SubMenu (
                                                               _barItems.Children [_currentChild]
                                                              )
-                                        != null
+                                        != null!
                                        );
 
                         return true;
@@ -162,7 +161,7 @@ internal sealed class Menu : View
                     Command.Left,
                     () =>
                     {
-                        _host.PreviousMenu (true);
+                        _host!.PreviousMenu (true);
 
                         return true;
                     }
@@ -207,6 +206,7 @@ internal sealed class Menu : View
             return;
         }
 
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         foreach (MenuItem menuItem in menuBarItem.Children.Where (m => m is { }))
         {
             KeyBinding keyBinding = new ([Command.ToggleExpandCollapse], KeyBindingScope.HotKey, menuItem);
@@ -228,6 +228,7 @@ internal sealed class Menu : View
             return;
         }
 
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         foreach (MenuItem menuItem in menuBarItem.Children.Where (m => m is { }))
         {
             if (menuItem.HotKey != Key.Empty)
@@ -248,7 +249,7 @@ internal sealed class Menu : View
         }
 
 
-        for (var c = 0; c < _barItems.Children.Length; c++)
+        for (var c = 0; c < _barItems!.Children!.Length; c++)
         {
             if (_barItems.Children [c] == menuItem)
             {
@@ -266,11 +267,13 @@ internal sealed class Menu : View
             {
                 MenuItem? item = _barItems.Children [_currentChild];
 
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                 if (item is null)
                 {
                     return true;
                 }
 
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                 bool disabled = item is null || !item.IsEnabled ();
 
                 if (!disabled && (_host.UseSubMenusSingleFrame || !CheckSubMenu ()))
@@ -388,7 +391,7 @@ internal sealed class Menu : View
 
     public override void OnDrawContent (Rectangle viewport)
     {
-        if (_barItems.Children is null)
+        if (_barItems!.Children is null)
         {
             return;
         }
@@ -400,7 +403,7 @@ internal sealed class Menu : View
         OnDrawAdornments ();
         OnRenderLineCanvas ();
 
-        for (int i = Viewport.Y; i < _barItems.Children.Length; i++)
+        for (int i = Viewport.Y; i < _barItems!.Children.Length; i++)
         {
             if (i < 0)
             {
@@ -415,6 +418,7 @@ internal sealed class Menu : View
             MenuItem item = _barItems.Children [i];
 
             Driver.SetAttribute (
+                                 // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                                  item is null ? GetNormalColor () :
                                  i == _currentChild ? GetFocusColor () : GetNormalColor ()
                                 );
@@ -449,13 +453,13 @@ internal sealed class Menu : View
                 {
                     Driver.AddRune (Glyphs.HLine);
                 }
-                else if (i == 0 && p == 0 && _host.UseSubMenusSingleFrame && item.Parent.Parent is { })
+                else if (i == 0 && p == 0 && _host.UseSubMenusSingleFrame && item.Parent!.Parent is { })
                 {
                     Driver.AddRune (Glyphs.LeftArrow);
                 }
 
                 // This `- 3` is left border + right border + one row in from right
-                else if (p == Frame.Width - 3 && _barItems.SubMenu (_barItems.Children [i]) is { })
+                else if (p == Frame.Width - 3 && _barItems?.SubMenu (_barItems.Children [i]) is { })
                 {
                     Driver.AddRune (Glyphs.RightArrow);
                 }
@@ -477,7 +481,7 @@ internal sealed class Menu : View
                 continue;
             }
 
-            string? textToDraw = null;
+            string? textToDraw;
             Rune nullCheckedChar = Glyphs.CheckStateNone;
             Rune checkChar = Glyphs.Selected;
             Rune uncheckedChar = Glyphs.UnSelected;
@@ -516,7 +520,7 @@ internal sealed class Menu : View
                 {
                     DrawHotString (textToDraw, ColorScheme.Disabled, ColorScheme.Disabled);
                 }
-                else if (i == 0 && _host.UseSubMenusSingleFrame && item.Parent.Parent is { })
+                else if (i == 0 && _host.UseSubMenusSingleFrame && item.Parent!.Parent is { })
                 {
                     var tf = new TextFormatter
                     {
@@ -579,11 +583,11 @@ internal sealed class Menu : View
 
     public override Point? PositionCursor ()
     {
-        if (_host?.IsMenuOpen != false)
+        if (_host.IsMenuOpen)
         {
-            if (_barItems.IsTopLevel)
+            if (_barItems!.IsTopLevel)
             {
-                return _host?.PositionCursor ();
+                return _host.PositionCursor ();
             }
 
             Move (2, 1 + _currentChild);
@@ -591,7 +595,7 @@ internal sealed class Menu : View
             return null; // Don't show the cursor
         }
 
-        return _host?.PositionCursor ();
+        return _host.PositionCursor ();
     }
 
     public void Run (Action? action)
@@ -608,17 +612,17 @@ internal sealed class Menu : View
         _host.Run (action);
     }
 
-    protected override void OnHasFocusChanged (bool newHasFocus, View previousFocusedView, View view)
+    protected override void OnHasFocusChanged (bool newHasFocus, View? previousFocusedView, View? view)
     {
         if (!newHasFocus)
         {
-            _host.LostFocus (previousFocusedView);
+            _host.LostFocus (previousFocusedView!);
         }
     }
 
     private void RunSelected ()
     {
-        if (_barItems.IsTopLevel)
+        if (_barItems!.IsTopLevel)
         {
             Run (_barItems.Action);
         }
@@ -626,15 +630,15 @@ internal sealed class Menu : View
         {
             switch (_currentChild)
             {
-                case > -1 when _barItems.Children [_currentChild].Action != null:
+                case > -1 when _barItems.Children! [_currentChild].Action != null!:
                     Run (_barItems.Children [_currentChild].Action);
 
                     break;
-                case 0 when _host.UseSubMenusSingleFrame && _barItems.Children [_currentChild].Parent.Parent != null:
-                    _host.PreviousMenu (_barItems.Children [_currentChild].Parent.IsFromSubMenu, true);
+                case 0 when _host.UseSubMenusSingleFrame && _barItems.Children [_currentChild].Parent!.Parent != null:
+                    _host.PreviousMenu (_barItems.Children [_currentChild].Parent!.IsFromSubMenu, true);
 
                     break;
-                case > -1 when _barItems.SubMenu (_barItems.Children [_currentChild]) != null:
+                case > -1 when _barItems.SubMenu (_barItems.Children [_currentChild]) != null!:
                     CheckSubMenu ();
 
                     break;
@@ -650,7 +654,7 @@ internal sealed class Menu : View
 
     private bool MoveDown ()
     {
-        if (_barItems.IsTopLevel)
+        if (_barItems!.IsTopLevel)
         {
             return true;
         }
@@ -661,7 +665,7 @@ internal sealed class Menu : View
         {
             _currentChild++;
 
-            if (_currentChild >= _barItems.Children.Length)
+            if (_currentChild >= _barItems.Children!.Length)
             {
                 _currentChild = 0;
             }
@@ -684,9 +688,8 @@ internal sealed class Menu : View
                 disabled = false;
             }
 
-            if (!_host.UseSubMenusSingleFrame
-                && _host.UseKeysUpDownAsKeysLeftRight
-                && _barItems.SubMenu (_barItems.Children [_currentChild]) != null
+            if (_host is { UseSubMenusSingleFrame: false, UseKeysUpDownAsKeysLeftRight: true }
+                && _barItems.SubMenu (_barItems.Children [_currentChild]) != null!
                 && !disabled
                 && _host.IsMenuOpen)
             {
@@ -703,7 +706,7 @@ internal sealed class Menu : View
                 _host.OpenMenu (_host._selected);
             }
         }
-        while (_barItems.Children [_currentChild] is null || disabled);
+        while (_barItems.Children? [_currentChild] is null || disabled);
 
         SetNeedsDisplay ();
         SetParentSetNeedsDisplay ();
@@ -718,7 +721,7 @@ internal sealed class Menu : View
 
     private bool MoveUp ()
     {
-        if (_barItems.IsTopLevel || _currentChild == -1)
+        if (_barItems!.IsTopLevel || _currentChild == -1)
         {
             return true;
         }
@@ -732,7 +735,7 @@ internal sealed class Menu : View
             if (_host.UseKeysUpDownAsKeysLeftRight && !_host.UseSubMenusSingleFrame)
             {
                 if ((_currentChild == -1 || this != _host.OpenCurrentMenu)
-                    && _barItems.Children [_currentChild + 1].IsFromSubMenu
+                    && _barItems.Children! [_currentChild + 1].IsFromSubMenu
                     && _host._selectedSub > -1)
                 {
                     _currentChild++;
@@ -750,14 +753,14 @@ internal sealed class Menu : View
 
             if (_currentChild < 0)
             {
-                _currentChild = _barItems.Children.Length - 1;
+                _currentChild = _barItems.Children!.Length - 1;
             }
 
             if (!_host.SelectEnabledItem (_barItems.Children, _currentChild, out _currentChild, false))
             {
                 _currentChild = 0;
 
-                if (!_host.SelectEnabledItem (_barItems.Children, _currentChild, out _currentChild) && !_host.CloseMenu (false))
+                if (!_host.SelectEnabledItem (_barItems.Children, _currentChild, out _currentChild) && !_host.CloseMenu ())
                 {
                     return false;
                 }
@@ -765,12 +768,12 @@ internal sealed class Menu : View
                 break;
             }
 
-            MenuItem item = _barItems.Children [_currentChild];
-            disabled = item?.IsEnabled () != true;
+            MenuItem item = _barItems.Children! [_currentChild];
+            disabled = item.IsEnabled () != true;
 
             if (_host.UseSubMenusSingleFrame
                 || !_host.UseKeysUpDownAsKeysLeftRight
-                || _barItems.SubMenu (_barItems.Children [_currentChild]) == null
+                || _barItems.SubMenu (_barItems.Children [_currentChild]) == null!
                 || disabled
                 || !_host.IsMenuOpen)
             {
@@ -784,7 +787,7 @@ internal sealed class Menu : View
 
             break;
         }
-        while (_barItems.Children [_currentChild] is null || disabled);
+        while (_barItems.Children? [_currentChild] is null || disabled);
 
         SetNeedsDisplay ();
         SetParentSetNeedsDisplay ();
@@ -807,8 +810,8 @@ internal sealed class Menu : View
             }
         }
 
-        _host?._openMenu?.SetNeedsDisplay ();
-        _host?.SetNeedsDisplay ();
+        _host._openMenu?.SetNeedsDisplay ();
+        _host.SetNeedsDisplay ();
     }
 
     protected internal override bool OnMouseEvent (MouseEvent me)
@@ -830,13 +833,14 @@ internal sealed class Menu : View
                 return me.Handled = true;
             }
 
-            if (me.Position.Y >= _barItems.Children.Length)
+            if (me.Position.Y >= _barItems!.Children!.Length)
             {
                 return me.Handled = true;
             }
 
             MenuItem item = _barItems.Children [me.Position.Y];
 
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (item is null || !item.IsEnabled ())
             {
                 disabled = true;
@@ -865,19 +869,20 @@ internal sealed class Menu : View
         {
             disabled = false;
 
-            if (me.Position.Y < 0 || me.Position.Y >= _barItems.Children.Length)
+            if (me.Position.Y < 0 || me.Position.Y >= _barItems!.Children!.Length)
             {
                 return me.Handled = true;
             }
 
             MenuItem item = _barItems.Children [me.Position.Y];
 
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (item is null)
             {
                 return me.Handled = true;
             }
 
-            if (item?.IsEnabled () != true)
+            if (item.IsEnabled () != true)
             {
                 disabled = true;
             }
@@ -903,25 +908,26 @@ internal sealed class Menu : View
 
     internal bool CheckSubMenu ()
     {
-        if (_currentChild == -1 || _barItems.Children [_currentChild] is null)
+        if (_currentChild == -1 || _barItems!.Children? [_currentChild] is null)
         {
             return true;
         }
 
         MenuBarItem subMenu = _barItems.SubMenu (_barItems.Children [_currentChild]);
 
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (subMenu is { })
         {
             int pos = -1;
 
             if (_host._openSubMenu is { })
             {
-                pos = _host._openSubMenu.FindIndex (o => o?._barItems == subMenu);
+                pos = _host._openSubMenu.FindIndex (o => o._barItems == subMenu);
             }
 
             if (pos == -1
                 && this != _host.OpenCurrentMenu
-                && subMenu.Children != _host.OpenCurrentMenu!._barItems.Children
+                && subMenu.Children != _host.OpenCurrentMenu!._barItems!.Children
                 && !_host.CloseMenu (false, true))
             {
                 return false;
@@ -929,7 +935,7 @@ internal sealed class Menu : View
 
             _host.Activate (_host._selected, pos, subMenu);
         }
-        else if (_host._openSubMenu?.Count == 0 || _host._openSubMenu?.Last ()._barItems.IsSubMenuOf (_barItems.Children [_currentChild]) == false)
+        else if (_host._openSubMenu?.Count == 0 || _host._openSubMenu?.Last ()._barItems!.IsSubMenuOf (_barItems.Children [_currentChild]) == false)
         {
             return _host.CloseMenu (false, true);
         }

--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -13,7 +13,7 @@ internal sealed class Menu : View
     internal int _currentChild;
     internal View? _previousSubFocused;
 
-    internal static Rectangle MakeFrame (int x, int y, MenuItem []? items, Menu? parent = null)
+    internal static Rectangle MakeFrame (int x, int y, MenuItem? []? items, Menu? parent = null)
     {
         if (items is null || items.Length == 0)
         {

--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -670,7 +670,8 @@ internal sealed class Menu : View
                 _currentChild = 0;
             }
 
-            if (this != _host.OpenCurrentMenu && _barItems?.Children? [_currentChild].IsFromSubMenu == true && _host._selectedSub > -1)
+            // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
+            if (this != _host.OpenCurrentMenu && _barItems?.Children? [_currentChild]?.IsFromSubMenu == true && _host._selectedSub > -1)
             {
                 _host.PreviousMenu (true);
                 _host.SelectEnabledItem (_barItems.Children, _currentChild, out _currentChild);

--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -49,7 +49,7 @@ internal sealed class Menu : View
         }
     }
 
-    internal required MenuBarItem BarItems
+    internal required MenuBarItem? BarItems
     {
         get => _barItems!;
         init
@@ -83,8 +83,8 @@ internal sealed class Menu : View
                     {
                         KeyBinding keyBinding = new ([Command.Select], KeyBindingScope.HotKey, menuItem);
                         // Remove an existent ShortcutKey
-                        menuItem._menuBar.KeyBindings.Remove (menuItem.ShortcutKey);
-                        menuItem._menuBar.KeyBindings.Add (menuItem.ShortcutKey, keyBinding);
+                        menuItem._menuBar.KeyBindings.Remove (menuItem.ShortcutKey!);
+                        menuItem._menuBar.KeyBindings.Add (menuItem.ShortcutKey!, keyBinding);
                     }
                 }
             }
@@ -213,9 +213,9 @@ internal sealed class Menu : View
 
             if (menuItem.HotKey != Key.Empty)
             {
-                KeyBindings.Remove (menuItem.HotKey);
-                KeyBindings.Add (menuItem.HotKey, keyBinding);
-                KeyBindings.Remove (menuItem.HotKey.WithAlt);
+                KeyBindings.Remove (menuItem.HotKey!);
+                KeyBindings.Add (menuItem.HotKey!, keyBinding);
+                KeyBindings.Remove (menuItem.HotKey!.WithAlt);
                 KeyBindings.Add (menuItem.HotKey.WithAlt, keyBinding);
             }
         }
@@ -233,8 +233,8 @@ internal sealed class Menu : View
         {
             if (menuItem.HotKey != Key.Empty)
             {
-                KeyBindings.Remove (menuItem.HotKey);
-                KeyBindings.Remove (menuItem.HotKey.WithAlt);
+                KeyBindings.Remove (menuItem.HotKey!);
+                KeyBindings.Remove (menuItem.HotKey!.WithAlt);
             }
         }
     }
@@ -665,19 +665,19 @@ internal sealed class Menu : View
         {
             _currentChild++;
 
-            if (_currentChild >= _barItems.Children!.Length)
+            if (_currentChild >= _barItems?.Children?.Length)
             {
                 _currentChild = 0;
             }
 
-            if (this != _host.OpenCurrentMenu && _barItems.Children [_currentChild]?.IsFromSubMenu == true && _host._selectedSub > -1)
+            if (this != _host.OpenCurrentMenu && _barItems?.Children? [_currentChild].IsFromSubMenu == true && _host._selectedSub > -1)
             {
                 _host.PreviousMenu (true);
                 _host.SelectEnabledItem (_barItems.Children, _currentChild, out _currentChild);
                 _host.OpenCurrentMenu = this;
             }
 
-            MenuItem item = _barItems.Children [_currentChild];
+            MenuItem? item = _barItems?.Children? [_currentChild];
 
             if (item?.IsEnabled () != true)
             {
@@ -689,7 +689,7 @@ internal sealed class Menu : View
             }
 
             if (_host is { UseSubMenusSingleFrame: false, UseKeysUpDownAsKeysLeftRight: true }
-                && _barItems.SubMenu (_barItems.Children [_currentChild]) != null!
+                && _barItems?.SubMenu (_barItems?.Children? [_currentChild]!) != null
                 && !disabled
                 && _host.IsMenuOpen)
             {
@@ -706,7 +706,7 @@ internal sealed class Menu : View
                 _host.OpenMenu (_host._selected);
             }
         }
-        while (_barItems.Children? [_currentChild] is null || disabled);
+        while (_barItems?.Children? [_currentChild] is null || disabled);
 
         SetNeedsDisplay ();
         SetParentSetNeedsDisplay ();
@@ -913,7 +913,7 @@ internal sealed class Menu : View
             return true;
         }
 
-        MenuBarItem subMenu = _barItems.SubMenu (_barItems.Children [_currentChild]);
+        MenuBarItem? subMenu = _barItems.SubMenu (_barItems.Children [_currentChild]);
 
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (subMenu is { })

--- a/Terminal.Gui/Views/Menu/MenuBarItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarItem.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Terminal.Gui;
 
 /// <summary>
@@ -16,8 +18,8 @@ public class MenuBarItem : MenuItem
         string title,
         string help,
         Action action,
-        Func<bool> canExecute = null,
-        MenuItem parent = null
+        Func<bool>? canExecute = null,
+        MenuItem? parent = null
     ) : base (title, help, action, canExecute, parent)
     {
         SetInitialProperties (title, null, null, true);
@@ -27,13 +29,13 @@ public class MenuBarItem : MenuItem
     /// <param name="title">Title for the menu item.</param>
     /// <param name="children">The items in the current menu.</param>
     /// <param name="parent">The parent <see cref="MenuItem"/> of this if any.</param>
-    public MenuBarItem (string title, MenuItem [] children, MenuItem parent = null) { SetInitialProperties (title, children, parent); }
+    public MenuBarItem (string title, MenuItem [] children, MenuItem? parent = null) { SetInitialProperties (title, children, parent); }
 
     /// <summary>Initializes a new <see cref="MenuBarItem"/> with separate list of items.</summary>
     /// <param name="title">Title for the menu item.</param>
     /// <param name="children">The list of items in the current menu.</param>
     /// <param name="parent">The parent <see cref="MenuItem"/> of this if any.</param>
-    public MenuBarItem (string title, List<MenuItem []> children, MenuItem parent = null) { SetInitialProperties (title, children, parent); }
+    public MenuBarItem (string title, List<MenuItem []> children, MenuItem? parent = null) { SetInitialProperties (title, children, parent); }
 
     /// <summary>Initializes a new <see cref="MenuBarItem"/>.</summary>
     /// <param name="children">The items in the current menu.</param>
@@ -47,7 +49,7 @@ public class MenuBarItem : MenuItem
     ///     <see cref="MenuBarItem"/>
     /// </summary>
     /// <value>The children.</value>
-    public MenuItem [] Children { get; set; }
+    public MenuItem []? Children { get; set; }
 
     internal bool IsTopLevel => Parent is null && (Children is null || Children.Length == 0) && Action != null;
 
@@ -81,13 +83,13 @@ public class MenuBarItem : MenuItem
     /// <returns>Returns <c>true</c> if it is a submenu. <c>false</c> otherwise.</returns>
     public bool IsSubMenuOf (MenuItem menuItem)
     {
-        return Children.Any (child => child == menuItem && child.Parent == menuItem.Parent);
+        return Children!.Any (child => child == menuItem && child.Parent == menuItem.Parent);
     }
 
     /// <summary>Check if a <see cref="MenuItem"/> is a <see cref="MenuBarItem"/>.</summary>
     /// <param name="menuItem"></param>
     /// <returns>Returns a <see cref="MenuBarItem"/> or null otherwise.</returns>
-    public MenuBarItem SubMenu (MenuItem menuItem) { return menuItem as MenuBarItem; }
+    public MenuBarItem SubMenu (MenuItem menuItem) { return (menuItem as MenuBarItem)!; }
 
     internal void AddShortcutKeyBindings (MenuBar menuBar)
     {
@@ -96,20 +98,24 @@ public class MenuBarItem : MenuItem
             return;
         }
 
+        _menuBar = menuBar;
+
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         foreach (MenuItem menuItem in Children.Where (m => m is { }))
         {
             // For MenuBar only add shortcuts for submenus
 
             if (menuItem.ShortcutKey != Key.Empty)
             {
-                menuItem.UpdateShortcutKeyBinding (Key.Empty);
+                menuItem._menuBar = menuBar;
+                menuItem.UpdateShortcutKeyBinding (menuItem._menuBar, Key.Empty);
             }
 
             SubMenu (menuItem)?.AddShortcutKeyBindings (menuBar);
         }
     }
 
-    private void SetInitialProperties (string title, object children, MenuItem parent = null, bool isTopLevel = false)
+    private void SetInitialProperties (string title, object? children, MenuItem? parent = null, bool isTopLevel = false)
     {
         if (!isTopLevel && children is null)
         {
@@ -179,7 +185,7 @@ public class MenuBarItem : MenuItem
     /// Add a <see cref="MenuBarItem"/> dynamically into the <see cref="MenuBar"/><c>.Menus</c>.
     /// </summary>
     /// <param name="menuItem"></param>
-    public void AddMenuBarItem (MenuItem menuItem = null)
+    public void AddMenuBarItem (MenuItem? menuItem = null)
     {
         if (menuItem is null)
         {
@@ -227,13 +233,14 @@ public class MenuBarItem : MenuItem
                 _menuBar?.KeyBindings.Remove (HotKey.WithAlt);
             }
 
-            _menuBar!.Menus [index] = null;
+            _menuBar!.Menus [index] = null!;
         }
 
         var i = 0;
 
         foreach (MenuBarItem m in _menuBar.Menus)
         {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (m != null)
             {
                 _menuBar.Menus [i] = m;

--- a/Terminal.Gui/Views/Menu/MenuBarItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarItem.cs
@@ -49,7 +49,7 @@ public class MenuBarItem : MenuItem
     ///     <see cref="MenuBarItem"/>
     /// </summary>
     /// <value>The children.</value>
-    public MenuItem []? Children { get; set; }
+    public MenuItem? []? Children { get; set; }
 
     internal bool IsTopLevel => Parent is null && (Children is null || Children.Length == 0) && Action != null;
 
@@ -65,7 +65,7 @@ public class MenuBarItem : MenuItem
             return -1;
         }
 
-        foreach (MenuItem child in Children)
+        foreach (MenuItem? child in Children)
         {
             if (child == children)
             {
@@ -89,7 +89,7 @@ public class MenuBarItem : MenuItem
     /// <summary>Check if a <see cref="MenuItem"/> is a <see cref="MenuBarItem"/>.</summary>
     /// <param name="menuItem"></param>
     /// <returns>Returns a <see cref="MenuBarItem"/> or null otherwise.</returns>
-    public MenuBarItem? SubMenu (MenuItem menuItem) { return menuItem as MenuBarItem; }
+    public MenuBarItem? SubMenu (MenuItem? menuItem) { return menuItem as MenuBarItem; }
 
     internal void AddShortcutKeyBindings (MenuBar menuBar)
     {
@@ -100,14 +100,16 @@ public class MenuBarItem : MenuItem
 
         _menuBar = menuBar;
 
-        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-        foreach (MenuItem menuItem in Children.Where (m => m is { }))
-        {
-            // For MenuBar only add shortcuts for submenus
+        IEnumerable<MenuItem> menuItems = Children.Where (m => m is { })!;
 
+        foreach (MenuItem menuItem in menuItems)
+        {
+            // Initialize MenuItem _menuBar
+            menuItem._menuBar = menuBar;
+
+            // For MenuBar only add shortcuts for submenus
             if (menuItem.ShortcutKey != Key.Empty)
             {
-                menuItem._menuBar = menuBar;
                 menuItem.AddShortcutKeyBinding (menuBar, Key.Empty);
             }
 
@@ -202,8 +204,9 @@ public class MenuBarItem : MenuItem
         }
         else
         {
-            MenuItem [] childrens = Children ?? [];
+            MenuItem [] childrens = (Children ?? [])!;
             Array.Resize (ref childrens, childrens.Length + 1);
+            menuItem._menuBar = menuBar;
             childrens [^1] = menuItem;
             Children = childrens;
         }
@@ -216,10 +219,10 @@ public class MenuBarItem : MenuItem
         {
             foreach (MenuItem? menuItem in Children)
             {
-                if (menuItem.ShortcutKey != Key.Empty)
+                if (menuItem?.ShortcutKey != Key.Empty)
                 {
                     // Remove an existent ShortcutKey
-                    _menuBar?.KeyBindings.Remove (menuItem.ShortcutKey!);
+                    _menuBar?.KeyBindings.Remove (menuItem?.ShortcutKey!);
                 }
             }
         }

--- a/Terminal.Gui/Views/Menu/MenuBarItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarItem.cs
@@ -108,7 +108,7 @@ public class MenuBarItem : MenuItem
             if (menuItem.ShortcutKey != Key.Empty)
             {
                 menuItem._menuBar = menuBar;
-                menuItem.UpdateShortcutKeyBinding (Key.Empty);
+                menuItem.AddShortcutKeyBinding (menuBar, Key.Empty);
             }
 
             SubMenu (menuItem)?.AddShortcutKeyBindings (menuBar);
@@ -126,7 +126,7 @@ public class MenuBarItem : MenuItem
                                             );
         }
 
-        Title = title;
+        SetTitle (title);
 
         if (parent is { })
         {
@@ -174,6 +174,12 @@ public class MenuBarItem : MenuItem
                 child.Parent = this;
             }
         }
+    }
+
+    private void SetTitle (string? title)
+    {
+        title ??= string.Empty;
+        Title = title;
     }
 
     /// <summary>

--- a/Terminal.Gui/Views/Menu/MenuBarItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarItem.cs
@@ -89,7 +89,7 @@ public class MenuBarItem : MenuItem
     /// <summary>Check if a <see cref="MenuItem"/> is a <see cref="MenuBarItem"/>.</summary>
     /// <param name="menuItem"></param>
     /// <returns>Returns a <see cref="MenuBarItem"/> or null otherwise.</returns>
-    public MenuBarItem SubMenu (MenuItem menuItem) { return (menuItem as MenuBarItem)!; }
+    public MenuBarItem? SubMenu (MenuItem menuItem) { return menuItem as MenuBarItem; }
 
     internal void AddShortcutKeyBindings (MenuBar menuBar)
     {
@@ -108,13 +108,14 @@ public class MenuBarItem : MenuItem
             if (menuItem.ShortcutKey != Key.Empty)
             {
                 menuItem._menuBar = menuBar;
-                menuItem.UpdateShortcutKeyBinding (menuItem._menuBar, Key.Empty);
+                menuItem.UpdateShortcutKeyBinding (Key.Empty);
             }
 
             SubMenu (menuItem)?.AddShortcutKeyBindings (menuBar);
         }
     }
 
+    // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
     private void SetInitialProperties (string title, object? children, MenuItem? parent = null, bool isTopLevel = false)
     {
         if (!isTopLevel && children is null)
@@ -125,7 +126,7 @@ public class MenuBarItem : MenuItem
                                             );
         }
 
-        SetTitle (title ?? "");
+        Title = title;
 
         if (parent is { })
         {
@@ -175,18 +176,17 @@ public class MenuBarItem : MenuItem
         }
     }
 
-    private void SetTitle (string title)
-    {
-        title ??= string.Empty;
-        Title = title;
-    }
-
     /// <summary>
     /// Add a <see cref="MenuBarItem"/> dynamically into the <see cref="MenuBar"/><c>.Menus</c>.
     /// </summary>
+    /// <param name="menuBar"></param>
     /// <param name="menuItem"></param>
-    public void AddMenuBarItem (MenuItem? menuItem = null)
+    public void AddMenuBarItem (MenuBar menuBar, MenuItem? menuItem = null)
     {
+        ArgumentNullException.ThrowIfNull (menuBar);
+
+        _menuBar = menuBar;
+
         if (menuItem is null)
         {
             MenuBarItem [] menus = _menuBar.Menus;
@@ -208,12 +208,12 @@ public class MenuBarItem : MenuItem
     {
         if (Children is { })
         {
-            foreach (MenuItem menuItem in Children)
+            foreach (MenuItem? menuItem in Children)
             {
                 if (menuItem.ShortcutKey != Key.Empty)
                 {
                     // Remove an existent ShortcutKey
-                    _menuBar?.KeyBindings.Remove (menuItem.ShortcutKey);
+                    _menuBar?.KeyBindings.Remove (menuItem.ShortcutKey!);
                 }
             }
         }
@@ -221,19 +221,19 @@ public class MenuBarItem : MenuItem
         if (ShortcutKey != Key.Empty)
         {
             // Remove an existent ShortcutKey
-            _menuBar?.KeyBindings.Remove (ShortcutKey);
+            _menuBar?.KeyBindings.Remove (ShortcutKey!);
         }
 
         var index = _menuBar!.Menus.IndexOf (this);
         if (index > -1)
         {
-            if (_menuBar!.Menus [index].HotKey != Key.Empty)
+            if (_menuBar.Menus [index].HotKey != Key.Empty)
             {
                 // Remove an existent HotKey
-                _menuBar?.KeyBindings.Remove (HotKey.WithAlt);
+                _menuBar.KeyBindings.Remove (HotKey!.WithAlt);
             }
 
-            _menuBar!.Menus [index] = null!;
+            _menuBar.Menus [index] = null!;
         }
 
         var i = 0;

--- a/Terminal.Gui/Views/Menu/MenuItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuItem.cs
@@ -21,8 +21,8 @@ public class MenuItem
     /// <param name="parent">The <see cref="Parent"/> of this menu item.</param>
     /// <param name="shortcutKey">The <see cref="ShortcutKey"/> keystroke combination.</param>
     public MenuItem (
-        string title,
-        string help,
+        string? title,
+        string? help,
         Action? action,
         Func<bool>? canExecute = null,
         MenuItem? parent = null,
@@ -50,7 +50,7 @@ public class MenuItem
 
     /// <summary>Gets or sets the action to be invoked when the menu item is triggered.</summary>
     /// <value>Method to invoke.</value>
-    public Action Action { get; set; }
+    public Action? Action { get; set; }
 
     /// <summary>
     ///     Used only if <see cref="CheckType"/> is of <see cref="MenuItemCheckStyle.Checked"/> type. If
@@ -72,7 +72,7 @@ public class MenuItem
     ///     returns <see langword="true"/> the menu item will be enabled. Otherwise, it will be disabled.
     /// </summary>
     /// <value>Function to determine if the action is can be executed or not.</value>
-    public Func<bool> CanExecute { get; set; }
+    public Func<bool>? CanExecute { get; set; }
 
     /// <summary>
     ///     Sets or gets whether the <see cref="MenuItem"/> shows a check indicator or not. See
@@ -188,7 +188,7 @@ public class MenuItem
                           (Checked == true || CheckType.HasFlag (MenuItemCheckStyle.Checked) || CheckType.HasFlag (MenuItemCheckStyle.Radio)
                                ? 2
                                : 0)
-                          + // check glyph + space 
+                          + // check glyph + space
                           (Help.GetColumns () > 0 ? 2 + Help.GetColumns () : 0)
                           + // Two spaces before Help
                           (ShortcutTag.GetColumns () > 0
@@ -219,12 +219,12 @@ public class MenuItem
     ///     </para>
     ///     <para>See also <see cref="ShortcutKey"/> which enable global key-bindings to menu items.</para>
     /// </summary>
-    public Key HotKey
+    public Key? HotKey
     {
         get => _hotKey;
         private set
         {
-            var oldKey = _hotKey ?? Key.Empty;
+            var oldKey = _hotKey;
             _hotKey = value ?? Key.Empty;
             UpdateHotKeyBinding (oldKey);
         }
@@ -262,30 +262,30 @@ public class MenuItem
     ///         <see cref="Help"/> text. See <see cref="ShortcutTag"/>.
     ///     </para>
     /// </summary>
-    public Key ShortcutKey
+    public Key? ShortcutKey
     {
         get => _shortcutKey;
         set
         {
-            var oldKey = _shortcutKey ?? Key.Empty;
+            var oldKey = _shortcutKey;
             _shortcutKey = value ?? Key.Empty;
-            UpdateShortcutKeyBinding (_menuBar, oldKey);
+            UpdateShortcutKeyBinding (oldKey);
         }
     }
 
     /// <summary>Gets the text describing the keystroke combination defined by <see cref="ShortcutKey"/>.</summary>
-    public string ShortcutTag => ShortcutKey != Key.Empty ? ShortcutKey.ToString () : string.Empty;
+    public string ShortcutTag => ShortcutKey != Key.Empty ? ShortcutKey!.ToString () : string.Empty;
 
     private void UpdateHotKeyBinding (Key oldKey)
     {
-        if (_menuBar is null || _menuBar?.IsInitialized == false)
+        if (_menuBar is null or { IsInitialized: false })
         {
             return;
         }
 
         if (oldKey != Key.Empty)
         {
-            var index = _menuBar.Menus?.IndexOf (this);
+            var index = _menuBar.Menus.IndexOf (this);
 
             if (index > -1)
             {
@@ -295,22 +295,20 @@ public class MenuItem
 
         if (HotKey != Key.Empty)
         {
-            var index = _menuBar.Menus?.IndexOf (this);
+            var index = _menuBar.Menus.IndexOf (this);
 
             if (index > -1)
             {
-                _menuBar.KeyBindings.Remove (HotKey.WithAlt);
+                _menuBar.KeyBindings.Remove (HotKey!.WithAlt);
                 KeyBinding keyBinding = new ([Command.ToggleExpandCollapse], KeyBindingScope.HotKey, this);
                 _menuBar.KeyBindings.Add (HotKey.WithAlt, keyBinding);
             }
         }
     }
 
-    internal void UpdateShortcutKeyBinding (MenuBar menuBar, Key oldKey)
+    internal void UpdateShortcutKeyBinding (Key oldKey)
     {
-        _menuBar ??= menuBar;
-
-        if (_menuBar is null)
+        if (_menuBar is null or { IsInitialized: false })
         {
             return;
         }
@@ -324,8 +322,8 @@ public class MenuItem
         {
             KeyBinding keyBinding = new ([Command.Select], KeyBindingScope.HotKey, this);
             // Remove an existent ShortcutKey
-            _menuBar?.KeyBindings.Remove (ShortcutKey);
-            _menuBar?.KeyBindings.Add (ShortcutKey, keyBinding);
+            _menuBar.KeyBindings.Remove (ShortcutKey!);
+            _menuBar.KeyBindings.Add (ShortcutKey!, keyBinding);
         }
     }
 
@@ -341,7 +339,7 @@ public class MenuItem
             MenuItem []? childrens = ((MenuBarItem)Parent).Children;
             var i = 0;
 
-            foreach (MenuItem c in childrens)
+            foreach (MenuItem c in childrens!)
             {
                 if (c != this)
                 {
@@ -365,7 +363,7 @@ public class MenuItem
         if (ShortcutKey != Key.Empty)
         {
             // Remove an existent ShortcutKey
-            _menuBar?.KeyBindings.Remove (ShortcutKey);
+            _menuBar.KeyBindings.Remove (ShortcutKey!);
         }
     }
 }

--- a/Terminal.Gui/Views/Menu/MenuItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuItem.cs
@@ -351,10 +351,10 @@ public class MenuItem
     {
         if (Parent is { })
         {
-            MenuItem []? childrens = ((MenuBarItem)Parent).Children;
+            MenuItem? []? childrens = ((MenuBarItem)Parent).Children;
             var i = 0;
 
-            foreach (MenuItem c in childrens!)
+            foreach (MenuItem? c in childrens!)
             {
                 if (c != this)
                 {

--- a/Terminal.Gui/Views/Menu/MenuItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuItem.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Terminal.Gui;
 
 /// <summary>
@@ -6,10 +8,10 @@ namespace Terminal.Gui;
 /// </summary>
 public class MenuItem
 {
-    internal static MenuBar _menuBar;
+    internal MenuBar _menuBar;
 
     /// <summary>Initializes a new instance of <see cref="MenuItem"/></summary>
-    public MenuItem (Key shortcutKey = null) : this ("", "", null, null, null, shortcutKey) { }
+    public MenuItem (Key? shortcutKey = null) : this ("", "", null, null, null, shortcutKey) { }
 
     /// <summary>Initializes a new instance of <see cref="MenuItem"/>.</summary>
     /// <param name="title">Title for the menu item.</param>
@@ -21,24 +23,24 @@ public class MenuItem
     public MenuItem (
         string title,
         string help,
-        Action action,
-        Func<bool> canExecute = null,
-        MenuItem parent = null,
-        Key shortcutKey = null
+        Action? action,
+        Func<bool>? canExecute = null,
+        MenuItem? parent = null,
+        Key? shortcutKey = null
     )
     {
         Title = title ?? "";
         Help = help ?? "";
-        Action = action;
-        CanExecute = canExecute;
-        Parent = parent;
+        Action = action!;
+        CanExecute = canExecute!;
+        Parent = parent!;
 
         if (Parent is { } && Parent.ShortcutKey != Key.Empty)
         {
             Parent.ShortcutKey = Key.Empty;
         }
         // Setter will ensure Key.Empty if it's null
-        ShortcutKey = shortcutKey;
+        ShortcutKey = shortcutKey!;
     }
 
     private bool _allowNullChecked;
@@ -112,7 +114,7 @@ public class MenuItem
 
     /// <summary>Gets the parent for this <see cref="MenuItem"/>.</summary>
     /// <value>The parent.</value>
-    public MenuItem Parent { get; set; }
+    public MenuItem? Parent { get; set; }
 
     /// <summary>Gets or sets the title of the menu item .</summary>
     /// <value>The title.</value>
@@ -267,7 +269,7 @@ public class MenuItem
         {
             var oldKey = _shortcutKey ?? Key.Empty;
             _shortcutKey = value ?? Key.Empty;
-            UpdateShortcutKeyBinding (oldKey);
+            UpdateShortcutKeyBinding (_menuBar, oldKey);
         }
     }
 
@@ -304,8 +306,10 @@ public class MenuItem
         }
     }
 
-    internal void UpdateShortcutKeyBinding (Key oldKey)
+    internal void UpdateShortcutKeyBinding (MenuBar menuBar, Key oldKey)
     {
+        _menuBar ??= menuBar;
+
         if (_menuBar is null)
         {
             return;
@@ -334,7 +338,7 @@ public class MenuItem
     {
         if (Parent is { })
         {
-            MenuItem [] childrens = ((MenuBarItem)Parent).Children;
+            MenuItem []? childrens = ((MenuBarItem)Parent).Children;
             var i = 0;
 
             foreach (MenuItem c in childrens)

--- a/Terminal.Gui/Views/Menu/MenuItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuItem.cs
@@ -276,6 +276,31 @@ public class MenuItem
     /// <summary>Gets the text describing the keystroke combination defined by <see cref="ShortcutKey"/>.</summary>
     public string ShortcutTag => ShortcutKey != Key.Empty ? ShortcutKey!.ToString () : string.Empty;
 
+    internal void AddShortcutKeyBinding (MenuBar menuBar, Key key)
+    {
+        ArgumentNullException.ThrowIfNull (menuBar);
+
+        _menuBar = menuBar;
+
+        AddOrUpdateShortcutKeyBinding (key);
+    }
+
+    private void AddOrUpdateShortcutKeyBinding (Key key)
+    {
+        if (key != Key.Empty)
+        {
+            _menuBar.KeyBindings.Remove (key);
+        }
+
+        if (ShortcutKey != Key.Empty)
+        {
+            KeyBinding keyBinding = new ([Command.Select], KeyBindingScope.HotKey, this);
+            // Remove an existent ShortcutKey
+            _menuBar.KeyBindings.Remove (ShortcutKey!);
+            _menuBar.KeyBindings.Add (ShortcutKey!, keyBinding);
+        }
+    }
+
     private void UpdateHotKeyBinding (Key oldKey)
     {
         if (_menuBar is null or { IsInitialized: false })
@@ -306,25 +331,15 @@ public class MenuItem
         }
     }
 
-    internal void UpdateShortcutKeyBinding (Key oldKey)
+    private void UpdateShortcutKeyBinding (Key oldKey)
     {
-        if (_menuBar is null or { IsInitialized: false })
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (_menuBar is null)
         {
             return;
         }
 
-        if (oldKey != Key.Empty)
-        {
-            _menuBar.KeyBindings.Remove (oldKey);
-        }
-
-        if (ShortcutKey != Key.Empty)
-        {
-            KeyBinding keyBinding = new ([Command.Select], KeyBindingScope.HotKey, this);
-            // Remove an existent ShortcutKey
-            _menuBar.KeyBindings.Remove (ShortcutKey!);
-            _menuBar.KeyBindings.Add (ShortcutKey!, keyBinding);
-        }
+        AddOrUpdateShortcutKeyBinding (oldKey);
     }
 
     #endregion Keyboard Handling

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -405,7 +405,7 @@ public class TextField : View
 
         _currentCulture = Thread.CurrentThread.CurrentUICulture;
 
-        ContextMenu = new ContextMenu { Host = this, MenuItems = BuildContextMenuBarItem () };
+        ContextMenu = new ContextMenu { Host = this };
         ContextMenu.KeyChanged += ContextMenu_KeyChanged;
 
         KeyBindings.Add (ContextMenu.Key, KeyBindingScope.HotKey, Command.ShowContextMenu);
@@ -1853,14 +1853,12 @@ public class TextField : View
 
     private void ShowContextMenu ()
     {
-        if (_currentCulture != Thread.CurrentThread.CurrentUICulture)
+        if (!Equals (_currentCulture, Thread.CurrentThread.CurrentUICulture))
         {
             _currentCulture = Thread.CurrentThread.CurrentUICulture;
-
-            ContextMenu.MenuItems = BuildContextMenuBarItem ();
         }
 
-        ContextMenu.Show ();
+        ContextMenu.Show (BuildContextMenuBarItem ());
     }
 
     private void TextField_Added (object sender, SuperViewChangedEventArgs e)

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -2498,7 +2498,7 @@ public class TextView : View
 
         _currentCulture = Thread.CurrentThread.CurrentUICulture;
 
-        ContextMenu = new () { MenuItems = BuildContextMenuBarItem () };
+        ContextMenu = new ();
         ContextMenu.KeyChanged += ContextMenu_KeyChanged!;
 
         KeyBindings.Add ((KeyCode)ContextMenu.Key, KeyBindingScope.HotKey, Command.ShowContextMenu);
@@ -3494,7 +3494,7 @@ public class TextView : View
         }
         else if (ev.Flags == ContextMenu!.MouseFlags)
         {
-            ContextMenu.Position = new (ev.Position.X + 2, ev.Position.Y + 2);
+            ContextMenu.Position = ViewportToScreen ((Viewport with { X = ev.Position.X, Y = ev.Position.Y }).Location);
             ShowContextMenu ();
         }
 
@@ -4131,7 +4131,7 @@ public class TextView : View
 
     private void AppendClipboard (string text) { Clipboard.Contents += text; }
 
-    private MenuBarItem BuildContextMenuBarItem ()
+    private MenuBarItem? BuildContextMenuBarItem ()
     {
         return new (
                     new MenuItem []
@@ -6289,14 +6289,12 @@ public class TextView : View
 
     private void ShowContextMenu ()
     {
-        if (_currentCulture != Thread.CurrentThread.CurrentUICulture)
+        if (!Equals (_currentCulture, Thread.CurrentThread.CurrentUICulture))
         {
             _currentCulture = Thread.CurrentThread.CurrentUICulture;
-
-            ContextMenu!.MenuItems = BuildContextMenuBarItem ();
         }
 
-        ContextMenu!.Show ();
+        ContextMenu!.Show (BuildContextMenuBarItem ());
     }
 
     private void StartSelecting ()

--- a/Terminal.sln.DotSettings
+++ b/Terminal.sln.DotSettings
@@ -400,6 +400,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Justifier/@EntryIndexedValue">True</s:Boolean>

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -902,31 +902,32 @@ internal class CharMap : View
 
             _contextMenu = new ()
             {
-                Position = new (me.Position.X + 1, me.Position.Y + 1),
-                MenuItems = new (
-                                 new MenuItem []
-                                 {
-                                     new (
-                                          "_Copy Glyph",
-                                          "",
-                                          CopyGlyph,
-                                          null,
-                                          null,
-                                          (KeyCode)Key.C.WithCtrl
-                                         ),
-                                     new (
-                                          "Copy Code _Point",
-                                          "",
-                                          CopyCodePoint,
-                                          null,
-                                          null,
-                                          (KeyCode)Key.C.WithCtrl
-                                                      .WithShift
-                                         )
-                                 }
-                                )
+                Position = new (me.Position.X + 1, me.Position.Y + 1)
             };
-            _contextMenu.Show ();
+
+            MenuBarItem menuItems = new (
+                                         new MenuItem []
+                                         {
+                                             new (
+                                                  "_Copy Glyph",
+                                                  "",
+                                                  CopyGlyph,
+                                                  null,
+                                                  null,
+                                                  (KeyCode)Key.C.WithCtrl
+                                                 ),
+                                             new (
+                                                  "Copy Code _Point",
+                                                  "",
+                                                  CopyCodePoint,
+                                                  null,
+                                                  null,
+                                                  (KeyCode)Key.C.WithCtrl
+                                                              .WithShift
+                                                 )
+                                         }
+                                        );
+            _contextMenu.Show (menuItems);
         }
     }
 

--- a/UICatalog/Scenarios/ContextMenus.cs
+++ b/UICatalog/Scenarios/ContextMenus.cs
@@ -163,133 +163,133 @@ public class ContextMenus : Scenario
         _contextMenu = new()
         {
             Position = new (x, y),
-            MenuItems = new (
-                             new []
-                             {
-                                 new (
-                                      "_Configuration",
-                                      "Show configuration",
-                                      () => MessageBox.Query (
-                                                              50,
-                                                              5,
-                                                              "Info",
-                                                              "This would open settings dialog",
-                                                              "Ok"
-                                                             )
-                                     ),
-                                 new MenuBarItem (
-                                                  "More options",
-                                                  new MenuItem []
-                                                  {
-                                                      new (
-                                                           "_Setup",
-                                                           "Change settings",
-                                                           () => MessageBox
-                                                               .Query (
-                                                                       50,
-                                                                       5,
-                                                                       "Info",
-                                                                       "This would open setup dialog",
-                                                                       "Ok"
-                                                                      ),
-                                                           shortcutKey: KeyCode.T
-                                                                     | KeyCode
-                                                                         .CtrlMask
-                                                          ),
-                                                      new (
-                                                           "_Maintenance",
-                                                           "Maintenance mode",
-                                                           () => MessageBox
-                                                               .Query (
-                                                                       50,
-                                                                       5,
-                                                                       "Info",
-                                                                       "This would open maintenance dialog",
-                                                                       "Ok"
-                                                                      )
-                                                          )
-                                                  }
-                                                 ),
-                                 new MenuBarItem (
-                                                  "_Languages",
-                                                  GetSupportedCultures ()
-                                                 ),
-                                 _miForceMinimumPosToZero =
-                                     new (
-                                          "ForceMinimumPosToZero",
-                                          "",
-                                          () =>
-                                          {
-                                              _miForceMinimumPosToZero
-                                                      .Checked =
-                                                  _forceMinimumPosToZero =
-                                                      !_forceMinimumPosToZero;
-
-                                              _tfTopLeft.ContextMenu
-                                                        .ForceMinimumPosToZero =
-                                                  _forceMinimumPosToZero;
-
-                                              _tfTopRight.ContextMenu
-                                                         .ForceMinimumPosToZero =
-                                                  _forceMinimumPosToZero;
-
-                                              _tfMiddle.ContextMenu
-                                                       .ForceMinimumPosToZero =
-                                                  _forceMinimumPosToZero;
-
-                                              _tfBottomLeft.ContextMenu
-                                                           .ForceMinimumPosToZero =
-                                                  _forceMinimumPosToZero;
-
-                                              _tfBottomRight
-                                                      .ContextMenu
-                                                      .ForceMinimumPosToZero =
-                                                  _forceMinimumPosToZero;
-                                          }
-                                         )
-                                     {
-                                         CheckType =
-                                             MenuItemCheckStyle
-                                                 .Checked,
-                                         Checked =
-                                             _forceMinimumPosToZero
-                                     },
-                                 _miUseSubMenusSingleFrame =
-                                     new (
-                                          "Use_SubMenusSingleFrame",
-                                          "",
-                                          () => _contextMenu
-                                                        .UseSubMenusSingleFrame =
-                                                    (bool)
-                                                    (_miUseSubMenusSingleFrame
-                                                             .Checked =
-                                                         _useSubMenusSingleFrame =
-                                                             !_useSubMenusSingleFrame)
-                                         )
-                                     {
-                                         CheckType = MenuItemCheckStyle
-                                             .Checked,
-                                         Checked =
-                                             _useSubMenusSingleFrame
-                                     },
-                                 null,
-                                 new (
-                                      "_Quit",
-                                      "",
-                                      () => Application.RequestStop ()
-                                     )
-                             }
-                            ),
             ForceMinimumPosToZero = _forceMinimumPosToZero,
             UseSubMenusSingleFrame = _useSubMenusSingleFrame
         };
 
+        MenuBarItem menuItems = new (
+                                     new []
+                                     {
+                                         new (
+                                              "_Configuration",
+                                              "Show configuration",
+                                              () => MessageBox.Query (
+                                                                      50,
+                                                                      5,
+                                                                      "Info",
+                                                                      "This would open settings dialog",
+                                                                      "Ok"
+                                                                     )
+                                             ),
+                                         new MenuBarItem (
+                                                          "More options",
+                                                          new MenuItem []
+                                                          {
+                                                              new (
+                                                                   "_Setup",
+                                                                   "Change settings",
+                                                                   () => MessageBox
+                                                                       .Query (
+                                                                               50,
+                                                                               5,
+                                                                               "Info",
+                                                                               "This would open setup dialog",
+                                                                               "Ok"
+                                                                              ),
+                                                                   shortcutKey: KeyCode.T
+                                                                                | KeyCode
+                                                                                    .CtrlMask
+                                                                  ),
+                                                              new (
+                                                                   "_Maintenance",
+                                                                   "Maintenance mode",
+                                                                   () => MessageBox
+                                                                       .Query (
+                                                                               50,
+                                                                               5,
+                                                                               "Info",
+                                                                               "This would open maintenance dialog",
+                                                                               "Ok"
+                                                                              )
+                                                                  )
+                                                          }
+                                                         ),
+                                         new MenuBarItem (
+                                                          "_Languages",
+                                                          GetSupportedCultures ()
+                                                         ),
+                                         _miForceMinimumPosToZero =
+                                             new (
+                                                  "ForceMinimumPosToZero",
+                                                  "",
+                                                  () =>
+                                                  {
+                                                      _miForceMinimumPosToZero
+                                                              .Checked =
+                                                          _forceMinimumPosToZero =
+                                                              !_forceMinimumPosToZero;
+
+                                                      _tfTopLeft.ContextMenu
+                                                                .ForceMinimumPosToZero =
+                                                          _forceMinimumPosToZero;
+
+                                                      _tfTopRight.ContextMenu
+                                                                 .ForceMinimumPosToZero =
+                                                          _forceMinimumPosToZero;
+
+                                                      _tfMiddle.ContextMenu
+                                                               .ForceMinimumPosToZero =
+                                                          _forceMinimumPosToZero;
+
+                                                      _tfBottomLeft.ContextMenu
+                                                                   .ForceMinimumPosToZero =
+                                                          _forceMinimumPosToZero;
+
+                                                      _tfBottomRight
+                                                              .ContextMenu
+                                                              .ForceMinimumPosToZero =
+                                                          _forceMinimumPosToZero;
+                                                  }
+                                                 )
+                                             {
+                                                 CheckType =
+                                                     MenuItemCheckStyle
+                                                         .Checked,
+                                                 Checked =
+                                                     _forceMinimumPosToZero
+                                             },
+                                         _miUseSubMenusSingleFrame =
+                                             new (
+                                                  "Use_SubMenusSingleFrame",
+                                                  "",
+                                                  () => _contextMenu
+                                                                .UseSubMenusSingleFrame =
+                                                            (bool)
+                                                            (_miUseSubMenusSingleFrame
+                                                                     .Checked =
+                                                                 _useSubMenusSingleFrame =
+                                                                     !_useSubMenusSingleFrame)
+                                                 )
+                                             {
+                                                 CheckType = MenuItemCheckStyle
+                                                     .Checked,
+                                                 Checked =
+                                                     _useSubMenusSingleFrame
+                                             },
+                                         null,
+                                         new (
+                                              "_Quit",
+                                              "",
+                                              () => Application.RequestStop ()
+                                             )
+                                     }
+                                    );
         _tfTopLeft.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
         _tfTopRight.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
         _tfMiddle.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
         _tfBottomLeft.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
         _tfBottomRight.ContextMenu.ForceMinimumPosToZero = _forceMinimumPosToZero;
 
-        _contextMenu.Show ();
+        _contextMenu.Show (menuItems);
     }
 }

--- a/UICatalog/Scenarios/ContextMenus.cs
+++ b/UICatalog/Scenarios/ContextMenus.cs
@@ -98,8 +98,8 @@ public class ContextMenus : Scenario
             Menus =
             [
                 new (
-                     "File",
-                     new MenuItem [] { new ("Quit", "", () => Application.RequestStop (), null, null, Application.QuitKey) })
+                     "_File",
+                     new MenuItem [] { new ("_Quit", "", () => Application.RequestStop (), null, null, Application.QuitKey) })
             ]
         };
 
@@ -170,6 +170,10 @@ public class ContextMenus : Scenario
         MenuBarItem menuItems = new (
                                      new []
                                      {
+                                         new MenuBarItem (
+                                                          "_Languages",
+                                                          GetSupportedCultures ()
+                                                         ),
                                          new (
                                               "_Configuration",
                                               "Show configuration",
@@ -213,10 +217,6 @@ public class ContextMenus : Scenario
                                                                               )
                                                                   )
                                                           }
-                                                         ),
-                                         new MenuBarItem (
-                                                          "_Languages",
-                                                          GetSupportedCultures ()
                                                          ),
                                          _miForceMinimumPosToZero =
                                              new (

--- a/UICatalog/Scenarios/ContextMenus.cs
+++ b/UICatalog/Scenarios/ContextMenus.cs
@@ -182,7 +182,7 @@ public class ContextMenus : Scenario
                                                                      )
                                              ),
                                          new MenuBarItem (
-                                                          "More options",
+                                                          "M_ore options",
                                                           new MenuItem []
                                                           {
                                                               new (
@@ -220,7 +220,7 @@ public class ContextMenus : Scenario
                                                          ),
                                          _miForceMinimumPosToZero =
                                              new (
-                                                  "ForceMinimumPosToZero",
+                                                  "Fo_rceMinimumPosToZero",
                                                   "",
                                                   () =>
                                                   {

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -875,7 +875,7 @@ public class DynamicMenuBar : Scenario
                                   {
                                       MenuItem newMenu = CreateNewMenu (item, _currentMenuBarItem);
                                       var menuBarItem = _currentMenuBarItem as MenuBarItem;
-                                      menuBarItem.AddMenuBarItem (newMenu);
+                                      menuBarItem.AddMenuBarItem (MenuBar, newMenu);
 
 
                                       DataContext.Menus.Add (new () { Title = newMenu.Title, MenuItem = newMenu });
@@ -913,6 +913,11 @@ public class DynamicMenuBar : Scenario
                                         if (_lstMenus.Source.Count > 0 && _lstMenus.SelectedItem > _lstMenus.Source.Count - 1)
                                         {
                                             _lstMenus.SelectedItem = _lstMenus.Source.Count - 1;
+                                        }
+
+                                        if (_menuBar.Menus.Length == 0)
+                                        {
+                                            RemoveMenuBar ();
                                         }
 
                                         _lstMenus.SetNeedsDisplay ();
@@ -992,7 +997,7 @@ public class DynamicMenuBar : Scenario
                                          }
 
                                          var newMenu = CreateNewMenu (item) as MenuBarItem;
-                                         newMenu.AddMenuBarItem ();
+                                         newMenu.AddMenuBarItem (MenuBar);
 
                                          _currentMenuBarItem = newMenu;
                                          _currentMenuBarItem.CheckType = item.CheckStyle;
@@ -1012,7 +1017,7 @@ public class DynamicMenuBar : Scenario
 
             btnRemoveMenuBar.Accept += (s, e) =>
                                         {
-                                            if (_menuBar == null || _menuBar.Menus.Length == 0)
+                                            if (_menuBar == null)
                                             {
                                                 return;
                                             }
@@ -1033,24 +1038,29 @@ public class DynamicMenuBar : Scenario
                                                                           : null;
                                             }
 
-                                            if (MenuBar != null && _currentMenuBarItem == null && _menuBar.Menus.Length == 0)
-                                            {
-                                                Remove (_menuBar);
-                                                _menuBar.Dispose ();
-                                                _menuBar = null;
-                                                DataContext.Menus = new ();
-                                                _currentMenuBarItem = null;
-                                                _currentSelectedMenuBar = -1;
-                                                lblMenuBar.Text = string.Empty;
-                                            }
-                                            else
-                                            {
-                                                lblMenuBar.Text = _menuBar.Menus [_currentSelectedMenuBar].Title;
-                                            }
+                                            RemoveMenuBar ();
 
                                             SetListViewSource (_currentMenuBarItem, true);
                                             SetFrameDetails ();
                                         };
+
+            void RemoveMenuBar ()
+            {
+                if (MenuBar != null && _currentMenuBarItem == null && _menuBar.Menus.Length == 0)
+                {
+                    Remove (_menuBar);
+                    _menuBar.Dispose ();
+                    _menuBar = null;
+                    DataContext.Menus = new ();
+                    _currentMenuBarItem = null;
+                    _currentSelectedMenuBar = -1;
+                    lblMenuBar.Text = string.Empty;
+                }
+                else
+                {
+                    lblMenuBar.Text = _menuBar.Menus [_currentSelectedMenuBar].Title;
+                }
+            }
 
             SetFrameDetails ();
 

--- a/UICatalog/Scenarios/Notepad.cs
+++ b/UICatalog/Scenarios/Notepad.cs
@@ -362,9 +362,9 @@ public class Notepad : Scenario
 
         var screen = ((View)sender).ViewportToScreen (e.MouseEvent.Position);
 
-        var contextMenu = new ContextMenu { Position = screen, MenuItems = items };
+        var contextMenu = new ContextMenu { Position = screen };
 
-        contextMenu.Show ();
+        contextMenu.Show (items);
         e.MouseEvent.Handled = true;
     }
 

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -1266,28 +1266,28 @@ public class TableEditor : Scenario
 
         var contextMenu = new ContextMenu
         {
-            Position = new (e.MouseEvent.Position.X + 1, e.MouseEvent.Position.Y + 1),
-            MenuItems = new (
-                             [
-                                 new (
-                                      $"Hide {TrimArrows (colName)}",
-                                      "",
-                                      () => HideColumn (clickedCol)
-                                     ),
-                                 new (
-                                      $"Sort {StripArrows (sort)}",
-                                      "",
-                                      () => SortColumn (
-                                                        clickedCol,
-                                                        sort,
-                                                        isAsc
-                                                       )
-                                     )
-                             ]
-                            )
+            Position = new (e.MouseEvent.Position.X + 1, e.MouseEvent.Position.Y + 1)
         };
 
-        contextMenu.Show ();
+        MenuBarItem menuItems = new (
+                                     [
+                                         new (
+                                              $"Hide {TrimArrows (colName)}",
+                                              "",
+                                              () => HideColumn (clickedCol)
+                                             ),
+                                         new (
+                                              $"Sort {StripArrows (sort)}",
+                                              "",
+                                              () => SortColumn (
+                                                                clickedCol,
+                                                                sort,
+                                                                isAsc
+                                                               )
+                                             )
+                                     ]
+                                    );
+        contextMenu.Show (menuItems);
     }
 
     private void SortColumn (int clickedCol)

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -415,21 +415,20 @@ public class TreeViewFileSystem : Scenario
 
     private void ShowContextMenu (Point screenPoint, IFileSystemInfo forObject)
     {
-        var menu = new ContextMenu ();
-        menu.Position = screenPoint;
+        var menu = new ContextMenu { Position = screenPoint };
 
-        menu.MenuItems = new MenuBarItem (
-                                          new [] { new MenuItem ("Properties", null, () => ShowPropertiesOf (forObject)) }
-                                         );
+        var menuItems = new MenuBarItem (
+                                         new [] { new MenuItem ("Properties", null, () => ShowPropertiesOf (forObject)) }
+                                        );
 
-        Application.Invoke (menu.Show);
+        Application.Invoke (() => menu.Show (menuItems));
     }
 
     private void ShowLines ()
     {
         _miShowLines.Checked = !_miShowLines.Checked;
 
-        _treeViewFiles.Style.ShowBranchLines = (bool)_miShowLines.Checked;
+        _treeViewFiles.Style.ShowBranchLines = (bool)_miShowLines.Checked!;
         _treeViewFiles.SetNeedsDisplay ();
     }
 

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -875,7 +875,7 @@ public class UICatalogApp
                 };
             }
 
-            Enum GetDiagnosticsEnumValue (string title)
+            Enum GetDiagnosticsEnumValue (string? title)
             {
                 return title switch
                 {

--- a/UnitTests/Views/ContextMenuTests.cs
+++ b/UnitTests/Views/ContextMenuTests.cs
@@ -10,42 +10,53 @@ public class ContextMenuTests (ITestOutputHelper output)
     public void ContextMenu_Constructors ()
     {
         var cm = new ContextMenu ();
+        var top = new Toplevel ();
+        Application.Begin (top);
+
         Assert.Equal (Point.Empty, cm.Position);
-        Assert.Empty (cm.MenuItems.Children);
+        Assert.Null (cm.MenuItems);
         Assert.Null (cm.Host);
         cm.Position = new Point (20, 10);
 
-        cm.MenuItems = new MenuBarItem (
+        var menuItems = new MenuBarItem (
                                         [
                                             new MenuItem ("First", "", null)
                                         ]
                                        );
+        cm.Show (menuItems);
         Assert.Equal (new Point (20, 10), cm.Position);
-        Assert.Single (cm.MenuItems.Children);
+        Assert.Single (cm.MenuItems!.Children);
 
         cm = new ContextMenu
         {
-            Position = new Point (5, 10),
-            MenuItems = new MenuBarItem (
-                                         new [] { new MenuItem ("One", "", null), new MenuItem ("Two", "", null) }
-                                        )
+            Position = new Point (5, 10)
         };
+
+        menuItems = new MenuBarItem (
+                                     new [] { new MenuItem ("One", "", null), new MenuItem ("Two", "", null) }
+                                    );
+        cm.Show (menuItems);
         Assert.Equal (new Point (5, 10), cm.Position);
-        Assert.Equal (2, cm.MenuItems.Children.Length);
+        Assert.Equal (2, cm.MenuItems!.Children.Length);
         Assert.Null (cm.Host);
 
+        var view = new View { X = 5, Y = 10 };
+        top.Add (view);
         cm = new ContextMenu
         {
-            Host = new View { X = 5, Y = 10 },
-            Position = new Point (5, 10),
-            MenuItems = new MenuBarItem (
-                                         new [] { new MenuItem ("One", "", null), new MenuItem ("Two", "", null) }
-                                        )
+            Host = view,
+            Position = new Point (5, 10)
         };
 
+        menuItems = new MenuBarItem (
+                                     new [] { new MenuItem ("One", "", null), new MenuItem ("Two", "", null) }
+                                    );
+        cm.Show (menuItems);
         Assert.Equal (new Point (5, 10), cm.Position);
         Assert.Equal (2, cm.MenuItems.Children.Length);
         Assert.NotNull (cm.Host);
+
+        top.Dispose ();
     }
 
     [Fact]
@@ -54,15 +65,15 @@ public class ContextMenuTests (ITestOutputHelper output)
     {
         var cm = new ContextMenu
         {
-            Position = new Point (10, 5),
-            MenuItems = new MenuBarItem (
+            Position = new Point (10, 5)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         var menu = new MenuBar
         {
             Menus =
@@ -78,7 +89,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         Assert.Null (Application.MouseGrabView);
 
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.True (ContextMenu.IsShow);
         Assert.Equal (cm.MenuBar, Application.MouseGrabView);
         Assert.False (menu.IsMenuOpen);
@@ -87,7 +98,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.Equal (menu, Application.MouseGrabView);
         Assert.True (menu.IsMenuOpen);
 
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.True (ContextMenu.IsShow);
         Assert.Equal (cm.MenuBar, Application.MouseGrabView);
         Assert.False (menu.IsMenuOpen);
@@ -98,7 +109,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (menu.IsMenuOpen);
 #endif
 
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.True (ContextMenu.IsShow);
         Assert.Equal (cm.MenuBar, Application.MouseGrabView);
         Assert.False (menu.IsMenuOpen);
@@ -305,21 +316,21 @@ public class ContextMenuTests (ITestOutputHelper output)
     {
         var cm = new ContextMenu
         {
-            Position = new Point (-1, -2),
-            MenuItems = new MenuBarItem (
+            Position = new Point (-1, -2)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         Assert.Equal (new Point (-1, -2), cm.Position);
-        
+
         Toplevel top = new ();
         Application.Begin (top);
 
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.Equal (new Point (-1, -2), cm.Position);
         Application.Refresh ();
 
@@ -334,7 +345,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.Equal (new Rectangle (0, 1, 8, 4), pos);
 
         cm.ForceMinimumPosToZero = false;
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.Equal (new Point (-1, -2), cm.Position);
         Application.Refresh ();
 
@@ -355,22 +366,22 @@ public class ContextMenuTests (ITestOutputHelper output)
     {
         var cm = new ContextMenu
         {
-            Position = new Point (80, 25),
-            MenuItems = new MenuBarItem (
+            Position = new Point (80, 25)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         Toplevel top = new ();
         Application.Begin (top);
         top.Running = true;
 
         Assert.False (ContextMenu.IsShow);
 
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.True (ContextMenu.IsShow);
 
         top.RequestStop ();
@@ -388,7 +399,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Application.Begin (top);
 
         Assert.True (Application.OnKeyDown (ContextMenu.DefaultKey));
-        Assert.True (tf.ContextMenu.MenuBar.IsMenuOpen);
+        Assert.True (tf.ContextMenu.MenuBar!.IsMenuOpen);
         Assert.True (Application.OnKeyDown (ContextMenu.DefaultKey));
         // The last context menu bar opened is always preserved
         Assert.NotNull (tf.ContextMenu.MenuBar);
@@ -415,18 +426,18 @@ public class ContextMenuTests (ITestOutputHelper output)
     {
         var cm = new ContextMenu
         {
-            Position = new Point (10, 5),
-            MenuItems = new MenuBarItem (
+            Position = new Point (10, 5)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         Toplevel top = new ();
         Application.Begin (top);
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
 
         var expected = @"
@@ -438,15 +449,15 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         TestHelpers.AssertDriverContentsAre (expected, output);
 
-        cm.MenuItems = new MenuBarItem (
-                                        [
-                                            new MenuItem ("First", "", null),
-                                            new MenuItem ("Second", "", null),
-                                            new MenuItem ("Third", "", null)
-                                        ]
-                                       );
+        menuItems = new MenuBarItem (
+                                     [
+                                         new MenuItem ("First", "", null),
+                                         new MenuItem ("Second", "", null),
+                                         new MenuItem ("Third", "", null)
+                                     ]
+                                    );
 
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
 
         expected = @"
@@ -467,8 +478,10 @@ public class ContextMenuTests (ITestOutputHelper output)
     {
         var cm = new ContextMenu
         {
-            Position = new Point (-1, -2),
-            MenuItems = new MenuBarItem (
+            Position = new Point (-1, -2)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null),
@@ -488,15 +501,13 @@ public class ContextMenuTests (ITestOutputHelper output)
                                              new MenuItem ("Five", "", null),
                                              new MenuItem ("Six", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         Assert.Equal (new Point (-1, -2), cm.Position);
 
         Toplevel top = new ();
         Application.Begin (top);
 
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
 
         Assert.Equal (new Point (-1, -2), cm.Position);
@@ -545,7 +556,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         ((FakeDriver)Application.Driver!).SetBufferSize (40, 20);
         cm.Position = new Point (41, -2);
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
         Assert.Equal (new Point (41, -2), cm.Position);
 
@@ -592,7 +603,7 @@ public class ContextMenuTests (ITestOutputHelper output)
                                                      );
 
         cm.Position = new Point (41, 9);
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
         Assert.Equal (new Point (41, 9), cm.Position);
 
@@ -636,7 +647,7 @@ public class ContextMenuTests (ITestOutputHelper output)
                                                      );
 
         cm.Position = new Point (41, 22);
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
         Assert.Equal (new Point (41, 22), cm.Position);
 
@@ -680,7 +691,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         ((FakeDriver)Application.Driver!).SetBufferSize (18, 8);
         cm.Position = new Point (19, 10);
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
         Assert.Equal (new Point (19, 10), cm.Position);
 
@@ -773,18 +784,18 @@ public class ContextMenuTests (ITestOutputHelper output)
     {
         var cm = new ContextMenu
         {
-            Position = new Point (10, 5),
-            MenuItems = new MenuBarItem (
+            Position = new Point (10, 5)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         Toplevel top = new ();
         Application.Begin (top);
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
 
         var expected = @"
@@ -798,7 +809,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         cm.Position = new Point (5, 10);
 
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Refresh ();
 
         expected = @"
@@ -816,7 +827,14 @@ public class ContextMenuTests (ITestOutputHelper output)
     [AutoInitShutdown]
     public void RequestStop_While_ContextMenu_Is_Open_Does_Not_Throws ()
     {
-        ContextMenu cm = Create_ContextMenu_With_Two_MenuItem (10, 5);
+        ContextMenu cm = new ContextMenu
+        {
+            Position = new Point (10, 5)
+        };
+
+        var menuItems = new MenuBarItem (
+                                         new MenuItem [] { new ("One", "", null), new ("Two", "", null) }
+                                        );
         Toplevel top = new ();
         var isMenuAllClosed = false;
         MenuBarItem mi = null;
@@ -828,7 +846,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
                                      if (iterations == 0)
                                      {
-                                         cm.Show ();
+                                         cm.Show (menuItems);
                                          Assert.True (ContextMenu.IsShow);
                                          mi = cm.MenuBar.Menus [0];
 
@@ -853,7 +871,7 @@ public class ContextMenuTests (ITestOutputHelper output)
                                      else if (iterations == 3)
                                      {
                                          isMenuAllClosed = false;
-                                         cm.Show ();
+                                         cm.Show (menuItems);
                                          Assert.True (ContextMenu.IsShow);
                                          cm.MenuBar.MenuAllClosed += (_, _) => isMenuAllClosed = true;
                                      }
@@ -896,20 +914,20 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         var cm = new ContextMenu
         {
-            Position = Point.Empty,
-            MenuItems = new MenuBarItem (
+            Position = Point.Empty
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         Assert.Equal (Point.Empty, cm.Position);
 
         Toplevel top = new ();
         Application.Begin (top);
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.Equal (Point.Empty, cm.Position);
         Application.Refresh ();
 
@@ -934,20 +952,20 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         var cm = new ContextMenu
         {
-            Position = Point.Empty,
-            MenuItems = new MenuBarItem (
+            Position = Point.Empty
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         Assert.Equal (Point.Empty, cm.Position);
 
         Toplevel top = new ();
         Application.Begin (top);
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.Equal (Point.Empty, cm.Position);
         Application.Refresh ();
 
@@ -981,22 +999,22 @@ public class ContextMenuTests (ITestOutputHelper output)
         var cm = new ContextMenu
         {
             Host = view,
-            Position = new Point (10, 5),
-            MenuItems = new MenuBarItem (
+            Position = new Point (10, 5)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         var top = new Toplevel ();
         top.Add (view);
         Application.Begin (top);
 
         Assert.Equal (new Point (10, 5), cm.Position);
 
-        cm.Show ();
+        cm.Show (menuItems);
         top.Draw ();
         Assert.Equal (new Point (10, 5), cm.Position);
 
@@ -1017,7 +1035,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         cm.Host.Y = 10;
         cm.Host.Height = 3;
 
-        cm.Show ();
+        cm.Show (menuItems);
         Application.Top.Draw ();
         Assert.Equal (new Point (5, 12), cm.Position);
 
@@ -1045,20 +1063,20 @@ public class ContextMenuTests (ITestOutputHelper output)
     {
         var cm = new ContextMenu
         {
-            Position = new Point (80, 25),
-            MenuItems = new MenuBarItem (
+            Position = new Point (80, 25)
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         Assert.Equal (new Point (80, 25), cm.Position);
 
         Toplevel top = new ();
         Application.Begin (top);
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.Equal (new Point (80, 25), cm.Position);
         Application.Refresh ();
 
@@ -1092,15 +1110,15 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         var cm = new ContextMenu
         {
-            Host = view,
-            MenuItems = new MenuBarItem (
+            Host = view
+        };
+
+        var menuItems = new MenuBarItem (
                                          [
                                              new MenuItem ("One", "", null),
                                              new MenuItem ("Two", "", null)
                                          ]
-                                        )
-        };
-
+                                        );
         var top = new Toplevel ();
         top.Add (view);
         Application.Begin (top);
@@ -1108,7 +1126,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.Equal (new Rectangle (70, 24, 10, 1), view.Frame);
         Assert.Equal (Point.Empty, cm.Position);
 
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.Equal (new Point (70, 24), cm.Position);
         top.Draw ();
 
@@ -1132,11 +1150,18 @@ public class ContextMenuTests (ITestOutputHelper output)
     [AutoInitShutdown]
     public void Show_Hide_IsShow ()
     {
-        ContextMenu cm = Create_ContextMenu_With_Two_MenuItem (10, 5);
+        ContextMenu cm = new ContextMenu
+        {
+            Position = new Point (10, 5)
+        };
+
+        var menuItems = new MenuBarItem (
+                                         new MenuItem [] { new ("One", "", null), new ("Two", "", null) }
+                                        );
 
         Toplevel top = new ();
         Application.Begin (top);
-        cm.Show ();
+        cm.Show (menuItems);
         Assert.True (ContextMenu.IsShow);
         Application.Refresh ();
 
@@ -1167,7 +1192,10 @@ public class ContextMenuTests (ITestOutputHelper output)
         var cm = new ContextMenu
         {
             Position = new Point (5, 10),
-            MenuItems = new MenuBarItem (
+            UseSubMenusSingleFrame = true
+        };
+
+        var menuItems = new MenuBarItem (
                                          "Numbers",
                                          [
                                              new MenuItem ("One", "", null),
@@ -1184,19 +1212,11 @@ public class ContextMenuTests (ITestOutputHelper output)
                                                              ),
                                              new MenuItem ("Three", "", null)
                                          ]
-                                        ),
-            UseSubMenusSingleFrame = true
-        };
+                                        );
         Toplevel top = new ();
         RunState rs = Application.Begin (top);
-        top.SetFocus ();
-        Assert.NotNull (Application.Current);
-
-        cm.Show ();
-        Assert.True(ContextMenu.IsShow);
-        Assert.True (Application.Top.Subviews [0].HasFocus);
-        Assert.Equal(Application.Top.Subviews [0], Application.Navigation.GetFocused());
-        Assert.Equal (new Rectangle (5, 11, 10, 5), Application.Top.Subviews [0].Frame);
+        cm.Show (menuItems);
+        Assert.Equal (new Rectangle (5, 11, 10, 5), Application.Top!.Subviews [0].Frame);
         Application.Refresh ();
 
         TestHelpers.AssertDriverContentsWithFrameAre (
@@ -1254,8 +1274,10 @@ public class ContextMenuTests (ITestOutputHelper output)
     {
         var cm = new ContextMenu
         {
-            Position = new Point (5, 10),
-            MenuItems = new MenuBarItem (
+            Position = new Point (5, 10)
+        };
+
+        var menuItems = new MenuBarItem (
                                          "Numbers",
                                          [
                                              new MenuItem ("One", "", null),
@@ -1270,7 +1292,8 @@ public class ContextMenuTests (ITestOutputHelper output)
                                                                   new MenuItem ("Two-Menu 2", "", null)
                                                               ]
                                                              ),
-                                             new MenuBarItem ("Three",
+                                             new MenuBarItem (
+                                                              "Three",
                                                               [
                                                                   new MenuItem (
                                                                                 "Three-Menu 1",
@@ -1281,11 +1304,10 @@ public class ContextMenuTests (ITestOutputHelper output)
                                                               ]
                                                              )
                                          ]
-                                        )
-        };
+                                        );
         Toplevel top = new ();
         RunState rs = Application.Begin (top);
-        cm.Show ();
+        cm.Show (menuItems);
 
         Assert.Equal (new Rectangle (5, 11, 10, 5), Application.Top.Subviews [0].Frame);
         Application.Refresh ();
@@ -1356,17 +1378,6 @@ public class ContextMenuTests (ITestOutputHelper output)
         top.Dispose ();
     }
 
-    private ContextMenu Create_ContextMenu_With_Two_MenuItem (int x, int y)
-    {
-        return new ContextMenu
-        {
-            Position = new Point (x, y),
-            MenuItems = new MenuBarItem (
-                                         new MenuItem [] { new ("One", "", null), new ("Two", "", null) }
-                                        )
-        };
-    }
-
     [Fact]
     [AutoInitShutdown]
     public void Handling_TextField_With_Opened_ContextMenu_By_Mouse_HasFocus ()
@@ -1416,5 +1427,240 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         Application.End (rs);
         win.Dispose ();
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void Empty_Menus_Items_Children_Does_Not_Open_The_Menu ()
+    {
+        var cm = new ContextMenu ();
+        Assert.Null (cm.MenuItems);
+
+        var top = new Toplevel ();
+        Application.Begin (top);
+
+        cm.Show (cm.MenuItems);
+        Assert.Null (cm.MenuBar);
+
+        top.Dispose ();
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void KeyBinding_Removed_On_Close_ContextMenu ()
+    {
+        var newFile = false;
+        var renameFile = false;
+        var deleteFile = false;
+
+        var cm = new ContextMenu ();
+
+        var menuItems = new MenuBarItem (
+                                         [
+                                             new MenuItem ("New File", string.Empty, New, null, null, Key.N.WithCtrl),
+                                             new MenuItem ("Rename File", string.Empty, Rename, null, null, Key.R.WithCtrl),
+                                             new MenuItem ("Delete File", string.Empty, Delete, null, null, Key.D.WithCtrl)
+                                         ]
+                                        );
+        var top = new Toplevel ();
+        Application.Begin (top);
+
+        Assert.Null (cm.MenuBar);
+        Assert.False (Application.OnKeyDown (Key.N.WithCtrl));
+        Assert.False (Application.OnKeyDown (Key.R.WithCtrl));
+        Assert.False (Application.OnKeyDown (Key.D.WithCtrl));
+        Assert.False (newFile);
+        Assert.False (renameFile);
+        Assert.False (deleteFile);
+
+        cm.Show (menuItems);
+        Assert.True (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.True (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithCtrl));
+        Assert.True (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.D.WithCtrl));
+
+        Assert.True (Application.OnKeyDown (Key.N.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newFile);
+        Assert.False (cm.MenuBar!.IsMenuOpen);
+        cm.Show (menuItems);
+        Assert.True (Application.OnKeyDown (Key.R.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (renameFile);
+        Assert.False (cm.MenuBar.IsMenuOpen);
+        cm.Show (menuItems);
+        Assert.True (Application.OnKeyDown (Key.D.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (deleteFile);
+        Assert.False (cm.MenuBar.IsMenuOpen);
+
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithCtrl));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.D.WithCtrl));
+
+        newFile = false;
+        renameFile = false;
+        deleteFile = false;
+        Assert.False (Application.OnKeyDown (Key.N.WithCtrl));
+        Assert.False (Application.OnKeyDown (Key.R.WithCtrl));
+        Assert.False (Application.OnKeyDown (Key.D.WithCtrl));
+        Assert.False (newFile);
+        Assert.False (renameFile);
+        Assert.False (deleteFile);
+
+        top.Dispose ();
+
+        void New () { newFile = true; }
+
+        void Rename () { renameFile = true; }
+
+        void Delete () { deleteFile = true; }
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void KeyBindings_With_ContextMenu_And_MenuBar ()
+    {
+        var newFile = false;
+        var renameFile = false;
+
+        var menuBar = new MenuBar
+        {
+            Menus =
+            [
+                new (
+                     "File",
+                     new MenuItem []
+                     {
+                         new ("New", string.Empty, New, null, null, Key.N.WithCtrl)
+                     })
+            ]
+        };
+        var cm = new ContextMenu ();
+
+        var menuItems = new MenuBarItem (
+                                         [
+                                             new MenuItem ("Rename File", string.Empty, Rename, null, null, Key.R.WithCtrl),
+                                         ]
+                                        );
+        var top = new Toplevel ();
+        top.Add (menuBar);
+        Application.Begin (top);
+
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithCtrl));
+        Assert.Null (cm.MenuBar);
+
+        Assert.True (Application.OnKeyDown (Key.N.WithCtrl));
+        Assert.False (Application.OnKeyDown (Key.R.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newFile);
+        Assert.False (renameFile);
+
+        newFile = false;
+
+        cm.Show (menuItems);
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithCtrl));
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.True (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithCtrl));
+
+        Assert.True (cm.MenuBar.IsMenuOpen);
+        Assert.True (Application.OnKeyDown (Key.N.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newFile);
+        Assert.False (cm.MenuBar!.IsMenuOpen);
+        cm.Show (menuItems);
+        Assert.True (Application.OnKeyDown (Key.R.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (renameFile);
+        Assert.False (cm.MenuBar.IsMenuOpen);
+
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithCtrl));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithCtrl));
+
+        newFile = false;
+        renameFile = false;
+        Assert.True (Application.OnKeyDown (Key.N.WithCtrl));
+        Assert.False (Application.OnKeyDown (Key.R.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newFile);
+        Assert.False (renameFile);
+
+        top.Dispose ();
+
+        void New () { newFile = true; }
+
+        void Rename () { renameFile = true; }
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void KeyBindings_With_Same_Shortcut_ContextMenu_And_MenuBar ()
+    {
+        var newMenuBar = false;
+        var newContextMenu = false;
+
+        var menuBar = new MenuBar
+        {
+            Menus =
+            [
+                new (
+                     "File",
+                     new MenuItem []
+                     {
+                         new ("New", string.Empty, NewMenuBar, null, null, Key.N.WithCtrl)
+                     })
+            ]
+        };
+        var cm = new ContextMenu ();
+
+        var menuItems = new MenuBarItem (
+                                         [
+                                             new MenuItem ("New File", string.Empty, NewContextMenu, null, null, Key.N.WithCtrl),
+                                         ]
+                                        );
+        var top = new Toplevel ();
+        top.Add (menuBar);
+        Application.Begin (top);
+
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.Null (cm.MenuBar);
+
+        Assert.True (Application.OnKeyDown (Key.N.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newMenuBar);
+        Assert.False (newContextMenu);
+
+        newMenuBar = false;
+
+        cm.Show (menuItems);
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.True (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+
+        Assert.True (cm.MenuBar.IsMenuOpen);
+        Assert.True (Application.OnKeyDown (Key.N.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.False (newMenuBar);
+        // The most focused shortcut is executed
+        Assert.True (newContextMenu);
+        Assert.False (cm.MenuBar!.IsMenuOpen);
+
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithCtrl));
+
+        newMenuBar = false;
+        newContextMenu = false;
+        Assert.True (Application.OnKeyDown (Key.N.WithCtrl));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newMenuBar);
+        Assert.False (newContextMenu);
+
+        top.Dispose ();
+
+        void NewMenuBar () { newMenuBar = true; }
+
+        void NewContextMenu () { newContextMenu = true; }
     }
 }

--- a/UnitTests/Views/ContextMenuTests.cs
+++ b/UnitTests/Views/ContextMenuTests.cs
@@ -19,10 +19,10 @@ public class ContextMenuTests (ITestOutputHelper output)
         cm.Position = new Point (20, 10);
 
         var menuItems = new MenuBarItem (
-                                        [
-                                            new MenuItem ("First", "", null)
-                                        ]
-                                       );
+                                         [
+                                             new MenuItem ("First", "", null)
+                                         ]
+                                        );
         cm.Show (menuItems);
         Assert.Equal (new Point (20, 10), cm.Position);
         Assert.Single (cm.MenuItems!.Children);
@@ -42,6 +42,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         var view = new View { X = 5, Y = 10 };
         top.Add (view);
+
         cm = new ContextMenu
         {
             Host = view,
@@ -74,6 +75,7 @@ public class ContextMenuTests (ITestOutputHelper output)
                                              new MenuItem ("Two", "", null)
                                          ]
                                         );
+
         var menu = new MenuBar
         {
             Menus =
@@ -401,6 +403,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (Application.OnKeyDown (ContextMenu.DefaultKey));
         Assert.True (tf.ContextMenu.MenuBar!.IsMenuOpen);
         Assert.True (Application.OnKeyDown (ContextMenu.DefaultKey));
+
         // The last context menu bar opened is always preserved
         Assert.NotNull (tf.ContextMenu.MenuBar);
         top.Dispose ();
@@ -529,8 +532,8 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (
                      top.Subviews [0]
                         .NewMouseEvent (
-                                     new MouseEvent { Position = new (0, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
-                                    )
+                                        new MouseEvent { Position = new (0, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
+                                       )
                     );
         Application.Refresh ();
         Assert.Equal (new Point (-1, -2), cm.Position);
@@ -577,8 +580,8 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (
                      top.Subviews [0]
                         .NewMouseEvent (
-                                     new MouseEvent { Position = new (30, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
-                                    )
+                                        new MouseEvent { Position = new (30, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
+                                       )
                     );
         Application.Refresh ();
         Assert.Equal (new Point (41, -2), cm.Position);
@@ -624,8 +627,8 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (
                      top.Subviews [0]
                         .NewMouseEvent (
-                                     new MouseEvent { Position = new (30, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
-                                    )
+                                        new MouseEvent { Position = new (30, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
+                                       )
                     );
         Application.Refresh ();
         Assert.Equal (new Point (41, 9), cm.Position);
@@ -668,8 +671,8 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (
                      top.Subviews [0]
                         .NewMouseEvent (
-                                     new MouseEvent { Position = new (30, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
-                                    )
+                                        new MouseEvent { Position = new (30, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
+                                       )
                     );
         Application.Refresh ();
         Assert.Equal (new Point (41, 22), cm.Position);
@@ -712,8 +715,8 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (
                      top.Subviews [0]
                         .NewMouseEvent (
-                                     new MouseEvent { Position = new (30, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
-                                    )
+                                        new MouseEvent { Position = new (30, 3), Flags = MouseFlags.ReportMousePosition, View = top.Subviews [0] }
+                                       )
                     );
         Application.Refresh ();
         Assert.Equal (new Point (19, 10), cm.Position);
@@ -1408,6 +1411,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (tf1.HasFocus);
         Assert.False (tf2.HasFocus);
         Assert.Equal (4, win.Subviews.Count);
+
         // The last context menu bar opened is always preserved
         Assert.NotNull (tf2.ContextMenu.MenuBar);
         Assert.Equal (win.Focused, tf1);
@@ -1419,6 +1423,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.False (tf1.HasFocus);
         Assert.True (tf2.HasFocus);
         Assert.Equal (4, win.Subviews.Count);
+
         // The last context menu bar opened is always preserved
         Assert.NotNull (tf2.ContextMenu.MenuBar);
         Assert.Equal (win.Focused, tf2);
@@ -1447,7 +1452,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
     [Fact]
     [AutoInitShutdown]
-    public void KeyBinding_Removed_On_Close_ContextMenu ()
+    public void KeyBindings_Removed_On_Close_ContextMenu ()
     {
         var newFile = false;
         var renameFile = false;
@@ -1539,7 +1544,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         var menuItems = new MenuBarItem (
                                          [
-                                             new MenuItem ("Rename File", string.Empty, Rename, null, null, Key.R.WithCtrl),
+                                             new ("Rename File", string.Empty, Rename, null, null, Key.R.WithCtrl),
                                          ]
                                         );
         var top = new Toplevel ();
@@ -1618,7 +1623,7 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         var menuItems = new MenuBarItem (
                                          [
-                                             new MenuItem ("New File", string.Empty, NewContextMenu, null, null, Key.N.WithCtrl),
+                                             new ("New File", string.Empty, NewContextMenu, null, null, Key.N.WithCtrl),
                                          ]
                                         );
         var top = new Toplevel ();
@@ -1643,6 +1648,7 @@ public class ContextMenuTests (ITestOutputHelper output)
         Assert.True (Application.OnKeyDown (Key.N.WithCtrl));
         Application.MainLoop!.RunIteration ();
         Assert.False (newMenuBar);
+
         // The most focused shortcut is executed
         Assert.True (newContextMenu);
         Assert.False (cm.MenuBar!.IsMenuOpen);
@@ -1662,5 +1668,270 @@ public class ContextMenuTests (ITestOutputHelper output)
         void NewMenuBar () { newMenuBar = true; }
 
         void NewContextMenu () { newContextMenu = true; }
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void HotKeys_Removed_On_Close_ContextMenu ()
+    {
+        var newFile = false;
+        var renameFile = false;
+        var deleteFile = false;
+
+        var cm = new ContextMenu ();
+
+        var menuItems = new MenuBarItem (
+                                         [
+                                             new ("_New File", string.Empty, New, null, null),
+                                             new ("_Rename File", string.Empty, Rename, null, null),
+                                             new ("_Delete File", string.Empty, Delete, null, null)
+                                         ]
+                                        );
+        var top = new Toplevel ();
+        Application.Begin (top);
+
+        Assert.Null (cm.MenuBar);
+        Assert.False (Application.OnKeyDown (Key.N.WithAlt));
+        Assert.False (Application.OnKeyDown (Key.R.WithAlt));
+        Assert.False (Application.OnKeyDown (Key.D.WithAlt));
+        Assert.False (newFile);
+        Assert.False (renameFile);
+        Assert.False (deleteFile);
+
+        cm.Show (menuItems);
+        Assert.True (cm.MenuBar!.IsMenuOpen);
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.N.WithAlt));
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.N.NoShift));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.D.WithAlt));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.D.NoShift));
+        Assert.Single (Application.Current!.Subviews);
+        View [] menus = Application.Current!.Subviews.Where (v => v is Menu m && m.Host == cm.MenuBar).ToArray ();
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.N.WithAlt));
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.N.NoShift));
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.D.WithAlt));
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.D.NoShift));
+
+        Assert.True (Application.OnKeyDown (Key.N.WithAlt));
+        Assert.False (cm.MenuBar!.IsMenuOpen);
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newFile);
+        cm.Show (menuItems);
+        Assert.True (Application.OnKeyDown (Key.R.WithAlt));
+        Assert.False (cm.MenuBar.IsMenuOpen);
+        Application.MainLoop!.RunIteration ();
+        Assert.True (renameFile);
+        cm.Show (menuItems);
+        Assert.True (Application.OnKeyDown (Key.D.WithAlt));
+        Assert.False (cm.MenuBar.IsMenuOpen);
+        Application.MainLoop!.RunIteration ();
+        Assert.True (deleteFile);
+
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithAlt));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.N.NoShift));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.D.WithAlt));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.D.NoShift));
+
+        newFile = false;
+        renameFile = false;
+        deleteFile = false;
+        Assert.False (Application.OnKeyDown (Key.N.WithAlt));
+        Assert.False (Application.OnKeyDown (Key.R.WithAlt));
+        Assert.False (Application.OnKeyDown (Key.D.WithAlt));
+        Assert.False (newFile);
+        Assert.False (renameFile);
+        Assert.False (deleteFile);
+
+        top.Dispose ();
+
+        void New () { newFile = true; }
+
+        void Rename () { renameFile = true; }
+
+        void Delete () { deleteFile = true; }
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void HotKeys_With_ContextMenu_And_MenuBar ()
+    {
+        var newFile = false;
+        var renameFile = false;
+
+        var menuBar = new MenuBar
+        {
+            Menus =
+            [
+                new (
+                     "_File",
+                     new MenuItem []
+                     {
+                         new ("_New", string.Empty, New)
+                     })
+            ]
+        };
+        var cm = new ContextMenu ();
+
+        var menuItems = new MenuBarItem (
+                                         [
+                                             new MenuBarItem (
+                                                              "_Edit",
+                                                              new MenuItem []
+                                                              {
+                                                                  new ("_Rename File", string.Empty, Rename)
+                                                              }
+                                                             )
+                                         ]
+                                        );
+        var top = new Toplevel ();
+        top.Add (menuBar);
+        Application.Begin (top);
+
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.F.WithAlt));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithAlt));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        View [] menus = Application.Current!.Subviews.Where (v => v is Menu m && m.Host == menuBar).ToArray ();
+        Assert.Empty (menus);
+        Assert.Null (cm.MenuBar);
+
+        Assert.True (Application.OnKeyDown (Key.F.WithAlt));
+        Assert.True (menuBar.IsMenuOpen);
+        Assert.Equal (2, Application.Current!.Subviews.Count);
+        menus = Application.Current!.Subviews.Where (v => v is Menu m && m.Host == menuBar).ToArray ();
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.N.WithAlt));
+        Assert.True (Application.OnKeyDown (Key.N.WithAlt));
+        Assert.False (menuBar.IsMenuOpen);
+        Assert.False (Application.OnKeyDown (Key.R.WithAlt));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newFile);
+        Assert.False (renameFile);
+
+        newFile = false;
+
+        cm.Show (menuItems);
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.F.WithAlt));
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.F.NoShift));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithAlt));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.NoShift));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.E.WithAlt));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.E.NoShift));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+        Assert.True (cm.MenuBar!.IsMenuOpen);
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.F.WithAlt));
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.F.NoShift));
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.N.WithAlt));
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.N.NoShift));
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.E.WithAlt));
+        Assert.False (cm.MenuBar!.KeyBindings.Bindings.ContainsKey (Key.E.NoShift));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+        Assert.Equal (3, Application.Current!.Subviews.Count);
+        menus = Application.Current!.Subviews.Where (v => v is Menu m && m.Host == cm.MenuBar).ToArray ();
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.E.WithAlt));
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.E.NoShift));
+        Assert.True (menus [1].KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.True (menus [1].KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+        Assert.True (cm.MenuBar.IsMenuOpen);
+        Assert.True (Application.OnKeyDown (Key.F.WithAlt));
+        Assert.False (cm.MenuBar.IsMenuOpen);
+        Assert.True (Application.OnKeyDown (Key.N.WithAlt));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newFile);
+
+        cm.Show (menuItems);
+        Assert.True (cm.MenuBar.IsMenuOpen);
+        Assert.Equal (3, Application.Current!.Subviews.Count);
+        menus = Application.Current!.Subviews.Where (v => v is Menu m && m.Host == cm.MenuBar).ToArray ();
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.E.WithAlt));
+        Assert.True (menus [0].KeyBindings.Bindings.ContainsKey (Key.E.NoShift));
+        Assert.False (menus [0].KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.False (menus [0].KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+        Assert.False (menus [1].KeyBindings.Bindings.ContainsKey (Key.E.WithAlt));
+        Assert.False (menus [1].KeyBindings.Bindings.ContainsKey (Key.E.NoShift));
+        Assert.True (menus [1].KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.True (menus [1].KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+        Assert.True (Application.OnKeyDown (Key.E.NoShift));
+        Assert.True (Application.OnKeyDown (Key.R.WithAlt));
+        Assert.False (cm.MenuBar.IsMenuOpen);
+        Application.MainLoop!.RunIteration ();
+        Assert.True (renameFile);
+
+        Assert.Single (Application.Current!.Subviews);
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.F.WithAlt));
+        Assert.True (menuBar.KeyBindings.Bindings.ContainsKey (Key.F.NoShift));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.WithAlt));
+        Assert.False (menuBar.KeyBindings.Bindings.ContainsKey (Key.N.NoShift));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.E.WithAlt));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.E.NoShift));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.WithAlt));
+        Assert.False (cm.MenuBar.KeyBindings.Bindings.ContainsKey (Key.R.NoShift));
+
+        newFile = false;
+        renameFile = false;
+        Assert.True (Application.OnKeyDown (Key.F.WithAlt));
+        Assert.True (Application.OnKeyDown (Key.N.WithAlt));
+        Assert.False (Application.OnKeyDown (Key.R.WithAlt));
+        Application.MainLoop!.RunIteration ();
+        Assert.True (newFile);
+        Assert.False (renameFile);
+
+        top.Dispose ();
+
+        void New () { newFile = true; }
+
+        void Rename () { renameFile = true; }
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void Opened_MenuBar_Is_Closed_When_Another_MenuBar_Is_Opening_Also_By_HotKey ()
+    {
+        var menuBar = new MenuBar
+        {
+            Menus =
+            [
+                new (
+                     "_File",
+                     new MenuItem []
+                     {
+                         new ("_New", string.Empty, null)
+                     })
+            ]
+        };
+        var cm = new ContextMenu ();
+
+        var menuItems = new MenuBarItem (
+                                         [
+                                             new MenuBarItem (
+                                                              "_Edit",
+                                                              new MenuItem []
+                                                              {
+                                                                  new ("_Rename File", string.Empty, null)
+                                                              }
+                                                             )
+                                         ]
+                                        );
+        var top = new Toplevel ();
+        top.Add (menuBar);
+        Application.Begin (top);
+
+        Assert.True (Application.OnKeyDown (Key.F.WithAlt));
+        Assert.True (menuBar.IsMenuOpen);
+
+        cm.Show (menuItems);
+        Assert.False (menuBar.IsMenuOpen);
+        Assert.True (cm.MenuBar!.IsMenuOpen);
+
+        Assert.True (Application.OnKeyDown (Key.F.WithAlt));
+        Assert.True (menuBar.IsMenuOpen);
+        Assert.False (cm.MenuBar!.IsMenuOpen);
+
+        top.Dispose ();
     }
 }

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -15,10 +15,10 @@ public class MenuBarTests (ITestOutputHelper output)
         Assert.Equal ("n", menuBarItem.HotKey);
         Assert.Equal ("i", menuItem.HotKey);
         Assert.Empty (menuBar.Menus);
-        menuBarItem.AddMenuBarItem (menuItem);
+        menuBarItem.AddMenuBarItem (menuBar, menuItem);
         menuBar.Menus = [menuBarItem];
         Assert.Single (menuBar.Menus);
-        Assert.Single (menuBar.Menus [0].Children);
+        Assert.Single (menuBar.Menus [0].Children!);
         Assert.Contains (Key.N.WithAlt, menuBar.KeyBindings.Bindings);
         Assert.DoesNotContain (Key.I, menuBar.KeyBindings.Bindings);
 

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -2938,7 +2938,7 @@ Edit
 
         Assert.Contains (Key.A.WithCtrl, menuBar.KeyBindings.Bindings);
 
-        menuBar.Menus [0].Children [0].ShortcutKey = Key.B.WithCtrl;
+        menuBar.Menus [0].Children! [0].ShortcutKey = Key.B.WithCtrl;
 
         Assert.DoesNotContain (Key.A.WithCtrl, menuBar.KeyBindings.Bindings);
         Assert.Contains (Key.B.WithCtrl, menuBar.KeyBindings.Bindings);

--- a/UnitTests/Views/MenuTests.cs
+++ b/UnitTests/Views/MenuTests.cs
@@ -43,4 +43,68 @@ public class MenuTests
 
         void Run () { }
     }
+
+    [Fact]
+    public void MenuBarItem_SubMenu_Can_Return_Null ()
+    {
+        var menuItem = new MenuItem ();
+        var menuBarItem = new MenuBarItem ();
+        Assert.Null (menuBarItem.SubMenu (menuItem));
+    }
+
+    [Fact]
+    public void MenuBarItem_Constructors_Defaults ()
+    {
+        var menuBarItem = new MenuBarItem ();
+        Assert.Equal ("", menuBarItem.Title);
+        Assert.Equal ("", menuBarItem.Help);
+        Assert.Null (menuBarItem.Action);
+        Assert.Null (menuBarItem.CanExecute);
+        Assert.Null (menuBarItem.Parent);
+        Assert.Equal (Key.Empty, menuBarItem.ShortcutKey);
+        Assert.Equal ([], menuBarItem.Children);
+        Assert.False (menuBarItem.IsTopLevel);
+
+        menuBarItem = new MenuBarItem (null!, null!, Run, () => true, new ());
+        Assert.Equal ("", menuBarItem.Title);
+        Assert.Equal ("", menuBarItem.Help);
+        Assert.Equal (Run, menuBarItem.Action);
+        Assert.NotNull (menuBarItem.CanExecute);
+        Assert.NotNull (menuBarItem.Parent);
+        Assert.Equal (Key.Empty, menuBarItem.ShortcutKey);
+        Assert.Null (menuBarItem.Children);
+        Assert.False (menuBarItem.IsTopLevel);
+
+        menuBarItem = new MenuBarItem (null!, Array.Empty<MenuItem> (), new ());
+        Assert.Equal ("", menuBarItem.Title);
+        Assert.Equal ("", menuBarItem.Help);
+        Assert.Null (menuBarItem.Action);
+        Assert.Null (menuBarItem.CanExecute);
+        Assert.NotNull (menuBarItem.Parent);
+        Assert.Equal (Key.Empty, menuBarItem.ShortcutKey);
+        Assert.Equal ([], menuBarItem.Children);
+        Assert.False (menuBarItem.IsTopLevel);
+
+        menuBarItem = new MenuBarItem (null!, new List<MenuItem []> (), new ());
+        Assert.Equal ("", menuBarItem.Title);
+        Assert.Equal ("", menuBarItem.Help);
+        Assert.Null (menuBarItem.Action);
+        Assert.Null (menuBarItem.CanExecute);
+        Assert.NotNull (menuBarItem.Parent);
+        Assert.Equal (Key.Empty, menuBarItem.ShortcutKey);
+        Assert.Equal ([], menuBarItem.Children);
+        Assert.False (menuBarItem.IsTopLevel);
+
+        menuBarItem = new MenuBarItem ([]);
+        Assert.Equal ("", menuBarItem.Title);
+        Assert.Equal ("", menuBarItem.Help);
+        Assert.Null (menuBarItem.Action);
+        Assert.Null (menuBarItem.CanExecute);
+        Assert.Null (menuBarItem.Parent);
+        Assert.Equal (Key.Empty, menuBarItem.ShortcutKey);
+        Assert.Equal ([], menuBarItem.Children);
+        Assert.False (menuBarItem.IsTopLevel);
+
+        void Run () { }
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3700

## Proposed Changes/Todos

- [x] Remove static from the  MenuItem _menuBar field
- [x] Only populate the ContextMenu keybindings when call the Show method.
- [x] Add #nullable enable to MenuBar, Menu, MenuBarItem, MenuItem and ContextMenu
- [x] Adapt the Views and Scenarios to use the changed ContextMenu

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
