### PR TITLE
Fixes #3695 - Add event handlers for Accept in ColorPicker text fields

### DIFF
--- a/Terminal.Gui/Views/ColorPicker.cs
+++ b/Terminal.Gui/Views/ColorPicker.cs
@@ -63,7 +63,8 @@ public class ColorPicker : View
                     Y = y,
                     Width = textFieldWidth
                 };
-                tfValue.HasFocusChanged += UpdateSingleBarValueFromTextField;
+                tfValue.HasFocusChanged += (s,_)=> UpdateSingleBarValueFromTextField(s);
+                tfValue.Accept += (s, _)=>UpdateSingleBarValueFromTextField(s);
                 _textFields.Add (bar, tfValue);
             }
 
@@ -152,7 +153,8 @@ public class ColorPicker : View
         };
         _tfName.Autocomplete = auto;
 
-        _tfName.HasFocusChanged += UpdateValueFromName;
+        _tfName.HasFocusChanged += (s,_)=> UpdateValueFromName(s);
+        _tfName.Accept += (s, _) => UpdateValueFromName (s);
     }
 
     private void CreateTextField ()
@@ -181,7 +183,8 @@ public class ColorPicker : View
         Add (_lbHex);
         Add (_tfHex);
 
-        _tfHex.HasFocusChanged += UpdateValueFromTextField;
+        _tfHex.HasFocusChanged += (s, _) => UpdateValueFromTextField(s);
+        _tfHex.Accept += (s, _) => UpdateValueFromTextField (s);
     }
 
     private void DisposeOldViews ()
@@ -192,7 +195,6 @@ public class ColorPicker : View
 
             if (_textFields.TryGetValue (bar, out TextField? tf))
             {
-                tf.HasFocusChanged -= UpdateSingleBarValueFromTextField;
                 Remove (tf);
                 tf.Dispose ();
             }
@@ -214,7 +216,6 @@ public class ColorPicker : View
         if (_tfHex != null)
         {
             Remove (_tfHex);
-            _tfHex.HasFocusChanged -= UpdateValueFromTextField;
             _tfHex.Dispose ();
             _tfHex = null;
         }
@@ -229,7 +230,6 @@ public class ColorPicker : View
         if (_tfName != null)
         {
             Remove (_tfName);
-            _tfName.HasFocusChanged -= UpdateValueFromName;
             _tfName.Dispose ();
             _tfName = null;
         }
@@ -277,12 +277,8 @@ public class ColorPicker : View
         }
     }
 
-    private void UpdateSingleBarValueFromTextField (object? sender, HasFocusEventArgs e)
+    private void UpdateSingleBarValueFromTextField (object? sender)
     {
-        if (e.NewValue)
-        {
-            return;
-        }
 
         foreach (KeyValuePair<IColorBar, TextField> kvp in _textFields)
         {
@@ -296,13 +292,8 @@ public class ColorPicker : View
         }
     }
 
-    private void UpdateValueFromName (object? sender, HasFocusEventArgs e)
+    private void UpdateValueFromName (object? sender)
     {
-        if (e.NewValue)
-        {
-            return;
-        }
-
         if (_tfName == null)
         {
             return;
@@ -319,13 +310,9 @@ public class ColorPicker : View
         }
     }
 
-    private void UpdateValueFromTextField (object? sender, HasFocusEventArgs e)
+    private void UpdateValueFromTextField (object? sender)
     {
-            if (e.NewValue)
-        {
-            return;
-        }
-
+        
         if (_tfHex == null)
         {
             return;

--- a/Terminal.Gui/Views/ColorPicker.cs
+++ b/Terminal.Gui/Views/ColorPicker.cs
@@ -63,7 +63,7 @@ public class ColorPicker : View
                     Y = y,
                     Width = textFieldWidth
                 };
-                tfValue.HasFocusChanged += (s,_)=> UpdateSingleBarValueFromTextField(s);
+                tfValue.HasFocusChanged += UpdateSingleBarValueFromTextField;
                 tfValue.Accept += (s, _)=>UpdateSingleBarValueFromTextField(s);
                 _textFields.Add (bar, tfValue);
             }
@@ -153,8 +153,8 @@ public class ColorPicker : View
         };
         _tfName.Autocomplete = auto;
 
-        _tfName.HasFocusChanged += (s,_)=> UpdateValueFromName(s);
-        _tfName.Accept += (s, _) => UpdateValueFromName (s);
+        _tfName.HasFocusChanged += UpdateValueFromName;
+        _tfName.Accept += (_s, _) => UpdateValueFromName ();
     }
 
     private void CreateTextField ()
@@ -183,8 +183,8 @@ public class ColorPicker : View
         Add (_lbHex);
         Add (_tfHex);
 
-        _tfHex.HasFocusChanged += (s, _) => UpdateValueFromTextField(s);
-        _tfHex.Accept += (s, _) => UpdateValueFromTextField (s);
+        _tfHex.HasFocusChanged += UpdateValueFromTextField;
+        _tfHex.Accept += (_,_)=> UpdateValueFromTextField();
     }
 
     private void DisposeOldViews ()
@@ -277,6 +277,17 @@ public class ColorPicker : View
         }
     }
 
+    private void UpdateSingleBarValueFromTextField (object? sender, HasFocusEventArgs e)
+    {
+        // if the new value of Focused is true then it is an enter event so ignore
+        if (e.NewValue)
+        {
+            return;
+        }
+
+        // it is a leave event so update
+        UpdateSingleBarValueFromTextField (sender);
+    }
     private void UpdateSingleBarValueFromTextField (object? sender)
     {
 
@@ -292,7 +303,18 @@ public class ColorPicker : View
         }
     }
 
-    private void UpdateValueFromName (object? sender)
+    private void UpdateValueFromName (object sender, HasFocusEventArgs e)
+    {
+        // if the new value of Focused is true then it is an enter event so ignore
+        if (e.NewValue)
+        {
+            return;
+        }
+
+        // it is a leave event so update
+        UpdateValueFromName();
+    }
+    private void UpdateValueFromName ()
     {
         if (_tfName == null)
         {
@@ -310,9 +332,19 @@ public class ColorPicker : View
         }
     }
 
-    private void UpdateValueFromTextField (object? sender)
+    private void UpdateValueFromTextField (object? sender, HasFocusEventArgs e)
     {
-        
+        // if the new value of Focused is true then it is an enter event so ignore
+        if (e.NewValue)
+        {
+            return;
+        }
+
+        // it is a leave event so update
+        UpdateValueFromTextField ();
+    }
+    private void UpdateValueFromTextField ()
+    {
         if (_tfHex == null)
         {
             return;

--- a/UnitTests/Views/ColorPickerTests.cs
+++ b/UnitTests/Views/ColorPickerTests.cs
@@ -790,6 +790,64 @@ public class ColorPickerTests
         Application.ResetState ();
     }
 
+    /// <summary>
+    /// In this version we use the Enter button to accept the typed text instead
+    /// of tabbing to the next view.
+    /// </summary>
+    [Fact]
+    [SetupFakeDriver]
+    public void ColorPicker_EnterHexFor_ColorName_AcceptVariation ()
+    {
+        var cp = GetColorPicker (ColorModel.RGB, true, true);
+        Application.Navigation = new ();
+        Application.Current = new ();
+        Application.Current.Add (cp);
+
+        cp.Draw ();
+
+        var name = GetTextField (cp, ColorPickerPart.ColorName);
+        var hex = GetTextField (cp, ColorPickerPart.Hex);
+
+        hex.SetFocus ();
+
+        Assert.True (hex.HasFocus);
+        Assert.Same (hex, cp.Focused);
+
+        hex.Text = "";
+        name.Text = "";
+
+        Assert.Empty (hex.Text);
+        Assert.Empty (name.Text);
+
+        Application.OnKeyDown ('#');
+        Assert.Empty (name.Text);
+        //7FFFD4
+
+        Assert.Equal ("#", hex.Text);
+        Application.OnKeyDown ('7');
+        Application.OnKeyDown ('F');
+        Application.OnKeyDown ('F');
+        Application.OnKeyDown ('F');
+        Application.OnKeyDown ('D');
+        Assert.Empty (name.Text);
+
+        Application.OnKeyDown ('4');
+
+        Assert.True (hex.HasFocus);
+
+        // Should stay in the hex field (because accept not tab)
+        Application.OnKeyDown (Key.Enter);
+        Assert.True (hex.HasFocus);
+        Assert.Same (hex, cp.Focused);
+
+        // But still, Color name should be recognised as a known string and populated
+        Assert.Equal ("#7FFFD4", hex.Text);
+        Assert.Equal ("Aquamarine", name.Text);
+
+        Application.Current?.Dispose ();
+        Application.ResetState ();
+    }
+
     [Fact]
     public void TestColorNames ()
     {


### PR DESCRIPTION
## Fixes

- Fixes #3695 

## Proposed Changes/Todos

Make Accept (default key Enter) in text boxes update color selection similarly to focus change events.

@tig I have removed the .NewValue if check as I'm not sure what it means on a focus changing event.   Presumably the new value is supposed to indicate whether it is entering or leaving? either way the behaviour seems correct regardless.

I've also removed the `-=` event handler removals.  The reason is because we are now using anonymous delegate `(s,_)=>` for both Accept and FocusChange.

I don't think they are needed anyway as the lifecycle of the view at that point is where they are Disposed anyway so no events should get raised and they will go out of scope and get cleaned up anyway.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
