### PR TITLE
Fixes #3807 - Accents (é) don't work on `WindowsDriver`

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1725,6 +1725,17 @@ internal class WindowsDriver : ConsoleDriver
                 }
             }
 
+            // If KeyInfo.Key is A...Z and KeyInfo.KeyChar is not a...z then we have an accent.
+            // See https://github.com/gui-cs/Terminal.Gui/issues/3807#issuecomment-2455997595
+            if (keyInfo.KeyChar <= (char)'z')
+            {
+                return (KeyCode)keyInfo.Key;
+            }
+            else
+            {
+                return (KeyCode)keyInfo.KeyChar;
+            }
+
             // Return the Key (not KeyChar!)
             return (KeyCode)keyInfo.Key;
         }

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1731,13 +1731,7 @@ internal class WindowsDriver : ConsoleDriver
             {
                 return (KeyCode)keyInfo.Key;
             }
-            else
-            {
-                return (KeyCode)keyInfo.KeyChar;
-            }
-
-            // Return the Key (not KeyChar!)
-            return (KeyCode)keyInfo.Key;
+            return (KeyCode)keyInfo.KeyChar;
         }
 
         // Handle control keys whose VK codes match the related ASCII value (those below ASCII 33) like ESC


### PR DESCRIPTION
## Fixes

- Fixes #3807

