### PR TITLE
UICatalog benchmark launch profiles for v2 drivers

### DIFF
--- a/UICatalog/Properties/launchSettings.json
+++ b/UICatalog/Properties/launchSettings.json
@@ -39,6 +39,14 @@
       "commandName": "Project",
       "commandLineArgs": "--driver NetDriver --benchmark"
     },
+    "Benchmark All --driver v2win": {
+      "commandName": "Project",
+      "commandLineArgs": "--driver v2win --benchmark"
+    },
+    "Benchmark All --driver v2net": {
+      "commandName": "Project",
+      "commandLineArgs": "--driver v2net --benchmark"
+    },
     "WSL: Benchmark All": {
       "commandName": "Executable",
       "executablePath": "wsl",


### PR DESCRIPTION
## Fixes

- Maybe helps with investigating #3941

## Proposed Changes

- [x] Add launch profiles for v2win and v2net driver.

![image](https://github.com/user-attachments/assets/2177cb6d-4840-46bc-b875-574264e459ab)

## Pull Request Checklist

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
