### PR TITLE
Fixes #3754. UICatalog throws System.NullReferenceException on MenuBar in Linux.

### DIFF
--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -101,7 +101,7 @@ internal sealed class Menu : View
 
             for (var i = 0; i < _barItems.Children?.Length; i++)
             {
-                if (_barItems.Children [i]!.IsEnabled ())
+                if (_barItems.Children [i]?.IsEnabled () == true)
                 {
                     _currentChild = i;
 

--- a/UnitTests/Views/MenuBarTests.cs
+++ b/UnitTests/Views/MenuBarTests.cs
@@ -150,6 +150,30 @@ public class MenuBarTests (ITestOutputHelper output)
 
     [Fact]
     [AutoInitShutdown]
+    public void CanExecute_False_Does_Not_Throws ()
+    {
+        var menu = new MenuBar
+        {
+            Menus =
+            [
+                new ("File", new MenuItem []
+                {
+                    new ("New", "", null, () => false),
+                    null,
+                    new ("Quit", "", null)
+                })
+            ]
+        };
+        var top = new Toplevel ();
+        top.Add (menu);
+        Application.Begin (top);
+
+        Assert.True (menu.NewKeyDownEvent (menu.Key));
+        Assert.True (menu.IsMenuOpen);
+    }
+
+    [Fact]
+    [AutoInitShutdown]
     public void CanExecute_HotKey ()
     {
         Window win = null;


### PR DESCRIPTION
## Fixes

- Fixes #3754

## Proposed Changes/Todos

- [x] IsEnabled method now checks for null MenuItem.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
