### PR TITLE
V1 - Fixes #3740. Disabled MenuItem triggers exception.

### DIFF
--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -1238,7 +1238,7 @@ namespace Terminal.Gui {
 				mi = openCurrentMenu.barItems.Children [openCurrentMenu.current];
 			} else if (openCurrentMenu.barItems.IsTopLevel) {
 				mi = openCurrentMenu.barItems;
-			} else {
+			} else if (openCurrentMenu?.current > -1) {
 				mi = openMenu.barItems.Children [openMenu.current];
 			}
 			MenuOpened?.Invoke (mi);

--- a/UnitTests/Menus/MenuTests.cs
+++ b/UnitTests/Menus/MenuTests.cs
@@ -219,8 +219,7 @@ Edit
 				View = mCurrent
 			}));
 			Assert.True (menu.IsMenuOpen);
-			Assert.Equal ("_File", miCurrent.Parent.Title);
-			Assert.Equal ("_New", miCurrent.Title);
+			Assert.Null (miCurrent);
 
 			Assert.True (mCurrent.MouseEvent (new MouseEvent () {
 				X = 1,
@@ -229,8 +228,7 @@ Edit
 				View = mCurrent
 			}));
 			Assert.True (menu.IsMenuOpen);
-			Assert.Equal ("_File", miCurrent.Parent.Title);
-			Assert.Equal ("_New", miCurrent.Title);
+			Assert.Null (miCurrent);
 
 			Assert.True (mCurrent.MouseEvent (new MouseEvent () {
 				X = 1,
@@ -239,8 +237,7 @@ Edit
 				View = mCurrent
 			}));
 			Assert.True (menu.IsMenuOpen);
-			Assert.Equal ("_File", miCurrent.Parent.Title);
-			Assert.Equal ("_Save", miCurrent.Title);
+			Assert.Null (miCurrent);
 
 			// close the menu
 			Assert.True (menu.MouseEvent (new MouseEvent () {
@@ -265,8 +262,7 @@ Edit
 
 			Assert.True (mCurrent.ProcessKey (new KeyEvent (Key.CursorUp, new KeyModifiers ())));
 			Assert.True (menu.IsMenuOpen);
-			Assert.Equal ("_File", miCurrent.Parent.Title);
-			Assert.Equal ("_New", miCurrent.Title);
+			Assert.Null (miCurrent);
 
 			// close the menu
 			Assert.True (menu.ProcessHotKey (new KeyEvent (Key.F9, new KeyModifiers ())));


### PR DESCRIPTION
## Fixes

- Fixes #3740

## Proposed Changes/Todos

- [x] MenuItem disabled return null

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
