### PR TITLE
Fixes #3937 Change LayoutAndDraw in v2 applications to simply set draw/layout flags

### DIFF
--- a/Terminal.Gui/Application/Application.Run.cs
+++ b/Terminal.Gui/Application/Application.Run.cs
@@ -412,6 +412,11 @@ public static partial class Application // Run (Begin, Run, End, Stop)
     /// <param name="forceDraw">If <see langword="true"/> the entire View hierarchy will be redrawn. The default is <see langword="false"/> and should only be overriden for testing.</param>
     public static void LayoutAndDraw (bool forceDraw = false)
     {
+        ApplicationImpl.Instance.LayoutAndDraw (forceDraw);
+    }
+
+    internal static void LayoutAndDrawImpl (bool forceDraw = false)
+    {
         bool neededLayout = View.Layout (TopLevels.Reverse (), Screen.Size);
 
         if (ClearScreenNextIteration)

--- a/Terminal.Gui/Application/ApplicationImpl.cs
+++ b/Terminal.Gui/Application/ApplicationImpl.cs
@@ -294,4 +294,10 @@ public class ApplicationImpl : IApplication
     { 
         return Application.MainLoop?.TimedEvents.RemoveTimeout (token) ?? false;
     }
+
+    /// <inheritdoc />
+    public virtual void LayoutAndDraw (bool forceDraw)
+    {
+        Application.LayoutAndDrawImpl (forceDraw);
+    }
 }

--- a/Terminal.Gui/Application/IApplication.cs
+++ b/Terminal.Gui/Application/IApplication.cs
@@ -182,4 +182,11 @@ public interface IApplication
     /// <see langword="false"/>
     /// if the timeout is not found.</returns>
     bool RemoveTimeout (object token);
+
+    /// <summary>
+    /// Causes any Toplevels that need layout to be laid out. Then draws any Toplevels that need display. Only Views that need to be laid out (see <see cref="View.NeedsLayout"/>) will be laid out.
+    /// Only Views that need to be drawn (see <see cref="View.NeedsDraw"/>) will be drawn.
+    /// </summary>
+    /// <param name="forceDraw">If <see langword="true"/> the entire View hierarchy will be redrawn. The default is <see langword="false"/> and should only be overriden for testing.</param>
+    void LayoutAndDraw (bool forceDraw);
 }

--- a/Terminal.Gui/ConsoleDrivers/V2/ApplicationV2.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/ApplicationV2.cs
@@ -232,4 +232,12 @@ public class ApplicationV2 : ApplicationImpl
 
     /// <inheritdoc/>
     public override bool RemoveTimeout (object token) { return _timedEvents.RemoveTimeout (token); }
+
+    /// <inheritdoc />
+    public override void LayoutAndDraw (bool forceDraw)
+    {
+        // No more ad-hoc drawing, you must wait for iteration to do it
+        Application.Top?.SetNeedsDraw();
+        Application.Top?.SetNeedsLayout ();
+    }
 }

--- a/Terminal.Gui/ConsoleDrivers/V2/MainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/MainLoop.cs
@@ -130,8 +130,7 @@ public class MainLoop<T> : IMainLoop<T>
             {
                 Logging.Redraws.Add (1);
 
-                // TODO: Test only
-                Application.LayoutAndDraw (true);
+                Application.LayoutAndDrawImpl (true);
 
                 Out.Write (OutputBuffer);
 


### PR DESCRIPTION
## Fixes

- Fixes #3937

## Proposed Changes/Todos

Takes static method `Application.LayoutAndDraw` and moves it into non static `ApplicationImpl` class.

Override behviour for v2 drivers to simply set the needs draw and needs layout flags.

## How it works

Application contains many static methods, these cannot be overriden and are publically accessible to consumers so cannot be easily changed.

The v2 driver branch introduced a non static `ApplicationImpl` class with many `virtual` methods.  

Process of making an Application method overrideable:
- Rename the `Application` static method with `Impl` at the end and make it `internal`
- Create a public method with the original name and signature (i.e. restore the existing method signature)
- The new method passes directly to the current `ApplicationImpl.Instance`.
- The default behaviour of the `ApplicationImpl` class is simply to call the new `Impl` method back in main `Application` (ping pong the call back to the static function)
- However since it is virtual the v2 class can override the behaviour and do something else

For the core iteration in `MainLoop<T>`, we still need the full method so we call the Impl version on Application.

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
