### PR TITLE
(Minor fix) Fix the link text, refer to the F# example too

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ The team is looking forward to seeing new amazing projects made by the community
 
 ## Sample Usage in C#
 
-The following example shows a basic Terminal.Gui application in C#:
-
-[!code-csharp[](./Example/Example.cs)]
+The following example shows a basic Terminal.Gui application in C#:  
+[Example (source)](./Example/Example.cs)
 
 When run the application looks as follows:
 
 ![Simple Usage app](./docfx/images/Example.png)
+
+## Sample usage in F#  
+F# examples are located [here](./FSharpExample/Program.fs)
 
 ## Installing
 


### PR DESCRIPTION
The sample code was removed and was replaced with a link; the markup was bleeding.

## Fixes

- Fixes Unmentioned, related: #3890
