### PR TITLE
Fixes #3757. ShadowView throws System.IndexOutOfRangeException if left is less than zero.

### DIFF
--- a/Terminal.Gui/View/Adornment/ShadowView.cs
+++ b/Terminal.Gui/View/Adornment/ShadowView.cs
@@ -109,7 +109,7 @@ internal class ShadowView : View
         Rectangle screen = ViewportToScreen (viewport);
 
         // Fill the rest of the rectangle - note we skip the last since vertical will draw it
-        for (int i = screen.X + 1; i < screen.X + screen.Width - 1; i++)
+        for (int i = Math.Max (screen.X + 1, 0); i < screen.X + screen.Width - 1; i++)
         {
             Driver.Move (i, screen.Y);
 


### PR DESCRIPTION
## Fixes

- Fixes #3757

## Proposed Changes/Todos

- [x] Prevents X being less than zero.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
