### PR TITLE
Reduce func allocations

### DIFF
--- a/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
@@ -746,32 +746,32 @@ public class LineCanvas : IDisposable
         internal Rune _thickV;
         protected IntersectionRuneResolver () { SetGlyphs (); }
 
-        public Rune? GetRuneForIntersects (IConsoleDriver? driver, IntersectionDefinition? [] intersects)
+        public Rune? GetRuneForIntersects (IConsoleDriver? driver, IntersectionDefinition [] intersects)
         {
             bool useRounded = intersects.Any (
-                                              i => i?.Line.Length != 0
+                                              i => i.Line.Length != 0
                                                    && (
-                                                          i?.Line.Style == LineStyle.Rounded
-                                                          || i?.Line.Style
+                                                          i.Line.Style == LineStyle.Rounded
+                                                          || i.Line.Style
                                                           == LineStyle.RoundedDashed
-                                                          || i?.Line.Style
+                                                          || i.Line.Style
                                                           == LineStyle.RoundedDotted)
                                              );
 
             // Note that there aren't any glyphs for intersections of double lines with heavy lines
 
             bool doubleHorizontal = intersects.Any (
-                                                    l => l?.Line.Orientation == Orientation.Horizontal
+                                                    l => l.Line.Orientation == Orientation.Horizontal
                                                          && l.Line.Style == LineStyle.Double
                                                    );
 
             bool doubleVertical = intersects.Any (
-                                                  l => l?.Line.Orientation == Orientation.Vertical
+                                                  l => l.Line.Orientation == Orientation.Vertical
                                                        && l.Line.Style == LineStyle.Double
                                                  );
 
             bool thickHorizontal = intersects.Any (
-                                                   l => l?.Line.Orientation == Orientation.Horizontal
+                                                   l => l.Line.Orientation == Orientation.Horizontal
                                                         && (
                                                                l.Line.Style == LineStyle.Heavy
                                                                || l.Line.Style == LineStyle.HeavyDashed
@@ -779,7 +779,7 @@ public class LineCanvas : IDisposable
                                                   );
 
             bool thickVertical = intersects.Any (
-                                                 l => l?.Line.Orientation == Orientation.Vertical
+                                                 l => l.Line.Orientation == Orientation.Vertical
                                                       && (
                                                              l.Line.Style == LineStyle.Heavy
                                                              || l.Line.Style == LineStyle.HeavyDashed

--- a/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
@@ -318,7 +318,14 @@ public class LineCanvas : IDisposable
 
     private static bool All (IntersectionDefinition [] intersects, Orientation orientation)
     {
-        return intersects.All (i => i.Line.Orientation == orientation);
+        foreach (var intersect in intersects)
+        {
+            if (intersect.Line.Orientation != orientation)
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void ConfigurationManager_Applied (object? sender, ConfigurationManagerEventArgs e)

--- a/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
@@ -804,10 +804,15 @@ public class LineCanvas : IDisposable
             {
                 foreach (var intersect in intersects)
                 {
-                    if (intersect.Line.Length != 0 &&
-                        (intersect.Line.Style == LineStyle.Rounded
-                        || intersect.Line.Style == LineStyle.RoundedDashed
-                        || intersect.Line.Style == LineStyle.RoundedDotted))
+                    if (intersect.Line.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    if (intersect.Line.Style is
+                        LineStyle.Rounded or
+                        LineStyle.RoundedDashed or
+                        LineStyle.RoundedDotted)
                     {
                         return true;
                     }

--- a/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
@@ -166,10 +166,11 @@ public class LineCanvas : IDisposable
         {
             for (int x = Bounds.X; x < Bounds.X + Bounds.Width; x++)
             {
-                IntersectionDefinition? [] intersects = _lines
-                                                        .Select (l => l.Intersects (x, y))
-                                                        .Where (i => i is { })
-                                                        .ToArray ();
+                IntersectionDefinition [] intersects = _lines
+                    // ! nulls filtered out by the next Where filter
+                    .Select (l => l.Intersects (x, y)!)
+                    .Where (i => i is not null)
+                    .ToArray ();
 
                 Cell? cell = GetCellForIntersects (Application.Driver, intersects);
 
@@ -345,9 +346,9 @@ public class LineCanvas : IDisposable
     /// <returns></returns>
     private static bool Exactly (HashSet<IntersectionType> intersects, params IntersectionType [] types) { return intersects.SetEquals (types); }
 
-    private Attribute? GetAttributeForIntersects (IntersectionDefinition? [] intersects)
+    private Attribute? GetAttributeForIntersects (IntersectionDefinition [] intersects)
     {
-        return Fill?.GetAttribute (intersects [0]!.Point) ?? intersects [0]!.Line.Attribute;
+        return Fill?.GetAttribute (intersects [0].Point) ?? intersects [0].Line.Attribute;
     }
 
     private readonly Dictionary<IntersectionRuneType, IntersectionRuneResolver> _runeResolvers = new ()
@@ -392,7 +393,7 @@ public class LineCanvas : IDisposable
         // TODO: Add other resolvers
     };
 
-    private Cell? GetCellForIntersects (IConsoleDriver? driver, IntersectionDefinition? [] intersects)
+    private Cell? GetCellForIntersects (IConsoleDriver? driver, IntersectionDefinition [] intersects)
     {
         if (!intersects.Any ())
         {

--- a/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
@@ -428,22 +428,22 @@ public class LineCanvas : IDisposable
         }
 
         // TODO: Remove these once we have all of the below ported to IntersectionRuneResolvers
-        bool useDouble = intersects.Any (i => i?.Line.Style == LineStyle.Double);
+        bool useDouble = intersects.Any (i => i.Line.Style == LineStyle.Double);
 
         bool useDashed = intersects.Any (
-                                         i => i?.Line.Style == LineStyle.Dashed
-                                              || i?.Line.Style == LineStyle.RoundedDashed
+                                         i => i.Line.Style == LineStyle.Dashed
+                                              || i.Line.Style == LineStyle.RoundedDashed
                                         );
 
         bool useDotted = intersects.Any (
-                                         i => i?.Line.Style == LineStyle.Dotted
-                                              || i?.Line.Style == LineStyle.RoundedDotted
+                                         i => i.Line.Style == LineStyle.Dotted
+                                              || i.Line.Style == LineStyle.RoundedDotted
                                         );
 
         // horiz and vert lines same as Single for Rounded
-        bool useThick = intersects.Any (i => i?.Line.Style == LineStyle.Heavy);
-        bool useThickDashed = intersects.Any (i => i?.Line.Style == LineStyle.HeavyDashed);
-        bool useThickDotted = intersects.Any (i => i?.Line.Style == LineStyle.HeavyDotted);
+        bool useThick = intersects.Any (i => i.Line.Style == LineStyle.Heavy);
+        bool useThickDashed = intersects.Any (i => i.Line.Style == LineStyle.HeavyDashed);
+        bool useThickDotted = intersects.Any (i => i.Line.Style == LineStyle.HeavyDotted);
 
         // TODO: Support ruler
         //var useRuler = intersects.Any (i => i.Line.Style == LineStyle.Ruler && i.Line.Length != 0);

--- a/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
@@ -207,10 +207,11 @@ public class LineCanvas : IDisposable
         {
             for (int x = inArea.X; x < inArea.X + inArea.Width; x++)
             {
-                IntersectionDefinition? [] intersects = _lines
-                                                        .Select (l => l.Intersects (x, y))
-                                                        .Where (i => i is { })
-                                                        .ToArray ();
+                IntersectionDefinition [] intersects = _lines
+                    // ! nulls are filtered out by the next Where filter
+                    .Select (l => l.Intersects (x, y)!)
+                    .Where (i => i is not null)
+                    .ToArray ();
 
                 Rune? rune = GetRuneForIntersects (Application.Driver, intersects);
 
@@ -315,9 +316,9 @@ public class LineCanvas : IDisposable
         return sb.ToString ();
     }
 
-    private static bool All (IntersectionDefinition? [] intersects, Orientation orientation)
+    private static bool All (IntersectionDefinition [] intersects, Orientation orientation)
     {
-        return intersects.All (i => i!.Line.Orientation == orientation);
+        return intersects.All (i => i.Line.Orientation == orientation);
     }
 
     private void ConfigurationManager_Applied (object? sender, ConfigurationManagerEventArgs e)
@@ -404,7 +405,7 @@ public class LineCanvas : IDisposable
         return cell;
     }
 
-    private Rune? GetRuneForIntersects (IConsoleDriver? driver, IntersectionDefinition? [] intersects)
+    private Rune? GetRuneForIntersects (IConsoleDriver? driver, IntersectionDefinition [] intersects)
     {
         if (!intersects.Any ())
         {
@@ -495,9 +496,9 @@ public class LineCanvas : IDisposable
         }
     }
 
-    private IntersectionRuneType GetRuneTypeForIntersects (IntersectionDefinition? [] intersects)
+    private IntersectionRuneType GetRuneTypeForIntersects (IntersectionDefinition [] intersects)
     {
-        HashSet<IntersectionType> set = new (intersects.Select (i => i!.Type));
+        HashSet<IntersectionType> set = new (intersects.Select (i => i.Type));
 
         #region Cross Conditions
 

--- a/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
@@ -820,7 +820,10 @@ public class LineCanvas : IDisposable
                 return false;
             }
 
-            static bool AnyWithOrientationAndAnyLineStyle (ReadOnlySpan<IntersectionDefinition> intersects, Orientation orientation, ReadOnlySpan<LineStyle> lineStyles)
+            static bool AnyWithOrientationAndAnyLineStyle (
+                ReadOnlySpan<IntersectionDefinition> intersects,
+                Orientation orientation,
+                ReadOnlySpan<LineStyle> lineStyles)
             {
                 foreach (var i in intersects)
                 {

--- a/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
+++ b/Terminal.Gui/Drawing/LineCanvas/LineCanvas.cs
@@ -683,7 +683,17 @@ public class LineCanvas : IDisposable
     /// <param name="intersects"></param>
     /// <param name="types"></param>
     /// <returns></returns>
-    private bool Has (HashSet<IntersectionType> intersects, params IntersectionType [] types) { return types.All (t => intersects.Contains (t)); }
+    private bool Has (HashSet<IntersectionType> intersects, params IntersectionType [] types)
+    {
+        foreach (var type in types)
+        {
+            if (!intersects.Contains (type))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
 
     private class BottomTeeIntersectionRuneResolver : IntersectionRuneResolver
     {

--- a/Terminal.Gui/Drawing/Region.cs
+++ b/Terminal.Gui/Drawing/Region.cs
@@ -154,14 +154,34 @@ public class Region : IDisposable
     /// <param name="x">The x-coordinate of the point.</param>
     /// <param name="y">The y-coordinate of the point.</param>
     /// <returns><c>true</c> if the point is contained within the region; otherwise, <c>false</c>.</returns>
-    public bool Contains (int x, int y) { return _rectangles.Any (r => r.Contains (x, y)); }
+    public bool Contains (int x, int y)
+    {
+        foreach (var rect in _rectangles)
+        {
+            if (rect.Contains (x, y))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /// <summary>
     ///     Determines whether the specified rectangle is contained within the region.
     /// </summary>
     /// <param name="rectangle">The rectangle to check for containment.</param>
     /// <returns><c>true</c> if the rectangle is contained within the region; otherwise, <c>false</c>.</returns>
-    public bool Contains (Rectangle rectangle) { return _rectangles.Any (r => r.Contains (rectangle)); }
+    public bool Contains (Rectangle rectangle)
+    {
+        foreach (var rect in _rectangles)
+        {
+            if (rect.Contains (rectangle))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /// <summary>
     ///     Returns an array of rectangles that represent the region.

--- a/Terminal.Gui/Drawing/Region.cs
+++ b/Terminal.Gui/Drawing/Region.cs
@@ -1,6 +1,6 @@
-﻿using System.Buffers;
+﻿#nullable enable
 
-#nullable enable
+using System.Buffers;
 
 /// <summary>
 ///     Represents a region composed of one or more rectangles, providing methods for union, intersection, exclusion, and

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -1926,12 +1926,12 @@ public class TextFormatter
 
     private static int GetRuneWidth (string str, int tabWidth, TextDirection textDirection = TextDirection.LeftRight_TopBottom)
     {
-        return GetRuneWidth (str.EnumerateRunes ().ToList (), tabWidth, textDirection);
-    }
-
-    private static int GetRuneWidth (List<Rune> runes, int tabWidth, TextDirection textDirection = TextDirection.LeftRight_TopBottom)
-    {
-        return runes.Sum (r => GetRuneWidth (r, tabWidth, textDirection));
+        int runesWidth = 0;
+        foreach (Rune rune in str.EnumerateRunes ())
+        {
+            runesWidth += GetRuneWidth (rune, tabWidth, textDirection);
+        }
+        return runesWidth;
     }
 
     private static int GetRuneWidth (Rune rune, int tabWidth, TextDirection textDirection = TextDirection.LeftRight_TopBottom)

--- a/Terminal.Gui/View/Layout/PosAlign.cs
+++ b/Terminal.Gui/View/Layout/PosAlign.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System.ComponentModel;
-using System.Text.RegularExpressions;
 
 namespace Terminal.Gui;
 
@@ -61,18 +60,12 @@ public record PosAlign : Pos
     /// <returns></returns>
     public static int CalculateMinDimension (int groupId, IList<View> views, Dimension dimension)
     {
-        // PERF: If this proves a perf issue, consider caching a ref to this list in each item
-        List<View> viewsInGroup = views.Where (v => HasGroupId (v, dimension, groupId)).ToList ();
-
-        if (viewsInGroup.Count == 0)
-        {
-            return 0;
-        }
-
         int dimensionsSum = 0;
-        for (int index = 0; index < viewsInGroup.Count; index++)
+        foreach (var view in views)
         {
-            View view = viewsInGroup [index];
+            if (!HasGroupId (view, dimension, groupId)) {
+                continue;
+            }
 
             PosAlign? posAlign = dimension == Dimension.Width
                 ? view.X as PosAlign

--- a/Terminal.Gui/View/Layout/PosAlign.cs
+++ b/Terminal.Gui/View/Layout/PosAlign.cs
@@ -61,8 +61,6 @@ public record PosAlign : Pos
     /// <returns></returns>
     public static int CalculateMinDimension (int groupId, IList<View> views, Dimension dimension)
     {
-        List<int> dimensionsList = new ();
-
         // PERF: If this proves a perf issue, consider caching a ref to this list in each item
         List<View> viewsInGroup = views.Where (v => HasGroupId (v, dimension, groupId)).ToList ();
 
@@ -71,23 +69,25 @@ public record PosAlign : Pos
             return 0;
         }
 
-        // PERF: We iterate over viewsInGroup multiple times here.
-
-        // Update the dimensionList with the sizes of the views
-        for (var index = 0; index < viewsInGroup.Count; index++)
+        int dimensionsSum = 0;
+        for (int index = 0; index < viewsInGroup.Count; index++)
         {
             View view = viewsInGroup [index];
 
-            PosAlign? posAlign = dimension == Dimension.Width ? view.X as PosAlign : view.Y as PosAlign;
+            PosAlign? posAlign = dimension == Dimension.Width
+                ? view.X as PosAlign
+                : view.Y as PosAlign;
 
             if (posAlign is { })
             {
-                dimensionsList.Add (dimension == Dimension.Width ? view.Frame.Width : view.Frame.Height);
+                dimensionsSum += dimension == Dimension.Width
+                    ? view.Frame.Width
+                    : view.Frame.Height;
             }
         }
 
         // Align
-        return dimensionsList.Sum ();
+        return dimensionsSum;
     }
 
     internal static bool HasGroupId (View v, Dimension dimension, int groupId)


### PR DESCRIPTION
## Fixes

- Improves #2725
- Eliminates major sources of `Func<,>` allocations originating from LINQ lambda outer variable captures by replacing them with equivalent loops.*

\* Measured in most likely skewed scenario described in the "Data collection scenario" section.

## Proposed Changes/Todos

- [x] Refactor `LineCanvas` to reduce majority of Func allocations
    - [x] `LineCanvas.All(...)`
    - [x] `LineCanvas.GetCellMap(...)`
    - [x] `LineCanvas.Has(...)`
- [x] Refactor `Region` to reduce majority of Func allocations
    - [x] `Region.Contains(...)`
    - [x] `Region.Intersect(...)`
- [x] Refactor `PosAlign.CalculateMinDimension(...)` to reduce majority of Func allocations  
- [x] Refactor `TextFormatter.GetRuneWidth(...)` to reduce majority of Func allocations

## Pull Request checklist

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

## Disclaimer

I like LINQ and the convenience it offers and use it most of time over loops when appropriate. Unfortunately when used in application hot paths the heap allocations can get out of hand due to hidden allocations from captured outer variables.

## Data collection scenario

Run in Windows Terminal v1.21.10351.0 120x30 Command Prompt tab.

1. Start UICatalog.
2. Navigate down the Categories list using arrow key down.
    - Pause for a while (~1 sec) between key presses so that the Scenarios view has time to load properly.
3. Once at the bottom of the list navigate up using the arrow key up in similar manner until back at the top of the Categories list.
4. Quit application.
5. ???
6. Profit

This does not necessarily represent a typical application use and probably skews the statistics but at least reveals some allocation issues when using similar list navigation.

Ideally there would be some sort of automation that emulates more typical application.

## Object allocation statistics

Data collected in Release build using Visual Studio Performance Profiler .NET Object Allocation Tracking.

### Before
![1_before_func-allocations](https://github.com/user-attachments/assets/4993ed12-1001-48bf-a244-cf3eee6fbea4)

### After

As a bonus, also list and enumerator allocations decreased slightly.
![2_after_1_top_allocations](https://github.com/user-attachments/assets/c21d40f2-a250-4f15-9e89-15633237296d)

The main focus `Func<,>` dropped way down the allocation list.

There are still some unnecessary Func<,> allocations but the PR is already getting quite bloated. Also some of them are not worth the effort unless of course profiling other parts of the UICatalog tells otherwise. I nope'd out quite quickly after seeing `DimAuto.Calculate(...)`. 😆

![2_after_2_func-allocations](https://github.com/user-attachments/assets/287da227-3313-4e81-a099-2e6dee1f9fdb)

## Refactors

### LineCanvas.All

LINQ All replaced with equivalent foreach loop.

### LineCanvas.GetCellMap

Replaced array allocation inside nested loops + LINQ lambdas with List buffer outside the nested. If IntersectionDefinition would be struct then stackalloc/ArrayPool would have made more sense.

Maybe the biggest change due to ReadOnlySpan replacing arrays in the methods further down the line, which forced to replace LINQ lambdas from those methods as well. `GetRuneForIntersects(...)` being the biggest "victim" of this change. Tried to keep it readable with local methods.

### LineCanvas.Has

Similar change as in `LineCanvas.All(...)`.

### Region.Contains

Replaced LINQ Any with foreach loop.

### Region.Intersect

Replaced list allocation and LINQ lambdas with foreach loop utilizing stackalloc buffer or pooled array depending on the amount of region rectangles. The original rectangles list is cleared and reused instead of creating new list every time. The list can still of course internally create new array if capacity is too small.

### PosAlign.CalculateMinDimension

Group list and sum list allocations with multiple loops replaced with single loop combining the group check and summing.

### TextFormatter.GetRuneWidth

Removed intermediate list allocation and just looped through the StringRuneEnumerator and summing the widths.
