### PR TITLE
Fix foreach runes bug with unicode surrogate pairs

### DIFF
--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -2124,7 +2124,7 @@ public class TextFormatter
         var start = string.Empty;
         var i = 0;
 
-        foreach (Rune c in text)
+        foreach (Rune c in text.EnumerateRunes ())
         {
             if (c == hotKeySpecifier && i == hotPos)
             {

--- a/UnitTests/Views/LabelTests.cs
+++ b/UnitTests/Views/LabelTests.cs
@@ -1460,4 +1460,16 @@ e
         Application.Top.Dispose ();
         Application.ResetState ();
     }
+
+    // https://github.com/gui-cs/Terminal.Gui/issues/3893
+    [Fact]
+    [SetupFakeDriver]
+    public void TestLabelUnderscoreMinus ()
+    {
+        var lbl = new Label ()
+        {
+            Text = "TextView with some more test_- text. Unicode shouldn't 𝔹Aℝ𝔽!"
+        };
+        lbl.Draw ();
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3893 


## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
