### PR TITLE
Adds Draw benchmarking support

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/ConsoleDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/ConsoleDriver.cs
@@ -335,7 +335,14 @@ public abstract class ConsoleDriver
                 _dirtyLines [row] = true;
             }
         }
+
+        ClearedContents?.Invoke (this, EventArgs.Empty);
     }
+
+    /// <summary>
+    ///     Raised each time <see cref="ClearContents"/> is called. For benchmarking.
+    /// </summary>
+    public event EventHandler<EventArgs>? ClearedContents;
 
     /// <summary>
     /// Sets <see cref="Contents"/> as dirty for situations where views
@@ -448,7 +455,18 @@ public abstract class ConsoleDriver
     public void OnSizeChanged (SizeChangedEventArgs args) { SizeChanged?.Invoke (this, args); }
 
     /// <summary>Updates the screen to reflect all the changes that have been done to the display buffer</summary>
-    public abstract void Refresh ();
+    public void Refresh ()
+    {
+        bool updated = UpdateScreen ();
+        UpdateCursor ();
+
+        Refreshed?.Invoke (this, new EventArgs<bool> (in updated));
+    }
+
+    /// <summary>
+    ///     Raised each time <see cref="Refresh"/> is called. For benchmarking.
+    /// </summary>
+    public event EventHandler<EventArgs<bool>>? Refreshed;
 
     /// <summary>Sets the terminal cursor visibility.</summary>
     /// <param name="visibility">The wished <see cref="CursorVisibility"/></param>
@@ -466,7 +484,8 @@ public abstract class ConsoleDriver
     public abstract void UpdateCursor ();
 
     /// <summary>Redraws the physical screen with the contents that have been queued up via any of the printing commands.</summary>
-    public abstract void UpdateScreen ();
+    /// <returns><see langword="true"/> if any updates to the screen were made.</returns>
+    public abstract bool UpdateScreen ();
 
     #region Setup & Teardown
 

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -105,12 +105,7 @@ internal class CursesDriver : ConsoleDriver
         }
     }
 
-    public override void Refresh ()
-    {
-        UpdateScreen ();
-        UpdateCursor ();
-    }
-
+    
     public override void SendKeys (char keyChar, ConsoleKey consoleKey, bool shift, bool alt, bool control)
     {
         KeyCode key;
@@ -228,8 +223,9 @@ internal class CursesDriver : ConsoleDriver
         }
     }
 
-    public override void UpdateScreen ()
+    public override bool UpdateScreen ()
     {
+        bool updated = false;
         if (Force16Colors)
         {
             for (var row = 0; row < Rows; row++)
@@ -297,7 +293,7 @@ internal class CursesDriver : ConsoleDriver
                 || Contents.Length != Rows * Cols
                 || Rows != Console.WindowHeight)
             {
-                return;
+                return updated;
             }
 
             var top = 0;
@@ -315,7 +311,7 @@ internal class CursesDriver : ConsoleDriver
             {
                 if (Console.WindowHeight < 1)
                 {
-                    return;
+                    return updated;
                 }
 
                 if (!_dirtyLines [row])
@@ -325,7 +321,7 @@ internal class CursesDriver : ConsoleDriver
 
                 if (!SetCursorPosition (0, row))
                 {
-                    return;
+                    return updated;
                 }
 
                 _dirtyLines [row] = false;
@@ -338,6 +334,7 @@ internal class CursesDriver : ConsoleDriver
 
                     for (; col < cols; col++)
                     {
+                        updated = true;
                         if (!Contents [row, col].IsDirty)
                         {
                             if (output.Length > 0)
@@ -433,6 +430,8 @@ internal class CursesDriver : ConsoleDriver
                 outputWidth = 0;
             }
         }
+
+        return updated;
     }
 
     private bool SetCursorPosition (int col, int row)

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -101,8 +101,10 @@ public class FakeDriver : ConsoleDriver
         return new MainLoop (_mainLoopDriver);
     }
 
-    public override void UpdateScreen ()
+    public override bool UpdateScreen ()
     {
+        bool updated = false;
+
         int savedRow = FakeConsole.CursorTop;
         int savedCol = FakeConsole.CursorLeft;
         bool savedCursorVisible = FakeConsole.CursorVisible;
@@ -121,6 +123,8 @@ public class FakeDriver : ConsoleDriver
             {
                 continue;
             }
+
+            updated = true;
 
             FakeConsole.CursorTop = row;
             FakeConsole.CursorLeft = 0;
@@ -218,13 +222,9 @@ public class FakeDriver : ConsoleDriver
         FakeConsole.CursorTop = savedRow;
         FakeConsole.CursorLeft = savedCol;
         FakeConsole.CursorVisible = savedCursorVisible;
+        return updated;
     }
 
-    public override void Refresh ()
-    {
-        UpdateScreen ();
-        UpdateCursor ();
-    }
 
     #region Color Handling
 

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -823,12 +823,6 @@ internal class NetDriver : ConsoleDriver
     public override bool SupportsTrueColor => Environment.OSVersion.Platform == PlatformID.Unix
                                               || (IsWinPlatform && Environment.OSVersion.Version.Build >= 14931);
 
-    public override void Refresh ()
-    {
-        UpdateScreen ();
-        UpdateCursor ();
-    }
-
     public override void SendKeys (char keyChar, ConsoleKey key, bool shift, bool alt, bool control)
     {
         var input = new InputResult
@@ -876,15 +870,16 @@ internal class NetDriver : ConsoleDriver
         StartReportingMouseMoves ();
     }
 
-    public override void UpdateScreen ()
+    public override bool UpdateScreen ()
     {
+        bool updated = false;
         if (RunningUnitTests
             || _winSizeChanging
             || Console.WindowHeight < 1
             || Contents.Length != Rows * Cols
             || Rows != Console.WindowHeight)
         {
-            return;
+            return updated;
         }
 
         var top = 0;
@@ -902,7 +897,7 @@ internal class NetDriver : ConsoleDriver
         {
             if (Console.WindowHeight < 1)
             {
-                return;
+                return updated;
             }
 
             if (!_dirtyLines [row])
@@ -912,9 +907,10 @@ internal class NetDriver : ConsoleDriver
 
             if (!SetCursorPosition (0, row))
             {
-                return;
+                return updated;
             }
 
+            updated = true;
             _dirtyLines [row] = false;
             output.Clear ();
 
@@ -1034,6 +1030,8 @@ internal class NetDriver : ConsoleDriver
             lastCol += outputWidth;
             outputWidth = 0;
         }
+
+        return updated;
     }
 
     internal override void End ()

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1085,13 +1085,6 @@ internal class WindowsDriver : ConsoleDriver
 
     public override bool IsRuneSupported (Rune rune) { return base.IsRuneSupported (rune) && rune.IsBmp; }
 
-    public override void Refresh ()
-    {
-        UpdateScreen ();
-        //WinConsole?.SetInitialCursorVisibility ();
-        UpdateCursor ();
-    }
-
     public override void SendKeys (char keyChar, ConsoleKey key, bool shift, bool alt, bool control)
     {
         var input = new WindowsConsole.InputRecord
@@ -1284,13 +1277,14 @@ internal class WindowsDriver : ConsoleDriver
 
     #endregion Cursor Handling
 
-    public override void UpdateScreen ()
+    public override bool UpdateScreen ()
     {
+        bool updated = false;
         Size windowSize = WinConsole?.GetConsoleBufferWindow (out Point _) ?? new Size (Cols, Rows);
 
         if (!windowSize.IsEmpty && (windowSize.Width != Cols || windowSize.Height != Rows))
         {
-            return;
+            return updated;
         }
 
         var bufferCoords = new WindowsConsole.Coord
@@ -1307,6 +1301,7 @@ internal class WindowsDriver : ConsoleDriver
             }
 
             _dirtyLines [row] = false;
+            updated = true;
 
             for (var col = 0; col < Cols; col++)
             {
@@ -1365,6 +1360,8 @@ internal class WindowsDriver : ConsoleDriver
         }
 
         WindowsConsole.SmallRect.MakeEmpty (ref _damageRegion);
+
+        return updated;
     }
 
     internal override void End ()

--- a/UICatalog/Scenarios/AllViewsTester.cs
+++ b/UICatalog/Scenarios/AllViewsTester.cs
@@ -15,47 +15,31 @@ namespace UICatalog.Scenarios;
 [ScenarioCategory ("Adornments")]
 public class AllViewsTester : Scenario
 {
-    private readonly List<string> _dimNames = new () { "Auto", "Percent", "Fill", "Absolute" };
 
-    // TODO: This is missing some
-    private readonly List<string> _posNames = new () { "Percent", "AnchorEnd", "Center", "Absolute" };
-    private ListView _classListView;
-    private View _curView;
-    private FrameView _hostPane;
-    private AdornmentsEditor _adornmentsEditor;
-    private RadioGroup _hRadioGroup;
-    private TextField _hText;
-    private int _hVal;
-    private FrameView _leftPane;
-    private FrameView _locationFrame;
-
-    // Settings
-    private FrameView _settingsPane;
-    private FrameView _sizeFrame;
     private Dictionary<string, Type> _viewClasses;
-    private RadioGroup _wRadioGroup;
-    private TextField _wText;
-    private int _wVal;
-    private RadioGroup _xRadioGroup;
-    private TextField _xText;
-    private int _xVal;
-    private RadioGroup _yRadioGroup;
-    private TextField _yText;
-    private int _yVal;
+    private ListView _classListView;
+    private AdornmentsEditor _adornmentsEditor;
+
+    private LayoutEditor _layoutEditor;
+    private FrameView _settingsPane;
     private RadioGroup _orientation;
     private string _demoText = "This, that, and the other thing.";
     private TextView _demoTextView;
+
+    private FrameView _hostPane;
+    private View _curView;
+    private EventLog _eventLog;
 
     public override void Main ()
     {
         // Don't create a sub-win (Scenario.Win); just use Application.Top
         Application.Init ();
-   //     ConfigurationManager.Apply ();
 
         var app = new Window
         {
             Title = GetQuitKeyAndName (),
-            ColorScheme = Colors.ColorSchemes ["TopLevel"]
+            ColorScheme = Colors.ColorSchemes ["TopLevel"],
+            BorderStyle = LineStyle.None
         };
 
         _viewClasses = GetAllViewClassesCollection ()
@@ -63,19 +47,9 @@ public class AllViewsTester : Scenario
                        .Select (t => new KeyValuePair<string, Type> (t.Name, t))
                        .ToDictionary (t => t.Key, t => t.Value);
 
-        _leftPane = new ()
-        {
-            X = 0,
-            Y = 0,
-            Width = Dim.Auto (DimAutoStyle.Content),
-            Height = Dim.Fill (),
-            CanFocus = true,
-            ColorScheme = Colors.ColorSchemes ["TopLevel"],
-            Title = "Classes"
-        };
-
         _classListView = new ()
         {
+            Title = "Classes [_1]",
             X = 0,
             Y = 0,
             Width = Dim.Auto (),
@@ -83,7 +57,8 @@ public class AllViewsTester : Scenario
             AllowsMarking = false,
             ColorScheme = Colors.ColorSchemes ["TopLevel"],
             SelectedItem = 0,
-            Source = new ListWrapper<string> (new (_viewClasses.Keys.ToList ()))
+            Source = new ListWrapper<string> (new (_viewClasses.Keys.ToList ())),
+            BorderStyle = LineStyle.Rounded
         };
 
         _classListView.SelectedItemChanged += (s, args) =>
@@ -101,17 +76,23 @@ public class AllViewsTester : Scenario
                                                       _adornmentsEditor.ViewToEdit = _curView;
                                                   }
                                               };
-        _leftPane.Add (_classListView);
+
+        _classListView.Accepting += (sender, args) =>
+                                    {
+                                        _curView.SetFocus ();
+                                        args.Cancel = true;
+                                    };
 
         _adornmentsEditor = new ()
         {
-            X = Pos.Right (_leftPane),
+            Title = "Adornments [_2]",
+            X = Pos.Right (_classListView),
             Y = 0,
             Width = Dim.Auto (),
             Height = Dim.Fill (),
             ColorScheme = Colors.ColorSchemes ["TopLevel"],
             BorderStyle = LineStyle.Single,
-            AutoSelectViewToEdit = true,
+            AutoSelectViewToEdit = false,
             AutoSelectAdornments = false,
         };
 
@@ -122,150 +103,31 @@ public class AllViewsTester : Scenario
         };
         _adornmentsEditor.Border.Add (expandButton);
 
-        _settingsPane = new ()
+        _layoutEditor = new ()
         {
+            Title = "Layout [_3]",
             X = Pos.Right (_adornmentsEditor),
-            Y = 0, // for menu
-            Width = Dim.Fill (),
+            Y = 0,
+            //Width = Dim.Fill (), // set below
             Height = Dim.Auto (),
             CanFocus = true,
             ColorScheme = Colors.ColorSchemes ["TopLevel"],
-            Title = "Settings"
+            BorderStyle = LineStyle.Rounded
         };
 
-        string [] radioItems = { "_Percent(x)", "_AnchorEnd", "_Center", "A_bsolute(x)" };
-
-        _locationFrame = new ()
+        _settingsPane = new ()
         {
-            X = 0,
-            Y = 0,
+            Title = "Settings [_4]",
+            X = Pos.Right (_adornmentsEditor),
+            Y = Pos.Bottom (_layoutEditor),
+            Width = Dim.Width(_layoutEditor),
             Height = Dim.Auto (),
-            Width = Dim.Auto (),
-            Title = "Location (Pos)",
-            TabStop = TabBehavior.TabStop,
-        };
-        _settingsPane.Add (_locationFrame);
-
-        var label = new Label { X = 0, Y = 0, Text = "X:" };
-        _locationFrame.Add (label);
-        _xRadioGroup = new () { X = 0, Y = Pos.Bottom (label), RadioLabels = radioItems };
-        _xRadioGroup.SelectedItemChanged += OnRadioGroupOnSelectedItemChanged;
-        _xText = new () { X = Pos.Right (label) + 1, Y = 0, Width = 4, Text = $"{_xVal}" };
-
-        _xText.Accepting += (s, args) =>
-                         {
-                             try
-                             {
-                                 _xVal = int.Parse (_xText.Text);
-                                 DimPosChanged (_curView);
-                             }
-                             catch
-                             { }
-                         };
-        _locationFrame.Add (_xText);
-
-        _locationFrame.Add (_xRadioGroup);
-
-        radioItems = new [] { "P_ercent(y)", "A_nchorEnd", "C_enter", "Absolute(_y)" };
-        label = new () { X = Pos.Right (_xRadioGroup) + 1, Y = 0, Text = "Y:" };
-        _locationFrame.Add (label);
-        _yText = new () { X = Pos.Right (label) + 1, Y = 0, Width = 4, Text = $"{_yVal}" };
-
-        _yText.Accepting += (s, args) =>
-                         {
-                             try
-                             {
-                                 _yVal = int.Parse (_yText.Text);
-                                 DimPosChanged (_curView);
-                             }
-                             catch
-                             { }
-                         };
-        _locationFrame.Add (_yText);
-        _yRadioGroup = new () { X = Pos.X (label), Y = Pos.Bottom (label), RadioLabels = radioItems };
-        _yRadioGroup.SelectedItemChanged += OnRadioGroupOnSelectedItemChanged;
-        _locationFrame.Add (_yRadioGroup);
-
-        _sizeFrame = new ()
-        {
-            X = Pos.Right (_locationFrame),
-            Y = Pos.Y (_locationFrame),
-            Height = Dim.Auto (),
-            Width = Dim.Auto (),
-            Title = "Size (Dim)",
-            TabStop = TabBehavior.TabStop,
+            CanFocus = true,
+            ColorScheme = Colors.ColorSchemes ["TopLevel"],
+            BorderStyle = LineStyle.Rounded
         };
 
-        radioItems = new [] { "Auto", "_Percent(width)", "_Fill(width)", "A_bsolute(width)" };
-        label = new () { X = 0, Y = 0, Text = "Width:" };
-        _sizeFrame.Add (label);
-        _wRadioGroup = new () { X = 0, Y = Pos.Bottom (label), RadioLabels = radioItems };
-        _wRadioGroup.SelectedItemChanged += OnRadioGroupOnSelectedItemChanged;
-        _wText = new () { X = Pos.Right (label) + 1, Y = 0, Width = 4, Text = $"{_wVal}" };
-
-        _wText.Accepting += (s, args) =>
-                         {
-                             try
-                             {
-                                 switch (_wRadioGroup.SelectedItem)
-                                 {
-                                     case 1:
-                                         _wVal = Math.Min (int.Parse (_wText.Text), 100);
-
-                                         break;
-                                     case 0:
-                                     case 2:
-                                     case 3:
-                                         _wVal = int.Parse (_wText.Text);
-
-                                         break;
-                                 }
-
-                                 DimPosChanged (_curView);
-                             }
-                             catch
-                             { }
-                         };
-        _sizeFrame.Add (_wText);
-        _sizeFrame.Add (_wRadioGroup);
-
-        radioItems = new [] { "_Auto", "P_ercent(height)", "F_ill(height)", "Ab_solute(height)" };
-        label = new () { X = Pos.Right (_wRadioGroup) + 1, Y = 0, Text = "Height:" };
-        _sizeFrame.Add (label);
-        _hText = new () { X = Pos.Right (label) + 1, Y = 0, Width = 4, Text = $"{_hVal}" };
-
-        _hText.Accepting += (s, args) =>
-                         {
-                             try
-                             {
-                                 switch (_hRadioGroup.SelectedItem)
-                                 {
-                                     case 1:
-                                         _hVal = Math.Min (int.Parse (_hText.Text), 100);
-
-                                         break;
-                                     case 0:
-                                     case 2:
-                                     case 3:
-                                         _hVal = int.Parse (_hText.Text);
-
-                                         break;
-                                 }
-
-                                 DimPosChanged (_curView);
-                             }
-                             catch
-                             { }
-                         };
-        _sizeFrame.Add (_hText);
-
-        _hRadioGroup = new () { X = Pos.X (label), Y = Pos.Bottom (label), RadioLabels = radioItems };
-        _hRadioGroup.SelectedItemChanged += OnRadioGroupOnSelectedItemChanged;
-        _sizeFrame.Add (_hRadioGroup);
-
-        _settingsPane.Add (_sizeFrame);
-
-        label = new () { X = 0, Y = Pos.Bottom (_sizeFrame), Text = "_Orientation:" };
+        Label label = new () { X = 0, Y = 0, Text = "_Orientation:" };
 
         _orientation = new ()
         {
@@ -307,38 +169,65 @@ public class AllViewsTester : Scenario
 
         _settingsPane.Add (label, _demoTextView);
 
+        _eventLog = new EventLog ()
+        {
+           // X = Pos.Right(_layoutEditor)
+        };
+        _eventLog.X = Pos.AnchorEnd ();
+        _eventLog.Y = 0;
+
+        _eventLog.Height = Dim.Height (_classListView);
+        //_eventLog.Width = 30;
+
+        _layoutEditor.Width = Dim.Fill (Dim.Func ((() =>
+                                                   {
+                                                       //if (_eventLog.NeedsLayout)
+                                                       //{
+                                                       //    // We have two choices:
+                                                       //    // 1) Call Layout explicitly
+                                                       //    // 2) Throw LayoutException so Layout tries again
+                                                       //    _eventLog.Layout ();
+                                                       //    //throw new LayoutException ("_eventLog");
+                                                       //}
+                                                       return _eventLog.Frame.Width;
+                                                   })));
+
         _hostPane = new ()
         {
             X = Pos.Right (_adornmentsEditor),
             Y = Pos.Bottom (_settingsPane),
-            Width = Dim.Fill (),
-            Height = Dim.Fill (), // + 1 for status bar
+            Width = Dim.Width (_layoutEditor),
+            Height = Dim.Fill (),
             CanFocus = true,
-            TabStop = TabBehavior.TabGroup,
-            ColorScheme = Colors.ColorSchemes ["Dialog"]
+            TabStop = TabBehavior.TabStop,
+            ColorScheme = Colors.ColorSchemes ["Base"],
+            Arrangement = ViewArrangement.Resizable,
+            BorderStyle = LineStyle.RoundedDotted
         };
+        _hostPane.Border.ColorScheme = app.ColorScheme;
+        _hostPane.Padding.Thickness = new (1);
+        //_hostPane.Padding.Diagnostics = ViewDiagnosticFlags.Ruler;
+        _hostPane.Padding.ColorScheme = app.ColorScheme;
 
-        _hostPane.LayoutStarted += (sender, args) =>
-                                   {
+        app.Add (_classListView, _adornmentsEditor, _layoutEditor, _settingsPane, _eventLog, _hostPane);
 
-                                   };
-
-        app.Add (_leftPane, _adornmentsEditor, _settingsPane, _hostPane);
-
-        _classListView.SelectedItem = 0;
-        _leftPane.SetFocus ();
+        app.Initialized += App_Initialized;
 
         Application.Run (app);
         app.Dispose ();
         Application.Shutdown ();
     }
 
-    private void OnRadioGroupOnSelectedItemChanged (object s, SelectedItemChangedArgs selected) { DimPosChanged (_curView); }
+    private void App_Initialized (object sender, EventArgs e)
+    {
+        _classListView.SelectedItem = 0;
+        _classListView.SetFocus ();
+    }
 
     // TODO: Add Command.HotKey handler (pop a message box?)
     private void CreateCurrentView (Type type)
     {
-        Debug.Assert(_curView is null);
+        Debug.Assert (_curView is null);
 
         // If we are to create a generic Type
         if (type.IsGenericType)
@@ -358,7 +247,6 @@ public class AllViewsTester : Scenario
 
         // Instantiate view
         var view = (View)Activator.CreateInstance (type);
-
         if (view is IDesignable designable)
         {
             designable.EnableForDesign (ref _demoText);
@@ -382,9 +270,13 @@ public class AllViewsTester : Scenario
         view.Initialized += CurrentView_Initialized;
         view.LayoutComplete += CurrentView_LayoutComplete;
 
+        view.Id = "_curView";
         _curView = view;
+
+        _eventLog.ViewToLog = _curView;
         _hostPane.Add (_curView);
-       // Application.Refresh();
+        _layoutEditor.ViewToEdit = _curView;
+        //_curView.SetNeedsLayout ();
     }
 
     private void DisposeCurrentView ()
@@ -394,87 +286,14 @@ public class AllViewsTester : Scenario
             _curView.Initialized -= CurrentView_Initialized;
             _curView.LayoutComplete -= CurrentView_LayoutComplete;
             _hostPane.Remove (_curView);
+            _layoutEditor.ViewToEdit = null;
+
             _curView.Dispose ();
             _curView = null;
         }
     }
 
-    private void DimPosChanged (View view)
-    {
-        if (view == null || _updatingSettings)
-        {
-            return;
-        }
-
-        try
-        {
-            view.X = _xRadioGroup.SelectedItem switch
-            {
-                0 => Pos.Percent (_xVal),
-                1 => Pos.AnchorEnd (),
-                2 => Pos.Center (),
-                3 => Pos.Absolute (_xVal),
-                _ => view.X
-            };
-
-            view.Y = _yRadioGroup.SelectedItem switch
-            {
-                0 => Pos.Percent (_yVal),
-                1 => Pos.AnchorEnd (),
-                2 => Pos.Center (),
-                3 => Pos.Absolute (_yVal),
-                _ => view.Y
-            };
-
-            view.Width = _wRadioGroup.SelectedItem switch
-            {
-                0 => Dim.Auto (),
-                1 => Dim.Percent (_wVal),
-                2 => Dim.Fill (_wVal),
-                3 => Dim.Absolute (_wVal),
-                _ => view.Width
-            };
-
-            view.Height = _hRadioGroup.SelectedItem switch
-            {
-                0 => Dim.Auto (),
-                1 => Dim.Percent (_hVal),
-                2 => Dim.Fill (_hVal),
-                3 => Dim.Absolute (_hVal),
-                _ => view.Height
-            };
-        }
-        catch (Exception e)
-        {
-            MessageBox.ErrorQuery ("Exception", e.Message, "Ok");
-        }
-
-        if (view.Width is DimAuto)
-        {
-            _wText.Text = "Auto";
-            _wText.Enabled = false;
-        }
-        else
-        {
-            _wText.Text = $"{_wVal}";
-            _wText.Enabled = true;
-        }
-
-        if (view.Height is DimAuto)
-        {
-            _hText.Text = "Auto";
-            _hText.Enabled = false;
-        }
-        else
-        {
-            _hText.Text = $"{_hVal}";
-            _hText.Enabled = true;
-        }
-
-        UpdateHostTitle (view);
-    }
-
-    private List<Type> GetAllViewClassesCollection ()
+    private static List<Type> GetAllViewClassesCollection ()
     {
         List<Type> types = new ();
 
@@ -494,62 +313,10 @@ public class AllViewsTester : Scenario
 
     private void CurrentView_LayoutComplete (object sender, LayoutEventArgs args)
     {
-        UpdateSettings (_curView);
         UpdateHostTitle (_curView);
     }
 
-    private bool _updatingSettings = false;
-    private void UpdateSettings (View view)
-    {
-        _updatingSettings = true;
-        var x = view.X.ToString ();
-        var y = view.Y.ToString ();
-
-        try
-        {
-            _xRadioGroup.SelectedItem = _posNames.IndexOf (_posNames.First (s => x.Contains (s)));
-            _yRadioGroup.SelectedItem = _posNames.IndexOf (_posNames.First (s => y.Contains (s)));
-        }
-        catch (InvalidOperationException e)
-        {
-            // This is a hack to work around the fact that the Pos enum doesn't have an "Align" value yet
-            Debug.WriteLine ($"{e}");
-        }
-
-        _xText.Text = $"{view.Frame.X}";
-        _yText.Text = $"{view.Frame.Y}";
-
-        var w = view.Width.ToString ();
-        var h = view.Height.ToString ();
-        _wRadioGroup.SelectedItem = _dimNames.IndexOf (_dimNames.First (s => w.Contains (s)));
-        _hRadioGroup.SelectedItem = _dimNames.IndexOf (_dimNames.First (s => h.Contains (s)));
-
-        if (view.Width.Has<DimAuto> (out _))
-        {
-            _wText.Text = "Auto";
-            _wText.Enabled = false;
-        }
-        else
-        {
-            _wText.Text = $"{view.Frame.Width}";
-            _wText.Enabled = true;
-        }
-
-        if (view.Height.Has<DimAuto> (out _))
-        {
-            _hText.Text = "Auto";
-            _hText.Enabled = false;
-        }
-        else
-        {
-            _hText.Text = $"{view.Frame.Height}";
-            _hText.Enabled = true;
-        }
-
-        _updatingSettings = false;
-    }
-
-    private void UpdateHostTitle (View view) { _hostPane.Title = $"_Demo of {view.GetType ().Name}"; }
+    private void UpdateHostTitle (View view) { _hostPane.Title = $"{view.GetType ().Name} [_0]"; }
 
     private void CurrentView_Initialized (object sender, EventArgs e)
     {
@@ -558,17 +325,15 @@ public class AllViewsTester : Scenario
             return;
         }
 
-        if (!view.Width!.Has<DimAuto> (out _) || (view.Width is null || view.Frame.Width == 0))
+        if (!view.Width!.Has<DimAuto> (out _) || (view.Width is null))
         {
             view.Width = Dim.Fill ();
         }
 
-        if (!view.Height!.Has<DimAuto> (out _) || (view.Height is null || view.Frame.Height == 0))
+        if (!view.Height!.Has<DimAuto> (out _) || (view.Height is null))
         {
             view.Height = Dim.Fill ();
         }
-
-        UpdateSettings (view);
 
         UpdateHostTitle (view);
     }

--- a/UICatalog/Scenarios/Editors/AdornmentEditor.cs
+++ b/UICatalog/Scenarios/Editors/AdornmentEditor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Terminal.Gui;
 
 namespace UICatalog.Scenarios;
@@ -15,7 +16,6 @@ public class AdornmentEditor : View
         BoxHeight = 1,
         BorderStyle = LineStyle.Single,
         SuperViewRendersLineCanvas = true,
-        Enabled = false
     };
 
     private readonly ColorPicker16 _foregroundColorPicker = new ()
@@ -25,11 +25,15 @@ public class AdornmentEditor : View
         BoxHeight = 1,
         BorderStyle = LineStyle.Single,
         SuperViewRendersLineCanvas = true,
-        Enabled = false
     };
 
-    private Adornment _adornment;
-    public Adornment AdornmentToEdit
+
+    private CheckBox? _diagThicknessCheckBox;
+    private CheckBox? _diagRulerCheckBox;
+
+
+    private Adornment? _adornment;
+    public Adornment? AdornmentToEdit
     {
         get => _adornment;
         set
@@ -41,10 +45,7 @@ public class AdornmentEditor : View
 
             _adornment = value;
 
-            foreach (var subview in Subviews)
-            {
-                subview.Enabled = _adornment is { };
-            }
+            Enabled = _adornment is { };
 
             if (_adornment is null)
             {
@@ -53,10 +54,10 @@ public class AdornmentEditor : View
 
             if (IsInitialized)
             {
-                _topEdit.Value = _adornment.Thickness.Top;
-                _leftEdit.Value = _adornment.Thickness.Left;
-                _bottomEdit.Value = _adornment.Thickness.Bottom;
-                _rightEdit.Value = _adornment.Thickness.Right;
+                _topEdit!.Value = _adornment.Thickness.Top;
+                _leftEdit!.Value = _adornment.Thickness.Left;
+                _bottomEdit!.Value = _adornment.Thickness.Bottom;
+                _rightEdit!.Value = _adornment.Thickness.Right;
 
                 _adornment.Initialized += (sender, args) =>
                                           {
@@ -71,17 +72,17 @@ public class AdornmentEditor : View
         }
     }
 
-    public event EventHandler<EventArgs> AdornmentChanged;
+    public event EventHandler<EventArgs>? AdornmentChanged;
 
     public void OnAdornmentChanged ()
     {
         AdornmentChanged?.Invoke (this, EventArgs.Empty);
     }
 
-    private NumericUpDown<int> _topEdit;
-    private NumericUpDown<int> _leftEdit;
-    private NumericUpDown<int> _bottomEdit;
-    private NumericUpDown<int> _rightEdit;
+    private NumericUpDown<int>? _topEdit;
+    private NumericUpDown<int>? _leftEdit;
+    private NumericUpDown<int>? _bottomEdit;
+    private NumericUpDown<int>? _rightEdit;
 
     public AdornmentEditor ()
     {
@@ -95,16 +96,15 @@ public class AdornmentEditor : View
         TabStop = TabBehavior.TabStop;
     }
 
-    private void AdornmentEditor_Initialized (object sender, EventArgs e)
+    private void AdornmentEditor_Initialized (object? sender, EventArgs e)
     {
-        ExpanderButton expandButton;
+        ExpanderButton? expandButton;
         Border.Add (expandButton = new ExpanderButton ());
 
         _topEdit = new ()
         {
             X = Pos.Center (), Y = 0,
             Format = "{0, 2}",
-            Enabled = false
         };
 
         _topEdit.ValueChanging += Top_ValueChanging;
@@ -114,7 +114,6 @@ public class AdornmentEditor : View
         {
             X = Pos.Left (_topEdit) - Pos.Func (() => _topEdit.Text.Length) - 2, Y = Pos.Bottom (_topEdit),
             Format = _topEdit.Format,
-            Enabled = false
         };
 
         _leftEdit.ValueChanging += Left_ValueChanging;
@@ -124,7 +123,6 @@ public class AdornmentEditor : View
         {
             X = Pos.Right (_leftEdit) + 5, Y = Pos.Bottom (_topEdit),
             Format = _topEdit.Format,
-            Enabled = false
         };
 
         _rightEdit.ValueChanging += Right_ValueChanging;
@@ -134,7 +132,6 @@ public class AdornmentEditor : View
         {
             X = Pos.Center (), Y = Pos.Bottom (_leftEdit),
             Format = _topEdit.Format,
-            Enabled = false
         };
 
         _bottomEdit.ValueChanging += Bottom_ValueChanging;
@@ -143,12 +140,11 @@ public class AdornmentEditor : View
         var copyTop = new Button
         {
             X = Pos.Center (), Y = Pos.Bottom (_bottomEdit), Text = "Cop_y Top",
-            Enabled = false
         };
 
         copyTop.Accepting += (s, e) =>
                           {
-                              AdornmentToEdit.Thickness = new (_topEdit.Value);
+                              AdornmentToEdit!.Thickness = new (_topEdit.Value);
                               _leftEdit.Value = _rightEdit.Value = _bottomEdit.Value = _topEdit.Value;
                           };
         Add (copyTop);
@@ -172,10 +168,55 @@ public class AdornmentEditor : View
         _rightEdit.Value = AdornmentToEdit?.Thickness.Right ?? 0;
         _bottomEdit.Value = AdornmentToEdit?.Thickness.Bottom ?? 0;
 
-        foreach (var subview in Subviews)
-        {
-            subview.Enabled = AdornmentToEdit is { };
-        }
+        _diagThicknessCheckBox = new () { Text = "_Thickness Diag." };
+        //if (AdornmentToEdit is { })
+        //{
+        //    _diagThicknessCheckBox.CheckedState = AdornmentToEdit.Diagnostics.FastHasFlags (ViewDiagnosticFlags.Thickness) ? CheckState.Checked : CheckState.UnChecked;
+        //}
+        //else
+        //{
+        //    _diagThicknessCheckBox.CheckedState = Diagnostics.FastHasFlags (ViewDiagnosticFlags.Thickness) ? CheckState.Checked : CheckState.UnChecked;
+        //}
+
+        //_diagThicknessCheckBox.CheckedStateChanging += (s, e) =>
+        //                                             {
+        //                                                 if (e.NewValue == CheckState.Checked)
+        //                                                 {
+        //                                                     AdornmentToEdit!.Diagnostics |= ViewDiagnosticFlags.Thickness;
+        //                                                 }
+        //                                                 else
+        //                                                 {
+        //                                                     AdornmentToEdit!.Diagnostics &= ~ViewDiagnosticFlags.Thickness;
+        //                                                 }
+        //                                             };
+
+        Add (_diagThicknessCheckBox);
+        _diagThicknessCheckBox.Y = Pos.Bottom (_backgroundColorPicker);
+
+        _diagRulerCheckBox = new () { Text = "_Ruler" };
+        //if (AdornmentToEdit is { })
+        //{
+        //    _diagRulerCheckBox.CheckedState = AdornmentToEdit.Diagnostics.FastHasFlags (ViewDiagnosticFlags.Ruler) ? CheckState.Checked : CheckState.UnChecked;
+        //}
+        //else
+        //{
+        //    _diagRulerCheckBox.CheckedState = Diagnostics.FastHasFlags (ViewDiagnosticFlags.Ruler) ? CheckState.Checked : CheckState.UnChecked;
+        //}
+
+        //_diagRulerCheckBox.CheckedStateChanging += (s, e) =>
+        //                                           {
+        //                                               if (e.NewValue == CheckState.Checked)
+        //                                               {
+        //                                                   AdornmentToEdit!.Diagnostics |= ViewDiagnosticFlags.Ruler;
+        //                                               }
+        //                                               else
+        //                                               {
+        //                                                   AdornmentToEdit!.Diagnostics &= ~ViewDiagnosticFlags.Ruler;
+        //                                               }
+        //                                           };
+
+        Add (_diagRulerCheckBox);
+        _diagRulerCheckBox.Y = Pos.Bottom (_diagThicknessCheckBox);
     }
 
     private EventHandler<ColorEventArgs> ColorPickerColorChanged ()
@@ -193,7 +234,7 @@ public class AdornmentEditor : View
                };
     }
 
-    private void Top_ValueChanging (object sender, CancelEventArgs<int> e)
+    private void Top_ValueChanging (object? sender, CancelEventArgs<int> e)
     {
         if (e.NewValue < 0 || AdornmentToEdit is null)
         {
@@ -205,7 +246,7 @@ public class AdornmentEditor : View
         AdornmentToEdit.Thickness = new (AdornmentToEdit.Thickness.Left, e.NewValue, AdornmentToEdit.Thickness.Right, AdornmentToEdit.Thickness.Bottom);
     }
 
-    private void Left_ValueChanging (object sender, CancelEventArgs<int> e)
+    private void Left_ValueChanging (object? sender, CancelEventArgs<int> e)
     {
         if (e.NewValue < 0 || AdornmentToEdit is null)
         {
@@ -217,7 +258,7 @@ public class AdornmentEditor : View
         AdornmentToEdit.Thickness = new (e.NewValue, AdornmentToEdit.Thickness.Top, AdornmentToEdit.Thickness.Right, AdornmentToEdit.Thickness.Bottom);
     }
 
-    private void Right_ValueChanging (object sender, CancelEventArgs<int> e)
+    private void Right_ValueChanging (object? sender, CancelEventArgs<int> e)
     {
         if (e.NewValue < 0 || AdornmentToEdit is null)
         {
@@ -229,7 +270,7 @@ public class AdornmentEditor : View
         AdornmentToEdit.Thickness = new (AdornmentToEdit.Thickness.Left, AdornmentToEdit.Thickness.Top, e.NewValue, AdornmentToEdit.Thickness.Bottom);
     }
 
-    private void Bottom_ValueChanging (object sender, CancelEventArgs<int> e)
+    private void Bottom_ValueChanging (object? sender, CancelEventArgs<int> e)
     {
         if (e.NewValue < 0 || AdornmentToEdit is null)
         {

--- a/UICatalog/Scenarios/Editors/ArrangementEditor.cs
+++ b/UICatalog/Scenarios/Editors/ArrangementEditor.cs
@@ -24,43 +24,45 @@ public sealed class ArrangementEditor : View
 
         Initialized += ArrangementEditor_Initialized;
 
-        _arrangementSlider.Options = new List<SliderOption<ViewArrangement>> ();
+        _arrangementSlider.Options =
+        [
+            new SliderOption<ViewArrangement>
+            {
+                Legend = ViewArrangement.Movable.ToString (),
+                Data = ViewArrangement.Movable
+            },
 
-        _arrangementSlider.Options.Add (new SliderOption<ViewArrangement>
-        {
-            Legend = ViewArrangement.Movable.ToString (),
-            Data = ViewArrangement.Movable
-        });
+            new SliderOption<ViewArrangement>
+            {
+                Legend = ViewArrangement.LeftResizable.ToString (),
+                Data = ViewArrangement.LeftResizable
+            },
 
-        _arrangementSlider.Options.Add (new SliderOption<ViewArrangement>
-        {
-            Legend = ViewArrangement.LeftResizable.ToString (),
-            Data = ViewArrangement.LeftResizable
-        });
+            new SliderOption<ViewArrangement>
+            {
+                Legend = ViewArrangement.RightResizable.ToString (),
+                Data = ViewArrangement.RightResizable
+            },
 
-        _arrangementSlider.Options.Add (new SliderOption<ViewArrangement>
-        {
-            Legend = ViewArrangement.RightResizable.ToString (),
-            Data = ViewArrangement.RightResizable
-        });
+            new SliderOption<ViewArrangement>
+            {
+                Legend = ViewArrangement.TopResizable.ToString (),
+                Data = ViewArrangement.TopResizable
+            },
 
-        _arrangementSlider.Options.Add (new SliderOption<ViewArrangement>
-        {
-            Legend = ViewArrangement.TopResizable.ToString (),
-            Data = ViewArrangement.TopResizable
-        });
+            new SliderOption<ViewArrangement>
+            {
+                Legend = ViewArrangement.BottomResizable.ToString (),
+                Data = ViewArrangement.BottomResizable
+            },
 
-        _arrangementSlider.Options.Add (new SliderOption<ViewArrangement>
-        {
-            Legend = ViewArrangement.BottomResizable.ToString (),
-            Data = ViewArrangement.BottomResizable
-        });
+            new SliderOption<ViewArrangement>
+            {
+                Legend = ViewArrangement.Overlapped.ToString (),
+                Data = ViewArrangement.Overlapped
+            }
 
-        _arrangementSlider.Options.Add (new SliderOption<ViewArrangement>
-        {
-            Legend = ViewArrangement.Overlapped.ToString (),
-            Data = ViewArrangement.Overlapped
-        });
+        ];
 
         Add (_arrangementSlider);
     }
@@ -69,7 +71,7 @@ public sealed class ArrangementEditor : View
 
     private Label? _lblView; // Text describing the view being edited
 
-    private Slider<ViewArrangement> _arrangementSlider = new Slider<ViewArrangement> ()
+    private readonly Slider<ViewArrangement> _arrangementSlider = new Slider<ViewArrangement> ()
     {
         Orientation = Orientation.Vertical,
         UseMinimumSize = true,

--- a/UICatalog/Scenarios/Editors/BorderEditor.cs
+++ b/UICatalog/Scenarios/Editors/BorderEditor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Terminal.Gui;
@@ -7,9 +8,9 @@ namespace UICatalog.Scenarios;
 
 public class BorderEditor : AdornmentEditor
 {
-    private CheckBox _ckbTitle;
-    private RadioGroup _rbBorderStyle;
-    private CheckBox _ckbGradient;
+    private CheckBox? _ckbTitle;
+    private RadioGroup? _rbBorderStyle;
+    private CheckBox? _ckbGradient;
 
     public BorderEditor ()
     {
@@ -18,35 +19,34 @@ public class BorderEditor : AdornmentEditor
         AdornmentChanged += BorderEditor_AdornmentChanged;
     }
 
-    private void BorderEditor_AdornmentChanged (object sender, EventArgs e)
+    private void BorderEditor_AdornmentChanged (object? sender, EventArgs e)
     {
-        _ckbTitle.CheckedState = ((Border)AdornmentToEdit).Settings.FastHasFlags (BorderSettings.Title) ? CheckState.Checked : CheckState.UnChecked;
-        _rbBorderStyle.SelectedItem = (int)((Border)AdornmentToEdit).LineStyle;
-        _ckbGradient.CheckedState = ((Border)AdornmentToEdit).Settings.FastHasFlags (BorderSettings.Gradient) ? CheckState.Checked : CheckState.UnChecked;
+        _ckbTitle!.CheckedState = ((Border)AdornmentToEdit!).Settings.FastHasFlags (BorderSettings.Title) ? CheckState.Checked : CheckState.UnChecked;
+        _rbBorderStyle!.SelectedItem = (int)((Border)AdornmentToEdit).LineStyle;
+        _ckbGradient!.CheckedState = ((Border)AdornmentToEdit).Settings.FastHasFlags (BorderSettings.Gradient) ? CheckState.Checked : CheckState.UnChecked;
     }
 
-    private void BorderEditor_Initialized (object sender, EventArgs e)
+    private void BorderEditor_Initialized (object? sender, EventArgs e)
     {
         List<LineStyle> borderStyleEnum = Enum.GetValues (typeof (LineStyle)).Cast<LineStyle> ().ToList ();
 
-        _rbBorderStyle = new()
+        _rbBorderStyle = new ()
         {
             X = 0,
 
             Y = Pos.Bottom (Subviews [^1]),
             Width = Dim.Fill (),
-            SelectedItem = (int)(((Border)AdornmentToEdit)?.LineStyle ?? LineStyle.None),
+            SelectedItem = (int)(((Border)AdornmentToEdit!)?.LineStyle ?? LineStyle.None),
             BorderStyle = LineStyle.Single,
             Title = "Border St_yle",
             SuperViewRendersLineCanvas = true,
-            Enabled = AdornmentToEdit is { },
-            RadioLabels = borderStyleEnum.Select (e => e.ToString ()).ToArray ()
+            RadioLabels = borderStyleEnum.Select (style => style.ToString ()).ToArray ()
         };
         Add (_rbBorderStyle);
 
         _rbBorderStyle.SelectedItemChanged += OnRbBorderStyleOnSelectedItemChanged;
 
-        _ckbTitle = new()
+        _ckbTitle = new ()
         {
             X = 0,
             Y = Pos.Bottom (_rbBorderStyle),
@@ -54,7 +54,6 @@ public class BorderEditor : AdornmentEditor
             CheckedState = CheckState.Checked,
             SuperViewRendersLineCanvas = true,
             Text = "Title",
-            Enabled = AdornmentToEdit is { }
         };
 
         _ckbTitle.CheckedStateChanging += OnCkbTitleOnToggle;
@@ -68,7 +67,6 @@ public class BorderEditor : AdornmentEditor
             CheckedState = CheckState.Checked,
             SuperViewRendersLineCanvas = true,
             Text = "Gradient",
-            Enabled = AdornmentToEdit is { }
         };
 
         _ckbGradient.CheckedStateChanging += OnCkbGradientOnToggle;
@@ -76,10 +74,10 @@ public class BorderEditor : AdornmentEditor
 
         return;
 
-        void OnRbBorderStyleOnSelectedItemChanged (object s, SelectedItemChangedArgs e)
+        void OnRbBorderStyleOnSelectedItemChanged (object? s, SelectedItemChangedArgs args)
         {
-            LineStyle prevBorderStyle = AdornmentToEdit.BorderStyle;
-            ((Border)AdornmentToEdit).LineStyle = (LineStyle)e.SelectedItem;
+            LineStyle prevBorderStyle = AdornmentToEdit!.BorderStyle;
+            ((Border)AdornmentToEdit).LineStyle = (LineStyle)args.SelectedItem;
 
             if (((Border)AdornmentToEdit).LineStyle == LineStyle.None)
             {
@@ -91,34 +89,34 @@ public class BorderEditor : AdornmentEditor
             }
 
             ((Border)AdornmentToEdit).SetNeedsDisplay ();
-            LayoutSubviews ();
+            //SetNeedsLayout ();
         }
 
-        void OnCkbTitleOnToggle (object sender, CancelEventArgs<CheckState> args)
+        void OnCkbTitleOnToggle (object? _, CancelEventArgs<CheckState> args)
         {
             if (args.NewValue == CheckState.Checked)
 
             {
-                ((Border)AdornmentToEdit).Settings |= BorderSettings.Title;
+                ((Border)AdornmentToEdit!).Settings |= BorderSettings.Title;
             }
             else
 
             {
-                ((Border)AdornmentToEdit).Settings &= ~BorderSettings.Title;
+                ((Border)AdornmentToEdit!).Settings &= ~BorderSettings.Title;
             }
         }
 
-        void OnCkbGradientOnToggle (object sender, CancelEventArgs<CheckState> args)
+        void OnCkbGradientOnToggle (object? _, CancelEventArgs<CheckState> args)
         {
             if (args.NewValue == CheckState.Checked)
 
             {
-                ((Border)AdornmentToEdit).Settings |= BorderSettings.Gradient;
+                ((Border)AdornmentToEdit!).Settings |= BorderSettings.Gradient;
             }
             else
 
             {
-                ((Border)AdornmentToEdit).Settings &= ~BorderSettings.Gradient;
+                ((Border)AdornmentToEdit!).Settings &= ~BorderSettings.Gradient;
             }
         }
     }

--- a/UICatalog/Scenarios/Editors/DimEditor.cs
+++ b/UICatalog/Scenarios/Editors/DimEditor.cs
@@ -1,0 +1,301 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Terminal.Gui;
+
+namespace UICatalog.Scenarios;
+
+/// <summary>
+///     Provides an editor UI for the Margin, Border, and Padding of a View.
+/// </summary>
+public class DimEditor : View
+{
+    public DimEditor ()
+    {
+        Title = "Dim";
+
+        BorderStyle = LineStyle.Rounded;
+
+        Width = Dim.Auto (DimAutoStyle.Content);
+        Height = Dim.Auto (DimAutoStyle.Content);
+
+        CanFocus = true;
+
+        _expandButton = new ()
+        {
+            Orientation = Orientation.Vertical
+        };
+
+
+        TabStop = TabBehavior.TabStop;
+
+
+        Initialized += DimEditor_Initialized;
+
+        AddCommand (Command.Accept, () => true);
+    }
+
+    private View? _viewToEdit;
+
+    private int _value;
+    private RadioGroup? _dimRadioGroup;
+    private TextField? _valueEdit;
+
+    /// <summary>
+    ///     Gets or sets whether the DimEditor should automatically select the View to edit
+    ///     based on the values of <see cref="AutoSelectSuperView"/> and <see cref="AutoSelectAdornments"/>.
+    /// </summary>
+    public bool AutoSelectViewToEdit { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the View that will scope the behavior of <see cref="AutoSelectViewToEdit"/>.
+    /// </summary>
+    public View? AutoSelectSuperView { get; set; }
+
+    /// <summary>
+    ///     Gets or sets whether auto select with the mouse will select Adornments or just Views.
+    /// </summary>
+    public bool AutoSelectAdornments { get; set; }
+
+    public View? ViewToEdit
+    {
+        get => _viewToEdit;
+        set
+        {
+            if (_viewToEdit == value)
+            {
+                return;
+            }
+
+            if (value is null && _viewToEdit is { })
+            {
+                _viewToEdit.LayoutComplete -= View_LayoutComplete;
+            }
+
+            _viewToEdit = value;
+
+            if (_viewToEdit is { })
+            {
+                _viewToEdit.LayoutComplete += View_LayoutComplete;
+
+                _viewToEdit.LayoutStarted += (sender, args) =>
+                                             {
+
+                                             };
+            }
+        }
+    }
+
+    private void View_LayoutComplete (object? sender, LayoutEventArgs args)
+    {
+        UpdateSettings ();
+    }
+
+    private bool _updatingSettings = false;
+
+    private void UpdateSettings ()
+    {
+        if (ViewToEdit is null)
+        {
+            return;
+        }
+
+        _updatingSettings = true;
+
+        Dim? dim;
+        if (Dimension == Dimension.Width)
+        {
+            dim = ViewToEdit.Width;
+        }
+        else
+        {
+            dim = ViewToEdit.Height;
+        }
+
+        try
+        {
+            _dimRadioGroup!.SelectedItem = _dimNames.IndexOf (_dimNames.First (s => dim!.ToString ().StartsWith(s)));
+        }
+        catch (InvalidOperationException e)
+        {
+            // This is a hack to work around the fact that the Pos enum doesn't have an "Align" value yet
+            Debug.WriteLine ($"{e}");
+        }
+
+        _valueEdit!.Enabled = false;
+        switch (dim)
+        {
+            case DimAbsolute absolute:
+                _valueEdit.Enabled = true;
+                _value = absolute.Size;
+                _valueEdit!.Text = _value.ToString ();
+                break;
+            case DimFill fill:
+                var margin = fill.Margin as DimAbsolute;
+                _valueEdit.Enabled = margin is {};
+                _value = margin?.Size ?? 0;
+                _valueEdit!.Text = _value.ToString ();
+                break;
+            case DimFunc func:
+                _valueEdit.Enabled = true;
+                _value = func.Fn ();
+                _valueEdit!.Text = _value.ToString ();
+                break;
+            case DimPercent percent:
+                _valueEdit.Enabled = true;
+                _value = percent.Percentage;
+                _valueEdit!.Text = _value.ToString ();
+                break;
+            default:
+                _valueEdit!.Text = dim!.ToString ();
+                break;
+        }
+
+        _updatingSettings = false;
+    }
+
+    private void NavigationOnFocusedChanged (object? sender, EventArgs e)
+    {
+        if (AutoSelectSuperView is null)
+        {
+            return;
+        }
+
+        if (ApplicationNavigation.IsInHierarchy (this, Application.Navigation!.GetFocused ()))
+        {
+            return;
+        }
+
+        if (!ApplicationNavigation.IsInHierarchy (AutoSelectSuperView, Application.Navigation!.GetFocused ()))
+        {
+            return;
+        }
+
+        ViewToEdit = Application.Navigation!.GetFocused ();
+    }
+
+    private void ApplicationOnMouseEvent (object? sender, MouseEventArgs e)
+    {
+        if (e.Flags != MouseFlags.Button1Clicked || !AutoSelectViewToEdit)
+        {
+            return;
+        }
+
+        if ((AutoSelectSuperView is { } && !AutoSelectSuperView.FrameToScreen ().Contains (e.Position))
+            || FrameToScreen ().Contains (e.Position))
+        {
+            return;
+        }
+
+        View? view = e.View;
+
+        if (view is null)
+        {
+            return;
+        }
+
+        if (view is Adornment adornment)
+        {
+            ViewToEdit = AutoSelectAdornments ? adornment : adornment.Parent;
+        }
+        else
+        {
+            ViewToEdit = view;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose (bool disposing)
+    {
+        base.Dispose (disposing);
+    }
+
+    private readonly ExpanderButton? _expandButton;
+
+    public ExpanderButton? ExpandButton => _expandButton;
+
+    public Dimension Dimension { get; set; }
+
+    private void DimEditor_Initialized (object? sender, EventArgs e)
+    {
+        Border.Add (_expandButton!);
+
+        var label = new Label
+        {
+            X = 0, Y = 0,
+            Text = $"{Title}:"
+        };
+        Add (label);
+        _dimRadioGroup = new () { X = 0, Y = Pos.Bottom (label), RadioLabels = _radioItems };
+        _dimRadioGroup.SelectedItemChanged += OnRadioGroupOnSelectedItemChanged;
+        _valueEdit = new ()
+        {
+            X = Pos.Right (label) + 1,
+            Y = 0,
+            Width = Dim.Func (() => _radioItems.Max (i => i.GetColumns ()) - label.Frame.Width + 1),
+            Text = $"{_value}"
+        };
+
+        _valueEdit.Accepting += (s, args) =>
+        {
+            try
+            {
+                _value = int.Parse (_valueEdit.Text);
+                DimChanged ();
+            }
+            catch
+            {
+                // ignored
+            }
+            args.Cancel = true;
+        };
+        Add (_valueEdit);
+
+        Add (_dimRadioGroup);
+
+        Application.MouseEvent += ApplicationOnMouseEvent;
+        Application.Navigation!.FocusedChanged += NavigationOnFocusedChanged;
+    }
+
+    private void OnRadioGroupOnSelectedItemChanged (object? s, SelectedItemChangedArgs selected) { DimChanged (); }
+
+    // These need to have same order 
+    private readonly List<string> _dimNames = ["Absolute", "Auto", "Fill", "Func", "Percent",];
+    private readonly string [] _radioItems = ["Absolute(n)", "Auto", "Fill(n)", "Func(()=>n)", "Percent(n)",];
+
+    private void DimChanged ()
+    {
+        if (ViewToEdit == null || _updatingSettings)
+        {
+            return;
+        }
+
+        try
+        {
+            Dim? dim = _dimRadioGroup!.SelectedItem switch
+            {
+                0 => Dim.Absolute (_value),
+                1 => Dim.Auto (),
+                2 => Dim.Fill (_value),
+                3 => Dim.Func (() => _value),
+                4 => Dim.Percent (_value),
+                _ => Dimension == Dimension.Width ? ViewToEdit.Width : ViewToEdit.Height
+            };
+
+            if (Dimension == Dimension.Width)
+            {
+                ViewToEdit.Width = dim;
+            }
+            else
+            {
+                ViewToEdit.Height = dim;
+            }
+        }
+        catch (Exception e)
+        {
+            MessageBox.ErrorQuery ("Exception", e.Message, "Ok");
+        }
+    }
+}

--- a/UICatalog/Scenarios/Editors/EventLog.cs
+++ b/UICatalog/Scenarios/Editors/EventLog.cs
@@ -1,0 +1,119 @@
+﻿#nullable enable
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics.Tracing;
+using System.Text;
+using Terminal.Gui;
+
+namespace UICatalog.Scenarios;
+
+/// <summary>
+///     An event log that automatically shows the events that are raised.
+/// </summary>
+/// <remarks>
+/// </remarks>
+/// </example>
+public class EventLog : ListView
+{
+    public EventLog ()
+    {
+        Title = "Event Log";
+        CanFocus = false;
+
+        X = Pos.AnchorEnd ();
+        Y = 0;
+        Width = 30;//Dim.Func (() => Math.Min (SuperView!.Viewport.Width / 2, MaxLength + GetAdornmentsThickness ().Horizontal));
+        Height = Dim.Fill ();
+
+        ExpandButton = new ()
+        {
+            Orientation = Orientation.Horizontal
+        };
+
+        Initialized += EventLog_Initialized;
+
+        BorderStyle = LineStyle.Dotted;
+    }
+    public ExpanderButton? ExpandButton { get; }
+
+    private readonly ObservableCollection<string> _eventSource = [];
+
+    private View? _viewToLog;
+
+    public View? ViewToLog
+    {
+        get => _viewToLog;
+        set
+        {
+            if (_viewToLog == value)
+            {
+                return;
+            }
+
+            _viewToLog = value;
+
+            if (_viewToLog is { })
+            {
+                _viewToLog.Initialized += (s, args) =>
+                                             {
+                                                 View? sender = s as View;
+                                                 _eventSource.Add ($"Initialized: {GetIdentifyingString (sender)}");
+                                                 MoveEnd ();
+                                             };
+
+                _viewToLog.MouseClick += (s, args) =>
+                {
+                    View? sender = s as View;
+                    _eventSource.Add ($"MouseClick: {args}");
+                    MoveEnd ();
+                };
+
+                _viewToLog.HandlingHotKey += (s, args) =>
+                                        {
+                                            View? sender = s as View;
+                                            _eventSource.Add ($"HandlingHotKey: {args.Context.Command} {args.Context.Data}");
+                                            MoveEnd ();
+                                        };
+                _viewToLog.Selecting += (s, args) =>
+                                        {
+                                            View? sender = s as View;
+                                            _eventSource.Add ($"Selecting: {args.Context.Command} {args.Context.Data}");
+                                            MoveEnd ();
+                                        };
+                _viewToLog.Accepting += (s, args) =>
+                                        {
+                                            View? sender = s as View;
+                                            _eventSource.Add ($"Accepting: {args.Context.Command} {args.Context.Data}");
+                                            MoveEnd ();
+                                        };
+            }
+        }
+    }
+
+    private void EventLog_Initialized (object? _, EventArgs e)
+    {
+
+        Border.Add (ExpandButton!);
+        Source = new ListWrapper<string> (_eventSource);
+
+    }
+    private string GetIdentifyingString (View? view)
+    {
+        if (view is null)
+        {
+            return "null";
+        }
+
+        if (!string.IsNullOrEmpty (view.Title))
+        {
+            return view.Title;
+        }
+
+        if (!string.IsNullOrEmpty (view.Text))
+        {
+            return view.Text;
+        }
+
+        return view.GetType ().Name;
+    }
+}

--- a/UICatalog/Scenarios/Editors/ExpanderButton.cs
+++ b/UICatalog/Scenarios/Editors/ExpanderButton.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Text;
 using Terminal.Gui;
 
@@ -36,7 +37,6 @@ public class ExpanderButton : Button
         Height = 1;
         NoDecorations = true;
         NoPadding = true;
-        ShadowStyle = ShadowStyle.None;
 
         AddCommand (Command.HotKey, Toggle);
         AddCommand (Command.Toggle, Toggle);
@@ -44,10 +44,17 @@ public class ExpanderButton : Button
 
         Orientation = Orientation.Vertical;
 
+        HighlightStyle = HighlightStyle.None;
+
         Initialized += ExpanderButton_Initialized;
     }
 
-    private void ExpanderButton_Initialized (object sender, EventArgs e) { ExpandOrCollapse (Collapsed); }
+    private void ExpanderButton_Initialized (object? sender, EventArgs e)
+    {
+        ShadowStyle = ShadowStyle.None;
+
+        ExpandOrCollapse (Collapsed);
+    }
 
     private Orientation _orientation = Orientation.Horizontal;
 
@@ -82,15 +89,15 @@ public class ExpanderButton : Button
             {
                 X = Pos.AnchorEnd ();
                 Y = 0;
-                CollapsedGlyph = new ('\u21d1'); // ⇑
-                ExpandedGlyph = new ('\u21d3'); // ⇓
+                CollapseGlyph = new ('\u21d1'); // ⇑
+                ExpandGlyph = new ('\u21d3'); // ⇓
             }
             else
             {
                 X = 0;
                 Y = Pos.AnchorEnd ();
-                CollapsedGlyph = new ('\u21d0'); // ⇐
-                ExpandedGlyph = new ('\u21d2'); // ⇒
+                CollapseGlyph = new ('\u21d0'); // ⇐
+                ExpandGlyph = new ('\u21d2'); // ⇒
             }
 
             ExpandOrCollapse (Collapsed);
@@ -102,17 +109,17 @@ public class ExpanderButton : Button
     /// <summary>
     ///     Fired when the orientation has changed. Can be cancelled.
     /// </summary>
-    public event EventHandler<CancelEventArgs<Orientation>> OrientationChanging;
+    public event EventHandler<CancelEventArgs<Orientation>>? OrientationChanging;
 
     /// <summary>
-    ///     The glyph to display when the view is collapsed.
+    ///     The glyph that indicates the button will collapse the view.
     /// </summary>
-    public Rune CollapsedGlyph { get; set; }
+    public Rune CollapseGlyph { get; set; }
 
     /// <summary>
-    ///     The glyph to display when the view is expanded.
+    ///     The glyph that indicates the button will expand the view.
     /// </summary>
-    public Rune ExpandedGlyph { get; set; }
+    public Rune ExpandGlyph { get; set; }
 
     private bool _collapsed;
 
@@ -146,7 +153,7 @@ public class ExpanderButton : Button
     /// <summary>
     ///     Fired when the orientation has changed. Can be cancelled.
     /// </summary>
-    public event EventHandler<CancelEventArgs<bool>> CollapsedChanging;
+    public event EventHandler<CancelEventArgs<bool>>? CollapsedChanging;
 
     /// <summary>
     ///     Collapses or Expands the view.
@@ -159,13 +166,13 @@ public class ExpanderButton : Button
         return true;
     }
 
-    private Dim _previousDim;
+    private Dim? _previousDim;
 
     private void ExpandOrCollapse (bool collapse)
     {
-        Text = $"{(Collapsed ? CollapsedGlyph : ExpandedGlyph)}";
+        Text = $"{(Collapsed ? ExpandGlyph : CollapseGlyph)}";
 
-        View superView = SuperView;
+        View? superView = SuperView;
 
         if (superView is Adornment adornment)
         {
@@ -182,12 +189,12 @@ public class ExpanderButton : Button
             // Collapse
             if (Orientation == Orientation.Vertical)
             {
-                _previousDim = superView.Height;
+                _previousDim = superView!.Height!;
                 superView.Height = 1;
             }
             else
             {
-                _previousDim = superView.Width;
+                _previousDim = superView!.Width!;
                 superView.Width = 1;
             }
         }

--- a/UICatalog/Scenarios/Editors/LayoutEditor.cs
+++ b/UICatalog/Scenarios/Editors/LayoutEditor.cs
@@ -1,0 +1,228 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Terminal.Gui;
+
+namespace UICatalog.Scenarios;
+
+/// <summary>
+///     Provides an editor UI for the Margin, Border, and Padding of a View.
+/// </summary>
+public class LayoutEditor : View
+{
+    public LayoutEditor ()
+    {
+        Title = "_LayoutEditor";
+
+        Width = Dim.Auto (DimAutoStyle.Content);
+        Height = Dim.Auto (DimAutoStyle.Content);
+
+        CanFocus = true;
+
+        TabStop = TabBehavior.TabGroup;
+
+        _expandButton = new ()
+        {
+            Orientation = Orientation.Vertical
+        };
+
+        Initialized += LayoutEditor_Initialized;
+
+        AddCommand (Command.Accept, () => true);
+    }
+
+    private View? _viewToEdit;
+
+    private readonly List<string> _dimNames = ["Auto", "Percent", "Fill", "Absolute"];
+
+    private PosEditor? _xEditor;
+    private PosEditor? _yEditor;
+
+    private DimEditor? _widthEditor;
+    private DimEditor? _heightEditor;
+
+    /// <summary>
+    ///     Gets or sets whether the LayoutEditor should automatically select the View to edit
+    ///     based on the values of <see cref="AutoSelectSuperView"/> and <see cref="AutoSelectAdornments"/>.
+    /// </summary>
+    public bool AutoSelectViewToEdit { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the View that will scope the behavior of <see cref="AutoSelectViewToEdit"/>.
+    /// </summary>
+    public View? AutoSelectSuperView { get; set; }
+
+    /// <summary>
+    ///     Gets or sets whether auto select with the mouse will select Adornments or just Views.
+    /// </summary>
+    public bool AutoSelectAdornments { get; set; }
+
+    public View? ViewToEdit
+    {
+        get => _viewToEdit;
+        set
+        {
+            if (_viewToEdit == value)
+            {
+                return;
+            }
+
+            if (value is null && _viewToEdit is { })
+            {
+                _viewToEdit.LayoutComplete -= View_LayoutComplete;
+            }
+
+            _viewToEdit = value;
+
+            if (_viewToEdit is { })
+            {
+                _viewToEdit.LayoutComplete += View_LayoutComplete;
+            }
+
+            if (_xEditor is { })
+            {
+                _xEditor.ViewToEdit = _viewToEdit;
+            }
+
+            if (_yEditor is { })
+            {
+                _yEditor.ViewToEdit = _viewToEdit;
+            }
+
+            if (_widthEditor is { })
+            {
+                _widthEditor.ViewToEdit = _viewToEdit;
+            }
+
+            if (_heightEditor is { })
+            {
+                _heightEditor.ViewToEdit = _viewToEdit;
+            }
+
+        }
+    }
+
+    private void View_LayoutComplete (object? sender, LayoutEventArgs args)
+    {
+        UpdateSettings ();
+    }
+
+    private bool _updatingSettings = false;
+
+    private void UpdateSettings ()
+    {
+        if (ViewToEdit is null)
+        {
+            return;
+        }
+
+        _updatingSettings = true;
+
+        _updatingSettings = false;
+    }
+
+    private void NavigationOnFocusedChanged (object? sender, EventArgs e)
+    {
+        if (AutoSelectSuperView is null)
+        {
+            return;
+        }
+
+        if (ApplicationNavigation.IsInHierarchy (this, Application.Navigation!.GetFocused ()))
+        {
+            return;
+        }
+
+        if (!ApplicationNavigation.IsInHierarchy (AutoSelectSuperView, Application.Navigation!.GetFocused ()))
+        {
+            return;
+        }
+
+        ViewToEdit = Application.Navigation!.GetFocused ();
+    }
+
+    private void ApplicationOnMouseEvent (object? sender, MouseEventArgs e)
+    {
+        if (e.Flags != MouseFlags.Button1Clicked || !AutoSelectViewToEdit)
+        {
+            return;
+        }
+
+        if ((AutoSelectSuperView is { } && !AutoSelectSuperView.FrameToScreen ().Contains (e.Position))
+            || FrameToScreen ().Contains (e.Position))
+        {
+            return;
+        }
+
+        View? view = e.View;
+
+        if (view is null)
+        {
+            return;
+        }
+
+        if (view is Adornment adornment)
+        {
+            ViewToEdit = AutoSelectAdornments ? adornment : adornment.Parent;
+        }
+        else
+        {
+            ViewToEdit = view;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose (bool disposing)
+    {
+        base.Dispose (disposing);
+    }
+
+    private readonly ExpanderButton? _expandButton;
+
+    public ExpanderButton? ExpandButton => _expandButton;
+
+    private void LayoutEditor_Initialized (object? sender, EventArgs e)
+    {
+        BorderStyle = LineStyle.Rounded;
+
+        Border.Add (_expandButton!);
+
+        _xEditor = new ()
+        {
+            Title = "_X",
+            BorderStyle = LineStyle.None,
+            Dimension = Dimension.Width
+        };
+
+        _yEditor = new ()
+        {
+            Title = "_Y",
+            BorderStyle = LineStyle.None,
+            Dimension = Dimension.Height,
+            X = Pos.Right(_xEditor) + 1
+        };
+
+
+        _widthEditor = new ()
+        {
+            Title = "_Width",
+            BorderStyle = LineStyle.None,
+            Dimension = Dimension.Width,
+            X = Pos.Right(_yEditor) + 1
+        };
+
+        _heightEditor = new ()
+        {
+            Title = "_Height",
+            BorderStyle = LineStyle.None,
+            Dimension = Dimension.Height,
+            X = Pos.Right (_widthEditor) + 1
+        };
+
+        Add (_xEditor, _yEditor, _widthEditor, _heightEditor);
+
+        Application.MouseEvent += ApplicationOnMouseEvent;
+        Application.Navigation!.FocusedChanged += NavigationOnFocusedChanged;
+    }
+}

--- a/UICatalog/Scenarios/Editors/MarginEditor.cs
+++ b/UICatalog/Scenarios/Editors/MarginEditor.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Linq;
+﻿#nullable enable
+using System;
 using Terminal.Gui;
 
 namespace UICatalog.Scenarios;
@@ -13,17 +13,17 @@ public class MarginEditor : AdornmentEditor
         AdornmentChanged += MarginEditor_AdornmentChanged;
     }
 
-    RadioGroup _rgShadow;
+    private RadioGroup? _rgShadow;
 
-    private void MarginEditor_AdornmentChanged (object sender, EventArgs e)
+    private void MarginEditor_AdornmentChanged (object? sender, EventArgs e)
     {
         if (AdornmentToEdit is { })
         {
-            _rgShadow.SelectedItem = (int)((Margin)AdornmentToEdit).ShadowStyle;
+            _rgShadow!.SelectedItem = (int)((Margin)AdornmentToEdit).ShadowStyle;
         }
     }
 
-    private void MarginEditor_Initialized (object sender, EventArgs e)
+    private void MarginEditor_Initialized (object? sender, EventArgs e)
     {
         _rgShadow = new RadioGroup
         {
@@ -33,7 +33,6 @@ public class MarginEditor : AdornmentEditor
             SuperViewRendersLineCanvas = true,
             Title = "_Shadow",
             BorderStyle = LineStyle.Dashed,
-            Enabled = AdornmentToEdit is { },
             RadioLabels = Enum.GetNames (typeof (ShadowStyle)),
         };
 
@@ -44,7 +43,7 @@ public class MarginEditor : AdornmentEditor
 
         _rgShadow.SelectedItemChanged += (sender, args) =>
                                         {
-                                            ((Margin)AdornmentToEdit).ShadowStyle = (ShadowStyle)args.SelectedItem;
+                                            ((Margin)AdornmentToEdit!).ShadowStyle = (ShadowStyle)args.SelectedItem;
                                         };
 
         Add (_rgShadow);

--- a/UICatalog/Scenarios/Editors/PaddingEditor.cs
+++ b/UICatalog/Scenarios/Editors/PaddingEditor.cs
@@ -1,4 +1,5 @@
-﻿namespace UICatalog.Scenarios;
+﻿#nullable enable
+namespace UICatalog.Scenarios;
 
 public class PaddingEditor : AdornmentEditor
 {

--- a/UICatalog/Scenarios/Editors/PosEditor.cs
+++ b/UICatalog/Scenarios/Editors/PosEditor.cs
@@ -1,0 +1,292 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Terminal.Gui;
+
+namespace UICatalog.Scenarios;
+
+/// <summary>
+///     Provides an editor UI for the Margin, Border, and Padding of a View.
+/// </summary>
+public class PosEditor : View
+{
+    public PosEditor ()
+    {
+        Title = "Pos";
+
+        BorderStyle = LineStyle.Rounded;
+
+        Width = Dim.Auto (DimAutoStyle.Content);
+        Height = Dim.Auto (DimAutoStyle.Content);
+
+        CanFocus = true;
+
+        _expandButton = new ()
+        {
+            Orientation = Orientation.Vertical
+        };
+
+
+        TabStop = TabBehavior.TabStop;
+
+        Initialized += PosEditor_Initialized;
+
+        AddCommand (Command.Accept, () => true);
+    }
+
+    private View? _viewToEdit;
+
+    private int _value;
+    private RadioGroup? _posRadioGroup;
+    private TextField? _valueEdit;
+
+    /// <summary>
+    ///     Gets or sets whether the PosEditor should automatically select the View to edit
+    ///     based on the values of <see cref="AutoSelectSuperView"/> and <see cref="AutoSelectAdornments"/>.
+    /// </summary>
+    public bool AutoSelectViewToEdit { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the View that will scope the behavior of <see cref="AutoSelectViewToEdit"/>.
+    /// </summary>
+    public View? AutoSelectSuperView { get; set; }
+
+    /// <summary>
+    ///     Gets or sets whether auto select with the mouse will select Adornments or just Views.
+    /// </summary>
+    public bool AutoSelectAdornments { get; set; }
+
+    public View? ViewToEdit
+    {
+        get => _viewToEdit;
+        set
+        {
+            if (_viewToEdit == value)
+            {
+                return;
+            }
+
+            if (value is null && _viewToEdit is { })
+            {
+                _viewToEdit.LayoutComplete -= View_LayoutComplete;
+            }
+
+            _viewToEdit = value;
+
+            if (_viewToEdit is { })
+            {
+                _viewToEdit.LayoutComplete += View_LayoutComplete;
+            }
+        }
+    }
+
+    private void View_LayoutComplete (object? sender, LayoutEventArgs args)
+    {
+        UpdateSettings ();
+    }
+
+    private bool _updatingSettings = false;
+
+    private void UpdateSettings ()
+    {
+        if (ViewToEdit is null)
+        {
+            return;
+        }
+
+        _updatingSettings = true;
+
+        Pos? pos;
+        if (Dimension == Dimension.Width)
+        {
+            pos = ViewToEdit.X;
+        }
+        else
+        {
+            pos = ViewToEdit.Y;
+        }
+
+        try
+        {
+            _posRadioGroup!.SelectedItem = _posNames.IndexOf (_posNames.First (s => pos.ToString ().Contains (s)));
+        }
+        catch (InvalidOperationException e)
+        {
+            // This is a hack to work around the fact that the Pos enum doesn't have an "Align" value yet
+            Debug.WriteLine ($"{e}");
+        }
+
+        _valueEdit!.Enabled = false;
+        switch (pos)
+        {
+            case PosPercent percent:
+                _valueEdit.Enabled = true;
+                _value = percent.Percent;
+                _valueEdit!.Text = _value.ToString ();
+                break;
+            case PosAbsolute absolute:
+                _valueEdit.Enabled = true;
+                _value = absolute.Position;
+                _valueEdit!.Text = _value.ToString ();
+                break;
+            case PosFunc func:
+                _valueEdit.Enabled = true;
+                _value = func.Fn ();
+                _valueEdit!.Text = _value.ToString ();
+                break;
+            default:
+                _valueEdit!.Text = pos.ToString ();
+                break;
+        }
+
+        _updatingSettings = false;
+    }
+
+    private void NavigationOnFocusedChanged (object? sender, EventArgs e)
+    {
+        if (AutoSelectSuperView is null)
+        {
+            return;
+        }
+
+        if (ApplicationNavigation.IsInHierarchy (this, Application.Navigation!.GetFocused ()))
+        {
+            return;
+        }
+
+        if (!ApplicationNavigation.IsInHierarchy (AutoSelectSuperView, Application.Navigation!.GetFocused ()))
+        {
+            return;
+        }
+
+        ViewToEdit = Application.Navigation!.GetFocused ();
+    }
+
+    private void ApplicationOnMouseEvent (object? sender, MouseEventArgs e)
+    {
+        if (e.Flags != MouseFlags.Button1Clicked || !AutoSelectViewToEdit)
+        {
+            return;
+        }
+
+        if ((AutoSelectSuperView is { } && !AutoSelectSuperView.FrameToScreen ().Contains (e.Position))
+            || FrameToScreen ().Contains (e.Position))
+        {
+            return;
+        }
+
+        View? view = e.View;
+
+        if (view is null)
+        {
+            return;
+        }
+
+        if (view is Adornment adornment)
+        {
+            ViewToEdit = AutoSelectAdornments ? adornment : adornment.Parent;
+        }
+        else
+        {
+            ViewToEdit = view;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose (bool disposing)
+    {
+        base.Dispose (disposing);
+    }
+
+    private readonly ExpanderButton? _expandButton;
+
+    public ExpanderButton? ExpandButton => _expandButton;
+
+    public Dimension Dimension { get; set; }
+
+    private void PosEditor_Initialized (object? sender, EventArgs e)
+    {
+        Border.Add (_expandButton!);
+
+        var label = new Label
+        {
+            X = 0, Y = 0,
+            Text = $"{Title}:"
+        };
+        Add (label);
+        _posRadioGroup = new () { X = 0, Y = Pos.Bottom (label), RadioLabels = _radioItems };
+        _posRadioGroup.SelectedItemChanged += OnRadioGroupOnSelectedItemChanged;
+        _valueEdit = new ()
+        {
+            X = Pos.Right (label) + 1,
+            Y = 0,
+            Width = Dim.Func (() => _radioItems.Max (i => i.GetColumns ()) - label.Frame.Width + 1),
+            Text = $"{_value}"
+        };
+
+        _valueEdit.Accepting += (s, args) =>
+        {
+            try
+            {
+                _value = int.Parse (_valueEdit.Text);
+                PosChanged ();
+            }
+            catch
+            {
+                // ignored
+            }
+            args.Cancel = true;
+        };
+        Add (_valueEdit);
+
+        Add (_posRadioGroup);
+
+        Application.MouseEvent += ApplicationOnMouseEvent;
+        Application.Navigation!.FocusedChanged += NavigationOnFocusedChanged;
+    }
+
+    private void OnRadioGroupOnSelectedItemChanged (object? s, SelectedItemChangedArgs selected) { PosChanged (); }
+
+    // These need to have same order 
+    private readonly List<string> _posNames = ["Absolute", "Align", "AnchorEnd", "Center", "Func", "Percent",];
+    private readonly string [] _radioItems = ["Absolute(n)", "Align", "AnchorEnd", "Center", "Func(()=>n)", "Percent(n)",];
+
+    private void PosChanged ()
+    {
+        if (ViewToEdit == null || _updatingSettings)
+        {
+            return;
+        }
+
+        try
+        {
+            Pos? pos = _posRadioGroup!.SelectedItem switch
+            {
+                0 => Pos.Absolute (_value),
+                1 => Pos.Align (Alignment.Start),
+                2 => new PosAnchorEnd (),
+                3 => Pos.Center (),
+                4 => Pos.Func (() => _value),
+                5 => Pos.Percent (_value),
+                _ => Dimension == Dimension.Width ? ViewToEdit.X : ViewToEdit.Y
+            };
+
+            if (Dimension == Dimension.Width)
+            {
+                ViewToEdit.X = pos;
+            }
+            else
+            {
+                ViewToEdit.Y = pos;
+            }
+            //SetNeedsLayout ();
+
+        }
+        catch (Exception e)
+        {
+            MessageBox.ErrorQuery ("Exception", e.Message, "Ok");
+        }
+    }
+}

--- a/UICatalog/Scenarios/Generic.cs
+++ b/UICatalog/Scenarios/Generic.cs
@@ -4,7 +4,7 @@ namespace UICatalog.Scenarios;
 
 [ScenarioMetadata ("Generic", "Generic sample - A template for creating new Scenarios")]
 [ScenarioCategory ("Controls")]
-public sealed class MyScenario : Scenario
+public sealed class Generic : Scenario
 {
     public override void Main ()
     {

--- a/UICatalog/Scenarios/KeyBindings.cs
+++ b/UICatalog/Scenarios/KeyBindings.cs
@@ -125,39 +125,33 @@ public sealed class KeyBindings : Scenario
         };
         appWindow.Add (_focusedBindingsListView);
 
-        appWindow.HasFocusChanged += AppWindow_HasFocusChanged;
-        appWindow.DrawContent += AppWindow_DrawContent;
+        Application.Navigation!.FocusedChanged += Application_HasFocusChanged;
 
         // Run - Start the application.
         Application.Run (appWindow);
+        Application.Navigation!.FocusedChanged -= Application_HasFocusChanged;
         appWindow.Dispose ();
 
         // Shutdown - Calling Application.Shutdown is required.
         Application.Shutdown ();
     }
 
-    private void AppWindow_DrawContent (object sender, DrawEventArgs e)
-    {
-        _focusedBindingsListView.Title = $"_Focused ({Application.Top.MostFocused.GetType ().Name}) Bindings";
 
-        _focusedBindings.Clear ();
-        foreach (var binding in Application.Top.MostFocused.KeyBindings.Bindings.Where (b => b.Value.Scope == KeyBindingScope.Focused))
+    private void Application_HasFocusChanged (object sender, EventArgs e)
+    {
+        View focused = Application.Navigation!.GetFocused ();
+
+        if (focused == null)
+        {
+            return;
+        }
+
+        _focusedBindingsListView.Title = $"_Focused ({focused?.GetType ().Name}) Bindings";
+
+        _focusedBindings.Clear();
+        foreach (var binding in focused?.KeyBindings!.Bindings.Where (b => b.Value.Scope == KeyBindingScope.Focused)!)
         {
             _focusedBindings.Add ($"{binding.Key} -> {binding.Value.Commands [0]}");
-        }
-    }
-
-    private void AppWindow_HasFocusChanged (object sender, HasFocusEventArgs e)
-    {
-        if (e.NewValue)
-        {
-            if (Application.Top is { MostFocused: {} })
-            {
-                foreach (var binding in Application.Top.MostFocused.KeyBindings.Bindings.Where (b => b.Value.Scope == KeyBindingScope.Focused))
-                {
-                    _focusedBindings.Add ($"{binding.Key} -> {binding.Value.Commands [0]}");
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
This PR backports some drawing benchmark stuff from 

- #3798 

to quantify how much improvement I'm making.

## Proposed Changes/Todos

- [x] Add support to `ConsoleDriver` for tests to see how often draw code is called.
- [x] Add an `All_Scenarios_Time` unit test that measures how each Scenario performs w.r.t draw calls.

The results are pretty horrific.

For example. 

```
Scenario UICatalog.Scenarios.AllViewsTester
  took 20827 ms to run.
  called Driver.ClearContents 0 times.
  called Driver.Refresh 5004 times.
    which updated the screen 5003 times.

Scenario UICatalog.Scenarios.Generic
  took 4659 ms to run.
  called Driver.ClearContents 0 times.
  called Driver.Refresh 5004 times.
    which updated the screen 5003 times.

Scenario UICatalog.Scenarios.Progress
  took 12300 ms to run.
  called Driver.ClearContents 0 times.
  called Driver.Refresh 5004 times.
    which updated the screen 5003 times.
```

In #3798:

```
Scenario UICatalog.Scenarios.AllViewsTester
  took 91 ms to run.
  called Driver.ClearContents 1 times.
  called Driver.Refresh 5003 times.
    which updated the screen 1 times.

Scenario UICatalog.Scenarios.Generic
  took 16 ms to run.
  called Driver.ClearContents 0 times.
  called Driver.Refresh 5003 times.
    which updated the screen 1 times.

Scenario UICatalog.Scenarios.Progress
  took 84 ms to run.
  called Driver.ClearContents 0 times.
  called Driver.Refresh 5003 times.
    which updated the screen 1 times.
```