### PR TITLE
Fixes #3784. SelfContained and NativeAot projects should use the local package in the release mode.

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -78,8 +78,8 @@ jobs:
   
 
   build_release:
+    # Ensure that RELEASE builds are not broken  
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -90,8 +90,11 @@ jobs:
         dotnet-version: 8.x
         dotnet-quality: 'ga'
 
+    - name: Build Release Terminal.Gui
+      run: cd Terminal.Gui && dotnet build --configuration Release
+
     - name: Pack Release
-      run: cd Terminal.Gui && dotnet pack --configuration Release --output ./local_packages
+      run: dotnet pack Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ./local_packages
 
     - name: Build Release
       run: dotnet build --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -91,7 +91,7 @@ jobs:
         dotnet-quality: 'ga'
 
     - name: Pack Release
-      run: dotnet pack Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ./local_packages
+      run: cd Terminal.Gui && dotnet pack --configuration Release --output ./local_packages
 
     - name: Build Release
       run: dotnet build --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -99,32 +99,6 @@ jobs:
         name: local_nuget_package
         path: ./local_packages/*.nupkg
 
-  build_release_consumer:
-    runs-on: ubuntu-latest
-    needs: build_release
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.x
-        dotnet-quality: 'ga'
-
-    - name: Download package artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: local_nuget_package
-        path: ./local_packages
-
-    - name: Restore dependencies using downloaded package
-      run: dotnet restore --configfile nuget.config
-
-    - name: Build Release
-      run: dotnet build --configuration Release
-
 
     # Note: this step is currently not writing to the gist for some reason
     # - name: Create Test Coverage Badge

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -91,7 +91,7 @@ jobs:
         dotnet-quality: 'ga'
 
     - name: Build Release Terminal.Gui
-      run: dotnet build ../Terminal.Gui/Terminal.Gui.csproj --configuration Release
+      run: dotnet build Terminal.Gui/Terminal.Gui.csproj --configuration Release
 
     - name: Pack Release Terminal.Gui
       run: dotnet pack Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ./local_packages

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -78,7 +78,7 @@ jobs:
   
 
   build_release:
-    # Ensure that RELEASE builds are not broken  
+    # Ensure that RELEASE builds are not broken
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -90,14 +90,14 @@ jobs:
         dotnet-version: 8.x
         dotnet-quality: 'ga'
 
-    - name: Create LocalPackages Directory
-      run: mkdir -p LocalPackages
+    - name: Create local_packages Directory
+      run: mkdir -p local_packages
 
     - name: Pack Release
-      run: dotnet pack --configuration Release --output ./LocalPackages
+      run: dotnet pack --configuration Release --output ./local_packages
 
     - name: Restore dependencies
-      run: dotnet restore --source ./LocalPackages
+      run: dotnet restore --source ./local_packages
 
     - name: Build Release
       run: dotnet build --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -91,12 +91,12 @@ jobs:
         dotnet-quality: 'ga'
 
     - name: Build Release Terminal.Gui
-      run: cd Terminal.Gui && dotnet build --configuration Release
+      run: dotnet build ../Terminal.Gui/Terminal.Gui.csproj --configuration Release
 
-    - name: Pack Release
+    - name: Pack Release Terminal.Gui
       run: dotnet pack Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ./local_packages
 
-    - name: Build Release
+    - name: Build Release Solution
       run: dotnet build --configuration Release
 
 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -90,8 +90,8 @@ jobs:
         dotnet-version: 8.x
         dotnet-quality: 'ga'
 
-    - name: Build Release
-      run: dotnet build --configuration Release
+    - name: Pack Releae
+      run: dotnet pack --configuration Release --output ./bin/Release
 
 
     # Note: this step is currently not writing to the gist for some reason

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -91,7 +91,7 @@ jobs:
         dotnet-quality: 'ga'
 
     - name: Pack Release
-      run: dotnet pack ./Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ./local_packages
+      run: dotnet pack ./Terminal.Gui.csproj --configuration Release --output ./local_packages
 
     - name: Build Release
       run: dotnet build --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -78,8 +78,8 @@ jobs:
   
 
   build_release:
-    # Ensure that RELEASE builds are not broken
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -90,11 +90,14 @@ jobs:
         dotnet-version: 8.x
         dotnet-quality: 'ga'
 
-    - name: Restore dependencies
-      run: dotnet restore
+    - name: Build local NuGet package
+      run: dotnet pack --configuration Release -o ./local_packages
 
-    - name: Build Release
-      run: dotnet build --configuration Release
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: local_nuget_package
+        path: ./local_packages/*.nupkg
 
 
     # Note: this step is currently not writing to the gist for some reason

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -91,7 +91,7 @@ jobs:
         dotnet-quality: 'ga'
 
     - name: Pack Release
-      run: dotnet pack ./Terminal.Gui.csproj --configuration Release --output ./local_packages
+      run: dotnet pack Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ./local_packages
 
     - name: Build Release
       run: dotnet build --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -90,8 +90,17 @@ jobs:
         dotnet-version: 8.x
         dotnet-quality: 'ga'
 
-    - name: Pack Releae
-      run: dotnet pack --configuration Release --output ./bin/Release
+    - name: Create LocalPackages Directory
+      run: mkdir -p LocalPackages
+
+    - name: Pack Release
+      run: dotnet pack --configuration Release --output ./LocalPackages
+
+    - name: Restore dependencies
+      run: dotnet restore --source ./LocalPackages
+
+    - name: Build Release
+      run: dotnet build --configuration Release
 
 
     # Note: this step is currently not writing to the gist for some reason

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -90,14 +90,8 @@ jobs:
         dotnet-version: 8.x
         dotnet-quality: 'ga'
 
-    - name: Create local_packages Directory
-      run: mkdir -p local_packages
-
     - name: Pack Release
-      run: dotnet pack --configuration Release --output ./local_packages
-
-    - name: Restore dependencies
-      run: dotnet restore --source ./local_packages
+      run: dotnet pack ./Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ./local_packages
 
     - name: Build Release
       run: dotnet build --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -99,6 +99,32 @@ jobs:
         name: local_nuget_package
         path: ./local_packages/*.nupkg
 
+  build_release_consumer:
+    runs-on: ubuntu-latest
+    needs: build_release
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.x
+        dotnet-quality: 'ga'
+
+    - name: Download package artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: local_nuget_package
+        path: ./local_packages
+
+    - name: Restore dependencies using downloaded package
+      run: dotnet restore --configfile nuget.config
+
+    - name: Build Release
+      run: dotnet build --configuration Release
+
 
     # Note: this step is currently not writing to the gist for some reason
     # - name: Create Test Coverage Badge

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -90,14 +90,8 @@ jobs:
         dotnet-version: 8.x
         dotnet-quality: 'ga'
 
-    - name: Build local NuGet package
-      run: dotnet pack --configuration Release -o ./local_packages
-
-    - name: Upload package artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: local_nuget_package
-        path: ./local_packages/*.nupkg
+    - name: Build Release
+      run: dotnet build --configuration Release
 
 
     # Note: this step is currently not writing to the gist for some reason

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -90,6 +90,9 @@ jobs:
         dotnet-version: 8.x
         dotnet-quality: 'ga'
 
+    - name: Restore dependencies
+      run: dotnet restore
+
     - name: Build Release
       run: dotnet build --configuration Release
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ demo.*
 *.tui/
 
 *.dotCover
+/local_packages/

--- a/NativeAot/NativeAot.csproj
+++ b/NativeAot/NativeAot.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PackageReference Include="Terminal.Gui" Version="[2.0.0-v2-develop.2189,3)" />
+    <PackageReference Include="Terminal.Gui" Version="2.0.0" />
     <TrimmerRootAssembly Include="Terminal.Gui" />
   </ItemGroup>
 

--- a/NativeAot/PackTerminalGui.ps1
+++ b/NativeAot/PackTerminalGui.ps1
@@ -1,0 +1,8 @@
+﻿# Step 1: Build and pack Terminal.Gui
+dotnet pack ../Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ../local_packages
+
+# Step 2: Restore NativeAot with the new package
+dotnet restore ./NativeAot.csproj --source ./local_packages
+
+# Step 3: Build NativeAot
+dotnet build ./NativeAot.csproj --configuration Release

--- a/NativeAot/PackTerminalGui.ps1
+++ b/NativeAot/PackTerminalGui.ps1
@@ -1,4 +1,5 @@
 ﻿# Step 1: Build and pack Terminal.Gui
+dotnet build ../Terminal.Gui/Terminal.Gui.csproj --configuration Release
 dotnet pack ../Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ../local_packages
 
 # Step 2: Restore NativeAot with the new package

--- a/NativeAot/PackTerminalGui.sh
+++ b/NativeAot/PackTerminalGui.sh
@@ -1,6 +1,7 @@
 ﻿#!/bin/bash
 
 # Step 1: Build and pack Terminal.Gui
+dotnet build ../Terminal.Gui/Terminal.Gui.csproj --configuration Release
 dotnet pack ../Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ../local_packages
 
 # Step 2: Restore NativeAot with the new package

--- a/NativeAot/PackTerminalGui.sh
+++ b/NativeAot/PackTerminalGui.sh
@@ -1,0 +1,10 @@
+﻿#!/bin/bash
+
+# Step 1: Build and pack Terminal.Gui
+dotnet pack ../Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ../local_packages
+
+# Step 2: Restore NativeAot with the new package
+dotnet restore ./NativeAot.csproj --source ./local_packages
+
+# Step 3: Build NativeAot
+dotnet build ./NativeAot.csproj --configuration Release

--- a/SelfContained/PackTerminalGui.ps1
+++ b/SelfContained/PackTerminalGui.ps1
@@ -1,4 +1,5 @@
 ﻿# Step 1: Build and pack Terminal.Gui
+dotnet build ../Terminal.Gui/Terminal.Gui.csproj --configuration Release
 dotnet pack ../Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ../local_packages
 
 # Step 2: Restore SelfContained with the new package

--- a/SelfContained/PackTerminalGui.ps1
+++ b/SelfContained/PackTerminalGui.ps1
@@ -1,0 +1,8 @@
+﻿# Step 1: Build and pack Terminal.Gui
+dotnet pack ../Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ../local_packages
+
+# Step 2: Restore SelfContained with the new package
+dotnet restore ./SelfContained.csproj --source ./local_packages
+
+# Step 3: Build SelfContained
+dotnet build ./SelfContained.csproj --configuration Release

--- a/SelfContained/PackTerminalGui.sh
+++ b/SelfContained/PackTerminalGui.sh
@@ -1,6 +1,7 @@
 ﻿#!/bin/bash
 
 # Step 1: Build and pack Terminal.Gui
+dotnet build ../Terminal.Gui/Terminal.Gui.csproj --configuration Release
 dotnet pack ../Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ../local_packages
 
 # Step 2: Restore SelfContained with the new package

--- a/SelfContained/PackTerminalGui.sh
+++ b/SelfContained/PackTerminalGui.sh
@@ -1,0 +1,10 @@
+﻿#!/bin/bash
+
+# Step 1: Build and pack Terminal.Gui
+dotnet pack ../Terminal.Gui/Terminal.Gui.csproj --configuration Release --output ../local_packages
+
+# Step 2: Restore SelfContained with the new package
+dotnet restore ./SelfContained.csproj --source ./local_packages
+
+# Step 3: Build SelfContained
+dotnet build ./SelfContained.csproj --configuration Release

--- a/SelfContained/SelfContained.csproj
+++ b/SelfContained/SelfContained.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PackageReference Include="Terminal.Gui" Version="[2.0.0-pre.1788,3)" />
+    <PackageReference Include="Terminal.Gui" Version="2.0.0" />
     <TrimmerRootAssembly Include="Terminal.Gui" />
   </ItemGroup>
 

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -60,7 +60,7 @@
     <!-- Enable Nuget Source Link for github -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[8,9)" PrivateAssets="all" />
     <PackageReference Include="System.IO.Abstractions" Version="[21.0.22,22)" />
-    <PackageReference Include="System.Text.Json" Version="[8.0.4,9)" />
+    <PackageReference Include="System.Text.Json" Version="[8.0.5,9)" />
     <PackageReference Include="Wcwidth" Version="[2,3)" />
   </ItemGroup>
   <!-- =================================================================== -->

--- a/nuget.config
+++ b/nuget.config
@@ -9,18 +9,14 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="LocalPackages" value="Terminal.Gui/bin/Release" />
-    <add key="local_packages" value="./local_packages" />
+    <add key="LocalPackages" value="./local_packages" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">
       <package pattern="*" />
     </packageSource>
 	<packageSource key="LocalPackages">
-	  <package pattern="Terminal.Gui" />
-	</packageSource>
-	<packageSource key="local_packages">
-       <package pattern="Terminal.Gui" />
+       <package pattern="Terminal.Gui*" />
 	</packageSource>
   </packageSourceMapping>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -9,6 +9,7 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="LocalPackages" value="Terminal.Gui\bin\Release" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">

--- a/nuget.config
+++ b/nuget.config
@@ -16,5 +16,11 @@
     <packageSource key="nuget">
       <package pattern="*" />
     </packageSource>
+	<packageSource key="LocalPackages">
+	 <package pattern="*" />
+	</packageSource>
+	<packageSource key="local_packages">
+	 <package pattern="*" />
+	</packageSource>
   </packageSourceMapping>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -10,7 +10,7 @@
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="LocalPackages" value="Terminal.Gui\bin\Release" />
-    <add key="local_packages" value="Terminal.Gui" />
+    <add key="local_packages" value="Terminal.Gui\local_packages" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">

--- a/nuget.config
+++ b/nuget.config
@@ -10,7 +10,6 @@
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="LocalPackages" value="Terminal.Gui\bin\Release" />
-    <add key="local_packages" value=".\local_packages" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">

--- a/nuget.config
+++ b/nuget.config
@@ -10,13 +10,17 @@
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="LocalPackages" value="Terminal.Gui/bin/Release" />
+    <add key="local_packages" value="./local_packages" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">
       <package pattern="*" />
     </packageSource>
 	<packageSource key="LocalPackages">
-	 <package pattern="Terminal.Gui" />
+	  <package pattern="Terminal.Gui" />
+	</packageSource>
+	<packageSource key="local_packages">
+       <package pattern="Terminal.Gui" />
 	</packageSource>
   </packageSourceMapping>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -10,6 +10,7 @@
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="LocalPackages" value="Terminal.Gui\bin\Release" />
+    <add key="local_packages" value="Terminal.Gui" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">

--- a/nuget.config
+++ b/nuget.config
@@ -10,7 +10,7 @@
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="LocalPackages" value="Terminal.Gui\bin\Release" />
-    <add key="local_packages" value="Terminal.Gui\local_packages" />
+    <add key="local_packages" value=".\local_packages" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">

--- a/nuget.config
+++ b/nuget.config
@@ -16,10 +16,7 @@
       <package pattern="*" />
     </packageSource>
 	<packageSource key="LocalPackages">
-	 <package pattern="*" />
-	</packageSource>
-	<packageSource key="local_packages">
-	 <package pattern="*" />
+	 <package pattern="Terminal.Gui" />
 	</packageSource>
   </packageSourceMapping>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -9,7 +9,7 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="LocalPackages" value="Terminal.Gui\bin\Release" />
+    <add key="LocalPackages" value="Terminal.Gui/bin/Release" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">


### PR DESCRIPTION
## Fixes

- Fixes #3784

## Proposed Changes/Todos

- [x] Provide local packages in release mode

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
