### PR TITLE
V2 - Fixes #3740. Disabled MenuItem triggers exception.

### DIFF
--- a/Terminal.Gui/Views/Menu/MenuBar.cs
+++ b/Terminal.Gui/Views/Menu/MenuBar.cs
@@ -351,7 +351,7 @@ public class MenuBar : View, IDesignable
     /// <summary>Virtual method that will invoke the <see cref="MenuOpened"/> event if it's defined.</summary>
     public virtual void OnMenuOpened ()
     {
-        MenuItem? mi;
+        MenuItem? mi = null;
         MenuBarItem? parent;
 
         if (OpenCurrentMenu?.BarItems?.Children is { Length: > 0 }
@@ -368,7 +368,11 @@ public class MenuBar : View, IDesignable
         else
         {
             parent = _openMenu?.BarItems;
-            mi = parent?.Children?.Length > 0 ? parent.Children [_openMenu!._currentChild] : null;
+
+            if (OpenCurrentMenu?._currentChild > -1)
+            {
+                mi = parent?.Children?.Length > 0 ? parent.Children [_openMenu!._currentChild] : null;
+            }
         }
 
         MenuOpened?.Invoke (this, new (parent, mi));

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -2241,6 +2241,7 @@ wo
     [AutoInitShutdown]
     public void MenuOpened_On_Disabled_MenuItem ()
     {
+        MenuItem parent = null;
         MenuItem miCurrent = null;
         Menu mCurrent = null;
 
@@ -2273,6 +2274,7 @@ wo
 
         menu.MenuOpened += (s, e) =>
                            {
+                               parent = e.Parent;
                                miCurrent = e.MenuItem;
                                mCurrent = menu._openMenu;
                            };
@@ -2288,6 +2290,7 @@ wo
                                         )
                     );
         Assert.True (menu.IsMenuOpen);
+        Assert.Equal ("_File", parent.Title);
         Assert.Equal ("_File", miCurrent.Parent.Title);
         Assert.Equal ("_New", miCurrent.Title);
 
@@ -2297,6 +2300,7 @@ wo
                                             )
                     );
         Assert.True (menu.IsMenuOpen);
+        Assert.Equal ("_File", parent.Title);
         Assert.Equal ("_File", miCurrent.Parent.Title);
         Assert.Equal ("_New", miCurrent.Title);
 
@@ -2306,6 +2310,7 @@ wo
                                             )
                     );
         Assert.True (menu.IsMenuOpen);
+        Assert.Equal ("_File", parent.Title);
         Assert.Equal ("_File", miCurrent.Parent.Title);
         Assert.Equal ("_New", miCurrent.Title);
 
@@ -2315,6 +2320,7 @@ wo
                                             )
                     );
         Assert.True (menu.IsMenuOpen);
+        Assert.Equal ("_File", parent.Title);
         Assert.Equal ("_File", miCurrent.Parent.Title);
         Assert.Equal ("_Save", miCurrent.Title);
 
@@ -2331,18 +2337,20 @@ wo
         Assert.True (menu.IsMenuOpen);
 
         // The _New doc is enabled but the sub-menu isn't enabled. Is show but can't be selected and executed
+        Assert.Equal ("_New", parent.Title);
         Assert.Equal ("_New", miCurrent.Parent.Title);
         Assert.Equal ("_New doc", miCurrent.Title);
 
         Assert.True (mCurrent.NewKeyDownEvent (Key.CursorDown));
         Assert.True (menu.IsMenuOpen);
+        Assert.Equal ("_File", parent.Title);
         Assert.Equal ("_File", miCurrent.Parent.Title);
         Assert.Equal ("_Save", miCurrent.Title);
 
         Assert.True (mCurrent.NewKeyDownEvent (Key.CursorUp));
         Assert.True (menu.IsMenuOpen);
-        Assert.Equal ("_File", miCurrent.Parent.Title);
-        Assert.Equal ("_New", miCurrent.Title);
+        Assert.Equal ("_File", parent.Title);
+        Assert.Null (miCurrent);
 
         // close the menu
         Assert.True (menu.NewKeyDownEvent (menu.Key));


### PR DESCRIPTION
## Fixes

- Fixes #3740

## Proposed Changes/Todos

- [x] MenuItem disabled return null

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
