### PR TITLE
Fixes #3864. Border isn't cleared after margin thickness change.

### DIFF
--- a/Terminal.Gui/View/View.Drawing.cs
+++ b/Terminal.Gui/View/View.Drawing.cs
@@ -167,6 +167,13 @@ public partial class View // Drawing APIs
 
     private void DoDrawBorderAndPadding ()
     {
+        if (Margin?.NeedsLayout == true)
+        {
+            Margin.NeedsLayout = false;
+            Margin?.ClearFrame ();
+            Margin?.Parent?.SetSubViewNeedsDraw ();
+        }
+
         if (SubViewNeedsDraw)
         {
             // A Subview may add to the LineCanvas. This ensures any Adornment LineCanvas updates happen.
@@ -208,6 +215,22 @@ public partial class View // Drawing APIs
             Padding?.Draw ();
         }
 
+    }
+
+    private void ClearFrame ()
+    {
+        if (Driver is null)
+        {
+            return;
+        }
+
+        // Get screen-relative coords
+        Rectangle toClear = FrameToScreen ();
+
+        Attribute prev = SetAttribute (GetNormalColor ());
+        Driver.FillRect (toClear);
+        SetAttribute (prev);
+        SetNeedsDraw ();
     }
 
     /// <summary>

--- a/UnitTests/View/Adornment/AdornmentTests.cs
+++ b/UnitTests/View/Adornment/AdornmentTests.cs
@@ -511,4 +511,66 @@ public class AdornmentTests (ITestOutputHelper output)
         bool result = adornment.Contains (new (pointX, pointY));
         Assert.Equal (expected, result);
     }
+
+    [Fact]
+    [SetupFakeDriver]
+    public void Border_Is_Cleared_After_Margin_Thickness_Change ()
+    {
+        View view = new () { Text = "View", Width = 6, Height = 3, BorderStyle = LineStyle.Rounded };
+        // Remove border bottom thickness
+        view.Border!.Thickness = new (1, 1, 1, 0);
+        // Add margin bottom thickness
+        view.Margin!.Thickness = new (0, 0, 0, 1);
+
+        Assert.Equal (6, view.Width);
+        Assert.Equal (3, view.Height);
+
+        view.Draw ();
+
+        TestHelpers.AssertDriverContentsWithFrameAre (
+                                                      @"
+╭────╮
+│View│
+",
+                                                      output
+                                                     );
+
+        // Add border bottom thickness
+        view.Border!.Thickness = new (1, 1, 1, 1);
+        // Remove margin bottom thickness
+        view.Margin!.Thickness = new (0, 0, 0, 0);
+
+        view.Draw ();
+
+        Assert.Equal (6, view.Width);
+        Assert.Equal (3, view.Height);
+
+        TestHelpers.AssertDriverContentsWithFrameAre (
+                                                      @"
+╭────╮
+│View│
+╰────╯
+",
+                                                      output
+                                                     );
+
+        // Remove border bottom thickness
+        view.Border!.Thickness = new (1, 1, 1, 0);
+        // Add margin bottom thickness
+        view.Margin!.Thickness = new (0, 0, 0, 1);
+
+        Assert.Equal (6, view.Width);
+        Assert.Equal (3, view.Height);
+
+        View.SetClipToScreen ();
+        view.Draw ();
+
+        TestHelpers.AssertDriverContentsWithFrameAre (
+                                                      @"
+╭────╮
+│View│
+",
+                                                      output
+                                                     );
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3864

## Proposed Changes/Todos

- [x] Clear view frame if margin has `NeedsLayout` as true

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
