### PR TITLE
fix the build issue of F# example

### DIFF
--- a/FSharpExample/Program.fs
+++ b/FSharpExample/Program.fs
@@ -19,7 +19,7 @@ type ExampleWindow() as this =
         let btnLogin = new Button(Text = "Login", Y = Pos.Bottom(passwordLabel) +  Pos.op_Implicit(1), X = Pos.Center(), IsDefault = true)
 
         // When login button is clicked display a message popup
-        btnLogin.Accept.Add(fun _ ->
+        btnLogin.Accepting.Add(fun _ ->
             if userNameText.Text = "admin" && passwordText.Text = "password" then
                 MessageBox.Query("Logging In", "Login Successful", "Ok") |> ignore
                 ExampleWindow.UserName <- userNameText.Text.ToString()


### PR DESCRIPTION
## Fixes

F# example cannot be built with latest Termina.Gui. I got the following error when building.

```
% cd FSharpExample
% dotnet build
...
Build FAILED.

/home/syohei/tmp/Terminal.Gui/FSharpExample/Program.fs(22,18): error FS0039: The type 'Button' does not define the field, constructor or member 'Accept'. [/home/syohei/tmp/Terminal.Gui/FSharpExample/FSharpExample.fsproj]
    0 Warning(s)
    1 Error(s)
```

The property name was updated at https://github.com/gui-cs/Terminal.Gui/commit/9990a552d24d2cc3be5e679cc8a50460b1c0b89b however F# example has not been updated yet.

## Proposed Changes/Todos


## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
