### PR TITLE
Fixes #3836. SetupFakeDriver sometimes causes failure in the unit test.

### DIFF
--- a/Terminal.Gui/Application/Application.Initialization.cs
+++ b/Terminal.Gui/Application/Application.Initialization.cs
@@ -150,6 +150,7 @@ public static partial class Application // Initialization (Init/Shutdown)
         try
         {
             MainLoop = Driver!.Init ();
+            SubscribeDriverEvents ();
         }
         catch (InvalidOperationException ex)
         {
@@ -163,8 +164,6 @@ public static partial class Application // Initialization (Init/Shutdown)
                                                 );
         }
 
-        InitState ();
-
         SynchronizationContext.SetSynchronizationContext (new MainLoopSyncContext ());
 
         SupportedCultures = GetSupportedCultures ();
@@ -173,7 +172,7 @@ public static partial class Application // Initialization (Init/Shutdown)
         InitializedChanged?.Invoke (null, new (init));
     }
 
-    internal static void InitState ()
+    internal static void SubscribeDriverEvents ()
     {
         ArgumentNullException.ThrowIfNull (Driver);
 
@@ -181,6 +180,14 @@ public static partial class Application // Initialization (Init/Shutdown)
         Driver.KeyDown += Driver_KeyDown;
         Driver.KeyUp += Driver_KeyUp;
         Driver.MouseEvent += Driver_MouseEvent;
+    }
+
+    internal static void UnsubscribeDriverEvents ()
+    {
+        Driver.SizeChanged -= Driver_SizeChanged;
+        Driver.KeyDown -= Driver_KeyDown;
+        Driver.KeyUp -= Driver_KeyUp;
+        Driver.MouseEvent -= Driver_MouseEvent;
     }
 
     private static void Driver_SizeChanged (object? sender, SizeChangedEventArgs e) { OnSizeChanging (e); }

--- a/Terminal.Gui/Application/Application.Initialization.cs
+++ b/Terminal.Gui/Application/Application.Initialization.cs
@@ -163,10 +163,7 @@ public static partial class Application // Initialization (Init/Shutdown)
                                                 );
         }
 
-        Driver.SizeChanged += Driver_SizeChanged;
-        Driver.KeyDown += Driver_KeyDown;
-        Driver.KeyUp += Driver_KeyUp;
-        Driver.MouseEvent += Driver_MouseEvent;
+        InitState ();
 
         SynchronizationContext.SetSynchronizationContext (new MainLoopSyncContext ());
 
@@ -174,6 +171,16 @@ public static partial class Application // Initialization (Init/Shutdown)
         MainThreadId = Thread.CurrentThread.ManagedThreadId;
         bool init = Initialized = true;
         InitializedChanged?.Invoke (null, new (init));
+    }
+
+    internal static void InitState ()
+    {
+        ArgumentNullException.ThrowIfNull (Driver);
+
+        Driver.SizeChanged += Driver_SizeChanged;
+        Driver.KeyDown += Driver_KeyDown;
+        Driver.KeyUp += Driver_KeyUp;
+        Driver.MouseEvent += Driver_MouseEvent;
     }
 
     private static void Driver_SizeChanged (object? sender, SizeChangedEventArgs e) { OnSizeChanging (e); }

--- a/Terminal.Gui/Application/Application.Initialization.cs
+++ b/Terminal.Gui/Application/Application.Initialization.cs
@@ -184,6 +184,8 @@ public static partial class Application // Initialization (Init/Shutdown)
 
     internal static void UnsubscribeDriverEvents ()
     {
+        ArgumentNullException.ThrowIfNull (Driver);
+
         Driver.SizeChanged -= Driver_SizeChanged;
         Driver.KeyDown -= Driver_KeyDown;
         Driver.KeyUp -= Driver_KeyUp;

--- a/Terminal.Gui/Application/Application.cs
+++ b/Terminal.Gui/Application/Application.cs
@@ -177,10 +177,7 @@ public static partial class Application
         // Driver stuff
         if (Driver is { })
         {
-            Driver.SizeChanged -= Driver_SizeChanged;
-            Driver.KeyDown -= Driver_KeyDown;
-            Driver.KeyUp -= Driver_KeyUp;
-            Driver.MouseEvent -= Driver_MouseEvent;
+            UnsubscribeDriverEvents ();
             Driver?.End ();
             Driver = null;
         }

--- a/UnitTests/Application/ApplicationScreenTests.cs
+++ b/UnitTests/Application/ApplicationScreenTests.cs
@@ -73,7 +73,7 @@ public class ApplicationScreenTests (ITestOutputHelper output)
         Application.ResetState (true);
         Assert.Null (Application.Driver);
         Application.Driver = new FakeDriver { Rows = 25, Cols = 25 };
-        Application.InitState ();
+        Application.SubscribeDriverEvents ();
         Assert.Equal (new (0, 0, 25, 25), Application.Screen);
 
         // Act

--- a/UnitTests/Application/ApplicationScreenTests.cs
+++ b/UnitTests/Application/ApplicationScreenTests.cs
@@ -65,4 +65,24 @@ public class ApplicationScreenTests (ITestOutputHelper output)
         Application.Top = null;
         Application.Shutdown ();
     }
+
+    [Fact]
+    public void Screen_Changes_OnSizeChanged_Without_Call_Application_Init ()
+    {
+        // Arrange
+        Application.ResetState (true);
+        Assert.Null (Application.Driver);
+        Application.Driver = new FakeDriver { Rows = 25, Cols = 25 };
+        Application.InitState ();
+        Assert.Equal (new (0, 0, 25, 25), Application.Screen);
+
+        // Act
+        (((FakeDriver)Application.Driver)!).SetBufferSize (120, 30);
+
+        // Assert
+        Assert.Equal (new (0, 0, 120, 30), Application.Screen);
+
+        // Cleanup
+        Application.ResetState (true);
+    }
 }

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -644,7 +644,7 @@ public class ApplicationTests
     [Fact]
     public void InitState_Throws_If_Driver_Is_Null ()
     {
-        Assert.Throws<ArgumentNullException> (static () => Application.InitState ());
+        Assert.Throws<ArgumentNullException> (static () => Application.SubscribeDriverEvents ());
     }
 
     private void Init ()

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -641,6 +641,12 @@ public class ApplicationTests
         Application.Shutdown ();
     }
 
+    [Fact]
+    public void InitState_Throws_If_Driver_Is_Null ()
+    {
+        Assert.Throws<ArgumentNullException> (static () => Application.InitState ());
+    }
+
     private void Init ()
     {
         Application.Init (new FakeDriver ());

--- a/UnitTests/TestHelpers.cs
+++ b/UnitTests/TestHelpers.cs
@@ -198,6 +198,7 @@ public class SetupFakeDriverAttribute : BeforeAfterTestAttribute
         View.Diagnostics = ViewDiagnosticFlags.Off;
 
         Application.ResetState (true);
+        Assert.Null (Application.Driver);
         Assert.Equal (new (0, 0, 2048, 2048), Application.Screen);
         base.After (methodUnderTest);
     }
@@ -209,6 +210,9 @@ public class SetupFakeDriverAttribute : BeforeAfterTestAttribute
         Application.ResetState (true);
         Assert.Null (Application.Driver);
         Application.Driver = new FakeDriver { Rows = 25, Cols = 25 };
+        Assert.Equal (new (0, 0, 25, 25), Application.Screen);
+        // Ensures subscribing events, at least for the SizeChanged event
+        Application.InitState ();
 
         base.Before (methodUnderTest);
     }

--- a/UnitTests/TestHelpers.cs
+++ b/UnitTests/TestHelpers.cs
@@ -212,7 +212,7 @@ public class SetupFakeDriverAttribute : BeforeAfterTestAttribute
         Application.Driver = new FakeDriver { Rows = 25, Cols = 25 };
         Assert.Equal (new (0, 0, 25, 25), Application.Screen);
         // Ensures subscribing events, at least for the SizeChanged event
-        Application.InitState ();
+        Application.SubscribeDriverEvents ();
 
         base.Before (methodUnderTest);
     }

--- a/UnitTests/TestHelpers.cs
+++ b/UnitTests/TestHelpers.cs
@@ -197,14 +197,8 @@ public class SetupFakeDriverAttribute : BeforeAfterTestAttribute
         // Turn off diagnostic flags in case some test left them on
         View.Diagnostics = ViewDiagnosticFlags.Off;
 
-        if (Application.Driver is { })
-        {
-            ((FakeDriver)Application.Driver).Rows = 25;
-            ((FakeDriver)Application.Driver).Cols = 25;
-            ((FakeDriver)Application.Driver).End ();
-        }
-
-        Application.Driver = null;
+        Application.ResetState (true);
+        Assert.Equal (new (0, 0, 2048, 2048), Application.Screen);
         base.After (methodUnderTest);
     }
 


### PR DESCRIPTION
## Fixes

- Fixes #3836

## Proposed Changes/Todos

- [x] `Application.Screen` was causing this issue because `_screen` wasn't being set to null after running a test using the `SetupFakeDriver`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
