### PR TITLE
Fixes #3855 - Text inputs keybindings update

### DIFF
--- a/Showcase.md
+++ b/Showcase.md
@@ -26,7 +26,7 @@
 
 - **[Muse](https://github.com/MaciekWin3/Muse)** - Muse is terminal music player built with Terminal.Gui and NAudio on .NET platform.
   ![Muse](https://github.com/user-attachments/assets/94aeb559-a889-4b52-bb0d-453b3e19b290)
-z
+
 - **[Whale](https://github.com/MaciekWin3/Whale)** - Lightweight terminal user interface application that helps software engineers manage Docker containers.
   ![Whale](https://github.com/user-attachments/assets/7ef6e348-c36b-4aee-a63c-4e5c60c3aad2)
 

--- a/Terminal.Gui/Views/DateField.cs
+++ b/Terminal.Gui/Views/DateField.cs
@@ -114,7 +114,7 @@ public class DateField : TextField
     }
 
     /// <inheritdoc/>
-    protected override bool OnMouseEvent  (MouseEventArgs ev)
+    protected override bool OnMouseEvent (MouseEventArgs ev)
     {
         if (base.OnMouseEvent (ev) || ev.Handled)
         {
@@ -410,7 +410,7 @@ public class DateField : TextField
         KeyBindings.ReplaceCommands (Key.Backspace, Command.DeleteCharLeft);
 
         KeyBindings.ReplaceCommands (Key.Home, Command.LeftStart);
-        KeyBindings.ReplaceCommands (Key.A.WithCtrl, Command.LeftStart);
+        KeyBindings.ReplaceCommands (Key.Home.WithCtrl, Command.LeftStart);
 
         KeyBindings.ReplaceCommands (Key.CursorLeft, Command.Left);
         KeyBindings.ReplaceCommands (Key.B.WithCtrl, Command.Left);
@@ -551,35 +551,35 @@ public class DateField : TextField
     private static string StandardizeDateFormat (string format)
     {
         return format switch
-               {
-                   "MM/dd/yyyy" => "MM/dd/yyyy",
-                   "yyyy-MM-dd" => "yyyy-MM-dd",
-                   "yyyy/MM/dd" => "yyyy/MM/dd",
-                   "dd/MM/yyyy" => "dd/MM/yyyy",
-                   "d?/M?/yyyy" => "dd/MM/yyyy",
-                   "dd.MM.yyyy" => "dd.MM.yyyy",
-                   "dd-MM-yyyy" => "dd-MM-yyyy",
-                   "dd/MM yyyy" => "dd/MM/yyyy",
-                   "d. M. yyyy" => "dd.MM.yyyy",
-                   "yyyy.MM.dd" => "yyyy.MM.dd",
-                   "g yyyy/M/d" => "yyyy/MM/dd",
-                   "d/M/yyyy" => "dd/MM/yyyy",
-                   "d?/M?/yyyy g" => "dd/MM/yyyy",
-                   "d-M-yyyy" => "dd-MM-yyyy",
-                   "d.MM.yyyy" => "dd.MM.yyyy",
-                   "d.MM.yyyy '?'." => "dd.MM.yyyy",
-                   "M/d/yyyy" => "MM/dd/yyyy",
-                   "d. M. yyyy." => "dd.MM.yyyy",
-                   "d.M.yyyy." => "dd.MM.yyyy",
-                   "g yyyy-MM-dd" => "yyyy-MM-dd",
-                   "d.M.yyyy" => "dd.MM.yyyy",
-                   "d/MM/yyyy" => "dd/MM/yyyy",
-                   "yyyy/M/d" => "yyyy/MM/dd",
-                   "dd. MM. yyyy." => "dd.MM.yyyy",
-                   "yyyy. MM. dd." => "yyyy.MM.dd",
-                   "yyyy. M. d." => "yyyy.MM.dd",
-                   "d. MM. yyyy" => "dd.MM.yyyy",
-                   _ => "dd/MM/yyyy"
-               };
+        {
+            "MM/dd/yyyy" => "MM/dd/yyyy",
+            "yyyy-MM-dd" => "yyyy-MM-dd",
+            "yyyy/MM/dd" => "yyyy/MM/dd",
+            "dd/MM/yyyy" => "dd/MM/yyyy",
+            "d?/M?/yyyy" => "dd/MM/yyyy",
+            "dd.MM.yyyy" => "dd.MM.yyyy",
+            "dd-MM-yyyy" => "dd-MM-yyyy",
+            "dd/MM yyyy" => "dd/MM/yyyy",
+            "d. M. yyyy" => "dd.MM.yyyy",
+            "yyyy.MM.dd" => "yyyy.MM.dd",
+            "g yyyy/M/d" => "yyyy/MM/dd",
+            "d/M/yyyy" => "dd/MM/yyyy",
+            "d?/M?/yyyy g" => "dd/MM/yyyy",
+            "d-M-yyyy" => "dd-MM-yyyy",
+            "d.MM.yyyy" => "dd.MM.yyyy",
+            "d.MM.yyyy '?'." => "dd.MM.yyyy",
+            "M/d/yyyy" => "MM/dd/yyyy",
+            "d. M. yyyy." => "dd.MM.yyyy",
+            "d.M.yyyy." => "dd.MM.yyyy",
+            "g yyyy-MM-dd" => "yyyy-MM-dd",
+            "d.M.yyyy" => "dd.MM.yyyy",
+            "d/MM/yyyy" => "dd/MM/yyyy",
+            "yyyy/M/d" => "yyyy/MM/dd",
+            "dd. MM. yyyy." => "dd.MM.yyyy",
+            "yyyy. MM. dd." => "yyyy.MM.dd",
+            "yyyy. M. d." => "yyyy.MM.dd",
+            "d. MM. yyyy" => "dd.MM.yyyy",
+            _ => "dd/MM/yyyy"
+        };
     }
 }

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -341,7 +341,6 @@ public class TextField : View
 
         KeyBindings.Add (Key.Home, Command.LeftStart);
         KeyBindings.Add (Key.Home.WithCtrl, Command.LeftStart);
-        KeyBindings.Add (Key.A.WithCtrl, Command.LeftStart);
 
         KeyBindings.Add (Key.CursorLeft.WithShift, Command.LeftExtend);
         KeyBindings.Add (Key.CursorUp.WithShift, Command.LeftExtend);
@@ -393,14 +392,14 @@ public class TextField : View
         KeyBindings.Add (Key.C.WithCtrl, Command.Copy);
         KeyBindings.Add (Key.X.WithCtrl, Command.Cut);
         KeyBindings.Add (Key.V.WithCtrl, Command.Paste);
-        KeyBindings.Add (Key.T.WithCtrl, Command.SelectAll);
+        KeyBindings.Add (Key.A.WithCtrl, Command.SelectAll);
 
         KeyBindings.Add (Key.R.WithCtrl, Command.DeleteAll);
         KeyBindings.Add (Key.D.WithCtrl.WithShift, Command.DeleteAll);
 
         _currentCulture = Thread.CurrentThread.CurrentUICulture;
 
-        ContextMenu = new() { Host = this };
+        ContextMenu = new () { Host = this };
         ContextMenu.KeyChanged += ContextMenu_KeyChanged;
 
         KeyBindings.Add (ContextMenu.Key, KeyBindingScope.HotKey, Command.Context);

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -2347,7 +2347,6 @@ public class TextView : View
         KeyBindings.Add (Key.Backspace, Command.DeleteCharLeft);
 
         KeyBindings.Add (Key.Home, Command.LeftStart);
-        KeyBindings.Add (Key.A.WithCtrl, Command.LeftStart);
 
         KeyBindings.Add (Key.Home.WithShift, Command.LeftStartExtend);
 
@@ -2387,7 +2386,7 @@ public class TextView : View
         KeyBindings.Add (Key.End.WithCtrl.WithShift, Command.EndExtend);
         KeyBindings.Add (Key.Home.WithCtrl, Command.Start);
         KeyBindings.Add (Key.Home.WithCtrl.WithShift, Command.StartExtend);
-        KeyBindings.Add (Key.T.WithCtrl, Command.SelectAll);
+        KeyBindings.Add (Key.A.WithCtrl, Command.SelectAll);
         KeyBindings.Add (Key.InsertChar, Command.ToggleOverwrite);
         KeyBindings.Add (Key.Tab, Command.Tab);
         KeyBindings.Add (Key.Tab.WithShift, Command.BackTab);
@@ -4466,12 +4465,12 @@ public class TextView : View
         }
         else
         {
-            _historyText.Add ([[.. currentLine]], CursorPosition);
+            _historyText.Add ([ [.. currentLine]], CursorPosition);
 
             currentLine.RemoveAt (CurrentColumn);
 
             _historyText.Add (
-                              [[.. currentLine]],
+                              [ [.. currentLine]],
                               CursorPosition,
                               HistoryText.LineStatus.Replaced
                              );
@@ -5058,7 +5057,7 @@ public class TextView : View
         }
 
         _historyText.Add (
-                          [[.. GetCurrentLine ()]],
+                          [ [.. GetCurrentLine ()]],
                           CursorPosition,
                           HistoryText.LineStatus.Replaced
                          );
@@ -5098,7 +5097,7 @@ public class TextView : View
             return;
         }
 
-        _historyText.Add ([[.. currentLine]], CursorPosition);
+        _historyText.Add ([ [.. currentLine]], CursorPosition);
 
         if (currentLine.Count == 0)
         {
@@ -5165,7 +5164,7 @@ public class TextView : View
         }
 
         _historyText.Add (
-                          [[.. GetCurrentLine ()]],
+                          [ [.. GetCurrentLine ()]],
                           CursorPosition,
                           HistoryText.LineStatus.Replaced
                          );
@@ -5189,14 +5188,14 @@ public class TextView : View
 
         List<Cell> currentLine = GetCurrentLine ();
 
-        _historyText.Add ([[.. GetCurrentLine ()]], CursorPosition);
+        _historyText.Add ([ [.. GetCurrentLine ()]], CursorPosition);
 
         if (CurrentColumn == 0)
         {
             DeleteTextBackwards ();
 
             _historyText.ReplaceLast (
-                                      [[.. GetCurrentLine ()]],
+                                      [ [.. GetCurrentLine ()]],
                                       CursorPosition,
                                       HistoryText.LineStatus.Replaced
                                      );
@@ -5235,7 +5234,7 @@ public class TextView : View
         }
 
         _historyText.Add (
-                          [[.. GetCurrentLine ()]],
+                          [ [.. GetCurrentLine ()]],
                           CursorPosition,
                           HistoryText.LineStatus.Replaced
                          );
@@ -5257,14 +5256,14 @@ public class TextView : View
 
         List<Cell> currentLine = GetCurrentLine ();
 
-        _historyText.Add ([[.. GetCurrentLine ()]], CursorPosition);
+        _historyText.Add ([ [.. GetCurrentLine ()]], CursorPosition);
 
         if (currentLine.Count == 0 || CurrentColumn == currentLine.Count)
         {
             DeleteTextForwards ();
 
             _historyText.ReplaceLast (
-                                      [[.. GetCurrentLine ()]],
+                                      [ [.. GetCurrentLine ()]],
                                       CursorPosition,
                                       HistoryText.LineStatus.Replaced
                                      );
@@ -5294,7 +5293,7 @@ public class TextView : View
         }
 
         _historyText.Add (
-                          [[.. GetCurrentLine ()]],
+                          [ [.. GetCurrentLine ()]],
                           CursorPosition,
                           HistoryText.LineStatus.Replaced
                          );

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -4465,12 +4465,12 @@ public class TextView : View
         }
         else
         {
-            _historyText.Add ([ [.. currentLine]], CursorPosition);
+            _historyText.Add ([[.. currentLine]], CursorPosition);
 
             currentLine.RemoveAt (CurrentColumn);
 
             _historyText.Add (
-                              [ [.. currentLine]],
+                              [[.. currentLine]],
                               CursorPosition,
                               HistoryText.LineStatus.Replaced
                              );
@@ -5057,7 +5057,7 @@ public class TextView : View
         }
 
         _historyText.Add (
-                          [ [.. GetCurrentLine ()]],
+                          [[.. GetCurrentLine ()]],
                           CursorPosition,
                           HistoryText.LineStatus.Replaced
                          );
@@ -5097,7 +5097,7 @@ public class TextView : View
             return;
         }
 
-        _historyText.Add ([ [.. currentLine]], CursorPosition);
+        _historyText.Add ([[.. currentLine]], CursorPosition);
 
         if (currentLine.Count == 0)
         {
@@ -5164,7 +5164,7 @@ public class TextView : View
         }
 
         _historyText.Add (
-                          [ [.. GetCurrentLine ()]],
+                          [[.. GetCurrentLine ()]],
                           CursorPosition,
                           HistoryText.LineStatus.Replaced
                          );
@@ -5188,14 +5188,14 @@ public class TextView : View
 
         List<Cell> currentLine = GetCurrentLine ();
 
-        _historyText.Add ([ [.. GetCurrentLine ()]], CursorPosition);
+        _historyText.Add ([[.. GetCurrentLine ()]], CursorPosition);
 
         if (CurrentColumn == 0)
         {
             DeleteTextBackwards ();
 
             _historyText.ReplaceLast (
-                                      [ [.. GetCurrentLine ()]],
+                                      [[.. GetCurrentLine ()]],
                                       CursorPosition,
                                       HistoryText.LineStatus.Replaced
                                      );
@@ -5234,7 +5234,7 @@ public class TextView : View
         }
 
         _historyText.Add (
-                          [ [.. GetCurrentLine ()]],
+                          [[.. GetCurrentLine ()]],
                           CursorPosition,
                           HistoryText.LineStatus.Replaced
                          );
@@ -5256,14 +5256,14 @@ public class TextView : View
 
         List<Cell> currentLine = GetCurrentLine ();
 
-        _historyText.Add ([ [.. GetCurrentLine ()]], CursorPosition);
+        _historyText.Add ([[.. GetCurrentLine ()]], CursorPosition);
 
         if (currentLine.Count == 0 || CurrentColumn == currentLine.Count)
         {
             DeleteTextForwards ();
 
             _historyText.ReplaceLast (
-                                      [ [.. GetCurrentLine ()]],
+                                      [[.. GetCurrentLine ()]],
                                       CursorPosition,
                                       HistoryText.LineStatus.Replaced
                                      );
@@ -5293,7 +5293,7 @@ public class TextView : View
         }
 
         _historyText.Add (
-                          [ [.. GetCurrentLine ()]],
+                          [[.. GetCurrentLine ()]],
                           CursorPosition,
                           HistoryText.LineStatus.Replaced
                          );

--- a/UnitTests/Views/DateFieldTests.cs
+++ b/UnitTests/Views/DateFieldTests.cs
@@ -126,8 +126,6 @@ public class DateFieldTests
         Assert.Equal (1, df.CursorPosition);
         Assert.True (df.NewKeyDownEvent (Key.End));
         Assert.Equal (10, df.CursorPosition);
-        Assert.True (df.NewKeyDownEvent (Key.A.WithCtrl));
-        Assert.Equal (1, df.CursorPosition);
         Assert.True (df.NewKeyDownEvent (Key.E.WithCtrl));
         Assert.Equal (10, df.CursorPosition);
         Assert.True (df.NewKeyDownEvent (Key.CursorLeft));

--- a/UnitTests/Views/TextFieldTests.cs
+++ b/UnitTests/Views/TextFieldTests.cs
@@ -651,7 +651,7 @@ public class TextFieldTests (ITestOutputHelper output)
         Assert.Null (tf.SelectedText);
         Assert.True (tf.NewKeyDownEvent (Key.A.WithCtrl));
         Assert.Equal ("is is a test.", tf.Text);
-        Assert.Equal (0, tf.CursorPosition);
+        Assert.Equal (tf.Text.Length, tf.CursorPosition);
         tf.CursorPosition = 5;
         tf.SelectedStart = -1;
         Assert.Null (tf.SelectedText);
@@ -804,7 +804,7 @@ public class TextFieldTests (ITestOutputHelper output)
         tf.CursorPosition = tf.Text.Length;
         Assert.True (tf.NewKeyDownEvent (Key.Backspace.WithCtrl));
         Assert.Equal ("to jump between text fields", tf.Text);
-        Assert.True (tf.NewKeyDownEvent (Key.T.WithCtrl));
+        Assert.True (tf.NewKeyDownEvent (Key.A.WithCtrl));
         Assert.Equal ("to jump between text fields", tf.SelectedText);
         Assert.True (tf.NewKeyDownEvent (Key.D.WithCtrl.WithShift));
         Assert.Equal ("", tf.Text);
@@ -2109,10 +2109,10 @@ Les Miśerables",
         tf.CursorPosition = 5;
 
         // When there is selected text and the cursor is at the end of the text field
-        Assert.Equal ("Hello",tf.SelectedText);
+        Assert.Equal ("Hello", tf.SelectedText);
 
         // Pressing right should not move focus, instead it should clear selection
-        Assert.True(tf.NewKeyDownEvent (Key.CursorRight));
+        Assert.True (tf.NewKeyDownEvent (Key.CursorRight));
         Assert.Null (tf.SelectedText);
 
         // Now that the selection is cleared another right keypress should move focus
@@ -2139,7 +2139,7 @@ Les Miśerables",
         Assert.Null (tf.SelectedText);
 
         // When clearing selected text with left the cursor should be at the start of the selection
-        Assert.Equal (0,tf.CursorPosition);
+        Assert.Equal (0, tf.CursorPosition);
 
         // Now that the selection is cleared another left keypress should move focus
         Assert.False (tf.NewKeyDownEvent (Key.CursorLeft));

--- a/UnitTests/Views/TextViewTests.cs
+++ b/UnitTests/Views/TextViewTests.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -5137,7 +5136,7 @@ This is the second line.
         Assert.Equal (0, tv.SelectedLength);
         Assert.Equal ("", tv.SelectedText);
         Assert.False (tv.IsSelecting);
-        Assert.True (tv.NewKeyDownEvent (Key.A.WithCtrl));
+        Assert.True (tv.NewKeyDownEvent (Key.Home));
         Assert.Equal (Point.Empty, tv.CursorPosition);
         Assert.Equal (0, tv.SelectedLength);
         Assert.Equal ("", tv.SelectedText);
@@ -5474,7 +5473,7 @@ This is the second line.
         Assert.Equal (Environment.NewLine.Length, tv.SelectedLength);
         Assert.Equal ($"{Environment.NewLine}", tv.SelectedText);
         Assert.True (tv.IsSelecting);
-        Assert.True (tv.NewKeyDownEvent (Key.T.WithCtrl));
+        Assert.True (tv.NewKeyDownEvent (Key.A.WithCtrl));
 
         Assert.Equal (
                       $"{Environment.NewLine}This is the second line.{Environment.NewLine}This is the third ",
@@ -8333,7 +8332,7 @@ Line 2.",
 
         var top = new Toplevel ();
         top.Add (tv);
-        top.Layout();
+        top.Layout ();
         tv.Draw ();
 
         TestHelpers.AssertDriverContentsWithFrameAre (
@@ -8810,7 +8809,7 @@ line.
         tv.SetFocus ();
 
         tv.NewKeyDownEvent (Key.End.WithShift);
-        Assert.Equal (5,tv.CursorPosition.X);
+        Assert.Equal (5, tv.CursorPosition.X);
 
         // When there is selected text and the cursor is at the end of the text field
         Assert.Equal ("Hello", tv.SelectedText);
@@ -8834,7 +8833,7 @@ line.
         tv.NewKeyDownEvent (Key.CursorRight);
         tv.NewKeyDownEvent (Key.CursorRight);
 
-        Assert.Equal (2,tv.CursorPosition.X);
+        Assert.Equal (2, tv.CursorPosition.X);
 
         Assert.True (tv.NewKeyDownEvent (Key.CursorLeft.WithShift));
         Assert.True (tv.NewKeyDownEvent (Key.CursorLeft.WithShift));

--- a/UnitTests/Views/TimeFieldTests.cs
+++ b/UnitTests/Views/TimeFieldTests.cs
@@ -147,6 +147,7 @@ public class TimeFieldTests
         Assert.True (tf.NewKeyDownEvent (Key.End));
         Assert.Equal (8, tf.CursorPosition);
         Assert.True (tf.NewKeyDownEvent (Key.A.WithCtrl));
+        Assert.Equal (9, tf.CursorPosition);
         Assert.Equal (tf.SelectedLength, tf.Text.Length);
         Assert.True (tf.NewKeyDownEvent (Key.E.WithCtrl));
         Assert.Equal (8, tf.CursorPosition);

--- a/UnitTests/Views/TimeFieldTests.cs
+++ b/UnitTests/Views/TimeFieldTests.cs
@@ -147,7 +147,7 @@ public class TimeFieldTests
         Assert.True (tf.NewKeyDownEvent (Key.End));
         Assert.Equal (8, tf.CursorPosition);
         Assert.True (tf.NewKeyDownEvent (Key.A.WithCtrl));
-        Assert.Equal (1, tf.CursorPosition);
+        Assert.Equal (tf.SelectedLength, tf.Text.Length);
         Assert.True (tf.NewKeyDownEvent (Key.E.WithCtrl));
         Assert.Equal (8, tf.CursorPosition);
         Assert.True (tf.NewKeyDownEvent (Key.CursorLeft));


### PR DESCRIPTION
## Fixes

- Fixes #3855 

## Proposed Changes/Todos
- Change Keybinding for "Select All" in Text Inputs from `Ctrl + T` to `Ctrl + A`

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
