### PR TITLE
Fixes #3715 - `Pos.Has (Type, out Pos)` -> `Pos.Has<T> (out Pos)`

### DIFF
--- a/Terminal.Gui/View/Layout/Dim.cs
+++ b/Terminal.Gui/View/Layout/Dim.cs
@@ -120,11 +120,17 @@ public abstract record Dim : IEqualityOperators<Dim, Dim, bool>
     }
 
     /// <summary>
+    ///     Creates a <see cref="Dim"/> object that fills the dimension, leaving no margin.
+    /// </summary>
+    /// <returns>The Fill dimension.</returns>
+    public static Dim? Fill () { return new DimFill (0); }
+
+    /// <summary>
     ///     Creates a <see cref="Dim"/> object that fills the dimension, leaving the specified margin.
     /// </summary>
     /// <returns>The Fill dimension.</returns>
     /// <param name="margin">Margin to use.</param>
-    public static Dim? Fill (int margin = 0) { return new DimFill (margin); }
+    public static Dim? Fill (Dim margin) { return new DimFill (margin); }
 
     /// <summary>
     ///     Creates a function <see cref="Dim"/> object that computes the dimension by executing the provided function.

--- a/Terminal.Gui/View/Layout/DimAuto.cs
+++ b/Terminal.Gui/View/Layout/DimAuto.cs
@@ -131,9 +131,9 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                     notDependentSubViews = includedSubviews.Where (
                                                                    v => v.Width is { }
                                                                         && (v.X is PosAbsolute or PosFunc || v.Width is DimAuto or DimAbsolute or DimFunc) // BUGBUG: We should use v.X.Has and v.Width.Has?
-                                                                        && !v.X.Has (typeof (PosAnchorEnd), out _)
-                                                                        && !v.X.Has (typeof (PosAlign), out _)
-                                                                        && !v.X.Has (typeof (PosCenter), out _)
+                                                                        && !v.X.Has<PosAnchorEnd> (out _)
+                                                                        && !v.X.Has<PosAlign> (out _)
+                                                                        && !v.X.Has<PosCenter> (out _)
                                                                         && !v.Width.Has<DimFill> (out _)
                                                                         && !v.Width.Has<DimPercent> (out _)
                                                                   )
@@ -144,9 +144,9 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                     notDependentSubViews = includedSubviews.Where (
                                                                    v => v.Height is { }
                                                                         && (v.Y is PosAbsolute or PosFunc || v.Height is DimAuto or DimAbsolute or DimFunc) // BUGBUG: We should use v.Y.Has and v.Height.Has?
-                                                                        && !v.Y.Has (typeof (PosAnchorEnd), out _)
-                                                                        && !v.Y.Has (typeof (PosAlign), out _)
-                                                                        && !v.Y.Has (typeof (PosCenter), out _)
+                                                                        && !v.Y.Has<PosAnchorEnd> (out _)
+                                                                        && !v.Y.Has<PosAlign> (out _)
+                                                                        && !v.Y.Has<PosCenter> (out _)
                                                                         && !v.Height.Has<DimFill> (out _)
                                                                         && !v.Height.Has<DimPercent> (out _)
                                                                   )
@@ -190,11 +190,11 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
 
                 if (dimension == Dimension.Width)
                 {
-                    centeredSubViews = us.Subviews.Where (v => v.X.Has (typeof (PosCenter), out _)).ToList ();
+                    centeredSubViews = us.Subviews.Where (v => v.X.Has<PosCenter> (out _)).ToList ();
                 }
                 else
                 {
-                    centeredSubViews = us.Subviews.Where (v => v.Y.Has (typeof (PosCenter), out _)).ToList ();
+                    centeredSubViews = us.Subviews.Where (v => v.Y.Has<PosCenter> (out _)).ToList ();
                 }
 
                 viewsNeedingLayout.AddRange (centeredSubViews);
@@ -239,14 +239,14 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                                                               {
                                                                   if (dimension == Dimension.Width)
                                                                   {
-                                                                      if (v.X.Has (typeof (PosAlign), out Pos posAlign))
+                                                                      if (v.X.Has<PosAlign> (out Pos posAlign))
                                                                       {
                                                                           return ((PosAlign)posAlign).GroupId;
                                                                       }
                                                                   }
                                                                   else
                                                                   {
-                                                                      if (v.Y.Has (typeof (PosAlign), out Pos posAlign))
+                                                                      if (v.Y.Has<PosAlign> (out Pos posAlign))
                                                                       {
                                                                           return ((PosAlign)posAlign).GroupId;
                                                                       }
@@ -294,11 +294,11 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
 
                 if (dimension == Dimension.Width)
                 {
-                    anchoredSubViews = includedSubviews.Where (v => v.X.Has (typeof (PosAnchorEnd), out _)).ToList ();
+                    anchoredSubViews = includedSubviews.Where (v => v.X.Has<PosAnchorEnd> (out _)).ToList ();
                 }
                 else
                 {
-                    anchoredSubViews = includedSubviews.Where (v => v.Y.Has (typeof (PosAnchorEnd), out _)).ToList ();
+                    anchoredSubViews = includedSubviews.Where (v => v.Y.Has<PosAnchorEnd> (out _)).ToList ();
                 }
 
                 viewsNeedingLayout.AddRange (anchoredSubViews);
@@ -336,11 +336,11 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
 
                 if (dimension == Dimension.Width)
                 {
-                    posViewSubViews = includedSubviews.Where (v => v.X.Has (typeof (PosView), out _)).ToList ();
+                    posViewSubViews = includedSubviews.Where (v => v.X.Has<PosView> (out _)).ToList ();
                 }
                 else
                 {
-                    posViewSubViews = includedSubviews.Where (v => v.Y.Has (typeof (PosView), out _)).ToList ();
+                    posViewSubViews = includedSubviews.Where (v => v.Y.Has<PosView> (out _)).ToList ();
                 }
 
                 for (var i = 0; i < posViewSubViews.Count; i++)

--- a/Terminal.Gui/View/Layout/DimFill.cs
+++ b/Terminal.Gui/View/Layout/DimFill.cs
@@ -9,10 +9,10 @@ namespace Terminal.Gui;
 ///     methods on the <see cref="Dim"/> class to create <see cref="Dim"/> objects instead.
 /// </remarks>
 /// <param name="Margin">The margin to not fill.</param>
-public record DimFill (int Margin) : Dim
+public record DimFill (Dim Margin) : Dim
 {
     /// <inheritdoc/>
     public override string ToString () { return $"Fill({Margin})"; }
 
-    internal override int GetAnchor (int size) { return size - Margin; }
+    internal override int GetAnchor (int size) { return size - Margin.GetAnchor(0); }
 }

--- a/Terminal.Gui/View/Layout/Pos.cs
+++ b/Terminal.Gui/View/Layout/Pos.cs
@@ -331,27 +331,20 @@ public abstract record Pos
     internal virtual bool ReferencesOtherViews () { return false; }
 
     /// <summary>
-    ///     Indicates whether the specified type is in the hierarchy of this Pos object.
+    ///     Indicates whether the specified type <typeparamref name="T"/> is in the hierarchy of this Pos object.
     /// </summary>
-    /// <param name="type"></param>
-    /// <param name="pos"></param>
+    /// <param name="pos">A reference to this <see cref="Pos}"/> instance.</param>
     /// <returns></returns>
-    public bool Has (Type type, out Pos pos)
+    public bool Has<T> (out Pos pos) where T : Pos
     {
         pos = this;
-        if (type == GetType ())
-        {
-            return true;
-        }
 
-        // If we are a PosCombine, we have to check the left and right
-        // to see if they are of the type we are looking for.
-        if (this is PosCombine { } combine && (combine.Left.Has (type, out pos) || combine.Right.Has (type, out pos)))
-        {
-            return true;
-        }
-
-        return false;
+        return this switch
+               {
+                   PosCombine combine => combine.Left.Has<T> (out pos) || combine.Right.Has<T> (out pos),
+                   T => true,
+                   _ => false
+               };
     }
 
     #endregion virtual methods

--- a/Terminal.Gui/View/Layout/PosAlign.cs
+++ b/Terminal.Gui/View/Layout/PosAlign.cs
@@ -67,11 +67,11 @@ public record PosAlign : Pos
                                                v =>
                                                {
                                                    return dimension switch
-                                                          {
-                                                              Dimension.Width when v.X is PosAlign alignX => alignX.GroupId == groupId,
-                                                              Dimension.Height when v.Y is PosAlign alignY => alignY.GroupId == groupId,
-                                                              _ => false
-                                                          };
+                                                   {
+                                                       Dimension.Width when v.X is PosAlign alignX => alignX.GroupId == groupId,
+                                                       Dimension.Height when v.Y is PosAlign alignY => alignY.GroupId == groupId,
+                                                       _ => false
+                                                   };
                                                })
                                        .ToList ();
 
@@ -150,7 +150,7 @@ public record PosAlign : Pos
                                                   {
                                                       switch (dimension)
                                                       {
-                                                          case Dimension.Width when v.X.Has (typeof (PosAlign), out Pos pos):
+                                                          case Dimension.Width when v.X.Has<PosAlign> (out Pos pos):
 
                                                               if (pos is PosAlign posAlignX && posAlignX.GroupId == groupId)
                                                               {
@@ -158,7 +158,7 @@ public record PosAlign : Pos
                                                               }
 
                                                               break;
-                                                          case Dimension.Height when v.Y.Has (typeof (PosAlign), out Pos pos):
+                                                          case Dimension.Height when v.Y.Has<PosAlign> (out Pos pos):
                                                               if (pos is PosAlign posAlignY && posAlignY.GroupId == groupId)
                                                               {
                                                                   return posAlignY;

--- a/Terminal.Gui/Views/Wizard/Wizard.cs
+++ b/Terminal.Gui/Views/Wizard/Wizard.cs
@@ -70,16 +70,18 @@ public class Wizard : Dialog
         ButtonAlignmentModes |= AlignmentModes.IgnoreFirstOrLast;
         BorderStyle = LineStyle.Double;
 
-        //// Add a horiz separator
-        var separator = new LineView (Orientation.Horizontal) { Y = Pos.AnchorEnd (2) };
-        Add (separator);
-
-        // BUGBUG: Space is to work around https://github.com/gui-cs/Terminal.Gui/issues/1812
         BackButton = new () { Text = Strings.wzBack };
-        AddButton (BackButton);
+        NextFinishButton = new ()
+        {
+            Text = Strings.wzFinish,
+            IsDefault = true
+        };
 
-        NextFinishButton = new () { Text = Strings.wzFinish };
-        NextFinishButton.IsDefault = true;
+        //// Add a horiz separator
+        var separator = new LineView (Orientation.Horizontal) { Y = Pos.Top (BackButton) - 1 };
+
+        Add (separator);
+        AddButton (BackButton);
         AddButton (NextFinishButton);
 
         BackButton.Accept += BackBtn_Clicked;
@@ -495,14 +497,14 @@ public class Wizard : Dialog
             // If we're modal, then we expand the WizardStep so that the top and side 
             // borders and not visible. The bottom border is the separator above the buttons.
             step.X = step.Y = 0;
-            step.Height = Dim.Fill (2); // for button frame
+            step.Height = Dim.Fill (Dim.Func (() => IsInitialized ? Subviews.First (view => view.Y.Has<PosAnchorEnd> (out _)).Frame.Height + 1 : 1)); // for button frame (+1 for lineView)
             step.Width = Dim.Fill ();
         }
         else
         {
             // If we're not a modal, then we show the border around the WizardStep
             step.X = step.Y = 0;
-            step.Height = Dim.Fill (1); // for button frame
+            step.Height = Dim.Fill (Dim.Func (() => IsInitialized ? Subviews.First (view => view.Y.Has<PosAnchorEnd> (out _)).Frame.Height + 1 : 2)); // for button frame (+1 for lineView)
             step.Width = Dim.Fill ();
         }
     }

--- a/Terminal.Gui/Views/Wizard/WizardStep.cs
+++ b/Terminal.Gui/Views/Wizard/WizardStep.cs
@@ -60,6 +60,7 @@ public class WizardStep : View
         TabStop = TabBehavior.TabStop;
         CanFocus = true;
         BorderStyle = LineStyle.None;
+
         base.Add (_contentView);
 
         base.Add (_helpTextView);
@@ -191,7 +192,7 @@ public class WizardStep : View
     internal void ShowHide ()
     {
         _contentView.Height = Dim.Fill ();
-        _helpTextView.Height = Dim.Fill ();
+        _helpTextView.Height = Dim.Height(_contentView);
         _helpTextView.Width = Dim.Fill ();
 
         if (_contentView.InternalSubviews?.Count > 0)

--- a/UICatalog/KeyBindingsDialog.cs
+++ b/UICatalog/KeyBindingsDialog.cs
@@ -32,7 +32,7 @@ internal class KeyBindingsDialog : Dialog
         _commandsListView = new ListView
         {
             Width = Dim.Percent (50),
-            Height = Dim.Fill () - Dim.Func (() => IsInitialized ? Subviews.First (view => view.Y.Has<PosAnchorEnd> (out _)).Frame.Height : 1),
+            Height = Dim.Fill (Dim.Func (() => IsInitialized ? Subviews.First (view => view.Y.Has<PosAnchorEnd> (out _)).Frame.Height : 1)),
             Source = new ListWrapper<Command> (_commands),
             SelectedItem = 0
         };

--- a/UICatalog/KeyBindingsDialog.cs
+++ b/UICatalog/KeyBindingsDialog.cs
@@ -19,8 +19,8 @@ internal class KeyBindingsDialog : Dialog
     {
         Title = "Keybindings";
 
-        Height = Dim.Percent(80);
-        Width = Dim.Percent(80);
+        Height = Dim.Percent (80);
+        Width = Dim.Percent (80);
         if (ViewTracker.Instance == null)
         {
             ViewTracker.Initialize ();
@@ -32,7 +32,7 @@ internal class KeyBindingsDialog : Dialog
         _commandsListView = new ListView
         {
             Width = Dim.Percent (50),
-            Height = Dim.Fill () - 1,
+            Height = Dim.Fill () - Dim.Func (() => IsInitialized ? Subviews.First (view => view.Y.Has<PosAnchorEnd> (out _)).Frame.Height : 1),
             Source = new ListWrapper<Command> (_commands),
             SelectedItem = 0
         };

--- a/UICatalog/Scenarios/WizardAsView.cs
+++ b/UICatalog/Scenarios/WizardAsView.cs
@@ -57,7 +57,14 @@ public class WizardAsView : Scenario
         topLevel.Add (menu);
 
         // No need for a Title because the border is disabled
-        var wizard = new Wizard { X = 0, Y = 0, Width = Dim.Fill (), Height = Dim.Fill () };
+        var wizard = new Wizard
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill (),
+            Height = Dim.Fill (),
+            ShadowStyle = ShadowStyle.None
+        };
 
         // Set Mdoal to false to cause the Wizard class to render without a frame and
         // behave like an non-modal View (vs. a modal/pop-up Window).

--- a/UICatalog/Scenarios/Wizards.cs
+++ b/UICatalog/Scenarios/Wizards.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Terminal.Gui;
 
 namespace UICatalog.Scenarios;
@@ -276,17 +277,26 @@ public class Wizards : Scenario
                                                X = 0,
                                                Y = 0,
                                                Width = Dim.Fill (),
-                                               Height = Dim.Fill (1),
                                                WordWrap = true,
                                                AllowsTab = false,
                                                ColorScheme = Colors.ColorSchemes ["Base"]
                                            };
+
+                                           someText.Height = Dim.Fill (
+                                                                       Dim.Func (
+                                                                                 () => someText.SuperView is { IsInitialized: true }
+                                                                                           ? someText.SuperView.Subviews
+                                                                                                     .First (view => view.Y.Has<PosAnchorEnd> (out _))
+                                                                                                     .Frame.Height
+                                                                                           : 1));
                                            var help = "This is helpful.";
                                            fourthStep.Add (someText);
 
                                            var hideHelpBtn = new Button
                                            {
-                                               Text = "Press me to show/hide help", X = Pos.Center (), Y = Pos.AnchorEnd (1)
+                                               Text = "Press me to show/hide help",
+                                               X = Pos.Center (),
+                                               Y = Pos.AnchorEnd ()
                                            };
 
                                            hideHelpBtn.Accept += (s, e) =>

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -477,7 +477,7 @@ public class UICatalogApp
                 ShVersion = new ()
                 {
                     Title = "Version Info",
-                    CanFocus = false
+                    CanFocus = false,
                 };
 
                 var statusBarShortcut = new Shortcut
@@ -546,7 +546,7 @@ public class UICatalogApp
                 X = 0,
                 Y = 1,
                 Width = Dim.Auto (),
-                Height = Dim.Fill (1),
+                Height = Dim.Fill (Dim.Func (() => IsInitialized ? Subviews.First (view => view.Y.Has<PosAnchorEnd> (out _)).Frame.Height : 1)),
                 AllowsMarking = false,
                 CanFocus = true,
                 Title = "_Categories",

--- a/UnitTests/View/Layout/Dim.FillTests.cs
+++ b/UnitTests/View/Layout/Dim.FillTests.cs
@@ -127,15 +127,28 @@ public class DimFillTests (ITestOutputHelper output)
     {
         var testMargin = 0;
         Dim dim = Dim.Fill ();
-        Assert.Equal ($"Fill({testMargin})", dim.ToString ());
+        Assert.Equal (testMargin, dim!.GetAnchor(0));
 
         testMargin = 0;
         dim = Dim.Fill (testMargin);
-        Assert.Equal ($"Fill({testMargin})", dim.ToString ());
+        Assert.Equal (testMargin, dim!.GetAnchor (0));
 
         testMargin = 5;
         dim = Dim.Fill (testMargin);
-        Assert.Equal ($"Fill({testMargin})", dim.ToString ());
+        Assert.Equal (-testMargin, dim!.GetAnchor (0));
+    }
+
+    [Fact]
+    public void DimFill_Margin_Is_Dim_SetsValue ()
+    {
+        Dim testMargin = Dim.Func (() => 0);
+        Dim dim = Dim.Fill (testMargin);
+        Assert.Equal (0, dim!.GetAnchor (0));
+
+
+        testMargin = Dim.Func (() => 5);
+        dim = Dim.Fill (testMargin);
+        Assert.Equal (-5, dim!.GetAnchor (0));
     }
 
     [Fact]

--- a/UnitTests/View/Layout/Dim.Tests.cs
+++ b/UnitTests/View/Layout/Dim.Tests.cs
@@ -315,7 +315,7 @@ public class DimTests
                        Assert.Equal (49, f1.Frame.Width); // 50-1=49
                        Assert.Equal (5, f1.Frame.Height);
 
-                       Assert.Equal ("Fill(0)", f2.Width.ToString ());
+                       Assert.Equal ("Fill(Absolute(0))", f2.Width.ToString ());
                        Assert.Equal ("Absolute(5)", f2.Height.ToString ());
                        Assert.Equal (49, f2.Frame.Width); // 50-1=49
                        Assert.Equal (5, f2.Frame.Height);
@@ -325,7 +325,7 @@ public class DimTests
 #else
                        Assert.Equal ($"Combine(View(Width,FrameView(){f1.Border.Frame})-Absolute(2))", v1.Width.ToString ());
 #endif
-                       Assert.Equal ("Combine(Fill(0)-Absolute(2))", v1.Height.ToString ());
+                       Assert.Equal ("Combine(Fill(Absolute(0))-Absolute(2))", v1.Height.ToString ());
                        Assert.Equal (47, v1.Frame.Width); // 49-2=47
                        Assert.Equal (89, v1.Frame.Height); // 98-5-2-2=89
 
@@ -340,7 +340,7 @@ public class DimTests
 #endif
                                     );
 #if DEBUG
-                       Assert.Equal ("Combine(Fill(0)-Absolute(2))", v2.Height.ToString ());
+                       Assert.Equal ("Combine(Fill(Absolute(0))-Absolute(2))", v2.Height.ToString ());
 #else
                        Assert.Equal ("Combine(Fill(0)-Absolute(2))", v2.Height.ToString ());
 #endif
@@ -380,7 +380,7 @@ public class DimTests
                        Assert.Equal (5, f1.Frame.Height);
 
                        f2.Text = "Frame2";
-                       Assert.Equal ("Fill(0)", f2.Width.ToString ());
+                       Assert.Equal ("Fill(Absolute(0))", f2.Width.ToString ());
                        Assert.Equal ("Absolute(5)", f2.Height.ToString ());
                        Assert.Equal (99, f2.Frame.Width); // 100-1=99
                        Assert.Equal (5, f2.Frame.Height);
@@ -391,7 +391,7 @@ public class DimTests
 #else
                        Assert.Equal ($"Combine(View(Width,FrameView(){f1.Frame})-Absolute(2))", v1.Width.ToString ());
 #endif
-                       Assert.Equal ("Combine(Fill(0)-Absolute(2))", v1.Height.ToString ());
+                       Assert.Equal ("Combine(Fill(Absolute(0))-Absolute(2))", v1.Height.ToString ());
                        Assert.Equal (97, v1.Frame.Width); // 99-2=97
                        Assert.Equal (189, v1.Frame.Height); // 198-2-7=189
 
@@ -402,7 +402,7 @@ public class DimTests
 #else
                        Assert.Equal ($"Combine(View(Width,FrameView(){f2.Frame})-Absolute(2))", v2.Width.ToString ());
 #endif
-                       Assert.Equal ("Combine(Fill(0)-Absolute(2))", v2.Height.ToString ());
+                       Assert.Equal ("Combine(Fill(Absolute(0))-Absolute(2))", v2.Height.ToString ());
                        Assert.Equal (97, v2.Frame.Width); // 99-2=97
                        Assert.Equal (189, v2.Frame.Height); // 198-2-7=189
 

--- a/UnitTests/View/Layout/SetRelativeLayoutTests.cs
+++ b/UnitTests/View/Layout/SetRelativeLayoutTests.cs
@@ -37,11 +37,11 @@ public class SetRelativeLayoutTests
 
         Assert.Equal ("Absolute(1)", view.X.ToString ());
         Assert.Equal ("Absolute(2)", view.Y.ToString ());
-        Assert.Equal ("Fill(0)", view.Width.ToString ());
-        Assert.Equal ("Fill(0)", view.Height.ToString ());
+        Assert.Equal ("Fill(Absolute(0))", view.Width.ToString ());
+        Assert.Equal ("Fill(Absolute(0))", view.Height.ToString ());
         view.SetRelativeLayout (screen);
-        Assert.Equal ("Fill(0)", view.Width.ToString ());
-        Assert.Equal ("Fill(0)", view.Height.ToString ());
+        Assert.Equal ("Fill(Absolute(0))", view.Width.ToString ());
+        Assert.Equal ("Fill(Absolute(0))", view.Height.ToString ());
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class SetRelativeLayoutTests
         var view = new View { X = 1, Y = 1, Width = Dim.Fill (), Height = Dim.Fill () };
 
         view.SetRelativeLayout (new Size (80, 25));
-        Assert.Equal ("Fill(0)", view.Width.ToString ());
+        Assert.Equal ("Fill(Absolute(0))", view.Width.ToString ());
         Assert.Equal (1, view.Frame.X);
         Assert.Equal (1, view.Frame.Y);
         Assert.Equal (79, view.Frame.Width);
@@ -63,7 +63,7 @@ public class SetRelativeLayoutTests
         view.X = 0;
         view.Y = 0;
         Assert.Equal ("Absolute(0)", view.X.ToString ());
-        Assert.Equal ("Fill(0)", view.Width.ToString ());
+        Assert.Equal ("Fill(Absolute(0))", view.Width.ToString ());
         view.SetRelativeLayout (new Size (80, 25));
         Assert.Equal (0, view.Frame.X);
         Assert.Equal (0, view.Frame.Y);

--- a/UnitTests/Views/ToplevelTests.cs
+++ b/UnitTests/Views/ToplevelTests.cs
@@ -10,8 +10,8 @@ public partial class ToplevelTests (ITestOutputHelper output)
         var top = new Toplevel ();
 
         Assert.Equal (Colors.ColorSchemes ["TopLevel"], top.ColorScheme);
-        Assert.Equal ("Fill(0)", top.Width.ToString ());
-        Assert.Equal ("Fill(0)", top.Height.ToString ());
+        Assert.Equal ("Fill(Absolute(0))", top.Width.ToString ());
+        Assert.Equal ("Fill(Absolute(0))", top.Height.ToString ());
         Assert.False (top.Running);
         Assert.False (top.Modal);
         Assert.Null (top.MenuBar);


### PR DESCRIPTION
## Fixes

- Fixes #3715 
- `Dim.Fill` now takes a `Dim`, instead of an `int`
- Fixes `KeyBindingsDialog` to correctly size list if button shadow style is enabled.

