### PR TITLE
Fixes #3930. Tests are crashing again...

### DIFF
--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -1140,7 +1140,7 @@ public class ApplicationTests
     #region ShutdownTests
 
     [Fact]
-    public async void Shutdown_Allows_Async ()
+    public async Task Shutdown_Allows_Async ()
     {
         var isCompletedSuccessfully = false;
 

--- a/UnitTests/Configuration/GlyphTests.cs
+++ b/UnitTests/Configuration/GlyphTests.cs
@@ -45,6 +45,7 @@ public class GlyphTests
 
         // clean up
         Locations = ConfigLocations.All;
+        Settings = null;
     }
 
 }

--- a/UnitTests/Configuration/GlyphTests.cs
+++ b/UnitTests/Configuration/GlyphTests.cs
@@ -45,7 +45,7 @@ public class GlyphTests
 
         // clean up
         Locations = ConfigLocations.All;
-        Settings = null;
+        Settings.Sources.Clear ();
     }
 
 }

--- a/UnitTests/Configuration/GlyphTests.cs
+++ b/UnitTests/Configuration/GlyphTests.cs
@@ -44,8 +44,6 @@ public class GlyphTests
         Assert.Equal((Rune)'[', Glyphs.LeftBracket);
 
         // clean up
-        Locations = ConfigLocations.All;
-        Settings.Sources.Clear ();
+        Reset ();
     }
-
 }

--- a/UnitTests/ConsoleDrivers/ConsoleKeyMappingTests.cs
+++ b/UnitTests/ConsoleDrivers/ConsoleKeyMappingTests.cs
@@ -403,67 +403,7 @@ public class ConsoleKeyMappingTests
     }
 
     [Theory]
-    [InlineData ('a', ConsoleKey.A, false, false, false, 30)]
-    [InlineData ('A', ConsoleKey.A, true, false, false, 30)]
-    [InlineData ('á', ConsoleKey.A, false, false, false, 30)]
-    [InlineData ('Á', ConsoleKey.A, true, false, false, 30)]
-    [InlineData ('à', ConsoleKey.A, false, false, false, 30)]
-    [InlineData ('À', ConsoleKey.A, true, false, false, 30)]
-    [InlineData ('0', ConsoleKey.D0, false, false, false, 11)]
-    [InlineData ('=', ConsoleKey.D0, true, false, false, 11)]
-    [InlineData ('}', ConsoleKey.D0, false, true, true, 11)]
-    [InlineData ('1', ConsoleKey.D1, false, false, false, 2)]
-    [InlineData ('!', ConsoleKey.D1, true, false, false, 2)]
-    [InlineData ('2', ConsoleKey.D2, false, false, false, 3)]
-    [InlineData ('"', ConsoleKey.D2, true, false, false, 3)]
-    [InlineData ('@', ConsoleKey.D2, false, true, true, 3)]
-    [InlineData ('3', ConsoleKey.D3, false, false, false, 4)]
-    [InlineData ('#', ConsoleKey.D3, true, false, false, 4)]
-    [InlineData ('£', ConsoleKey.D3, false, true, true, 4)]
-    [InlineData ('4', ConsoleKey.D4, false, false, false, 5)]
-    [InlineData ('$', ConsoleKey.D4, true, false, false, 5)]
-    [InlineData ('§', ConsoleKey.D4, false, true, true, 5)]
-    [InlineData ('5', ConsoleKey.D5, false, false, false, 6)]
-    [InlineData ('%', ConsoleKey.D5, true, false, false, 6)]
-    [InlineData ('€', ConsoleKey.D5, false, true, true, 6)]
-    [InlineData ('6', ConsoleKey.D6, false, false, false, 7)]
-    [InlineData ('&', ConsoleKey.D6, true, false, false, 7)]
-    [InlineData ('7', ConsoleKey.D7, false, false, false, 8)]
-    [InlineData ('/', ConsoleKey.D7, true, false, false, 8)]
-    [InlineData ('{', ConsoleKey.D7, false, true, true, 8)]
-    [InlineData ('8', ConsoleKey.D8, false, false, false, 9)]
-    [InlineData ('(', ConsoleKey.D8, true, false, false, 9)]
-    [InlineData ('[', ConsoleKey.D8, false, true, true, 9)]
-    [InlineData ('9', ConsoleKey.D9, false, false, false, 10)]
-    [InlineData (')', ConsoleKey.D9, true, false, false, 10)]
-    [InlineData (']', ConsoleKey.D9, false, true, true, 10)]
-    [InlineData ('´', ConsoleKey.Oem1, false, false, false, 27)]
-    [InlineData ('`', ConsoleKey.Oem1, true, false, false, 27)]
-    [InlineData ('~', ConsoleKey.Oem2, false, false, false, 43)]
-    [InlineData ('^', ConsoleKey.Oem2, true, false, false, 43)]
-    [InlineData ('ç', ConsoleKey.Oem3, false, false, false, 39)]
-    [InlineData ('Ç', ConsoleKey.Oem3, true, false, false, 39)]
-    [InlineData ('\'', ConsoleKey.Oem4, false, false, false, 12)]
-    [InlineData ('?', ConsoleKey.Oem4, true, false, false, 12)]
-    [InlineData ('\\', ConsoleKey.Oem5, false, true, true, 41)]
-    [InlineData ('|', ConsoleKey.Oem5, true, false, false, 41)]
-    [InlineData ('«', ConsoleKey.Oem6, false, true, true, 13)]
-    [InlineData ('»', ConsoleKey.Oem6, true, false, false, 13)]
-    [InlineData ('º', ConsoleKey.Oem7, false, true, true, 40)]
-    [InlineData ('ª', ConsoleKey.Oem7, true, false, false, 40)]
-    [InlineData ('+', ConsoleKey.OemPlus, false, true, true, 26)]
-    [InlineData ('*', ConsoleKey.OemPlus, true, false, false, 26)]
-    [InlineData ('¨', ConsoleKey.OemPlus, false, true, true, 26)]
-    [InlineData (',', ConsoleKey.OemComma, false, true, true, 51)]
-    [InlineData (';', ConsoleKey.OemComma, true, false, false, 51)]
-    [InlineData ('.', ConsoleKey.OemPeriod, false, true, true, 52)]
-    [InlineData (':', ConsoleKey.OemPeriod, true, false, false, 52)]
-    [InlineData ('-', ConsoleKey.OemMinus, false, true, true, 53)]
-    [InlineData ('_', ConsoleKey.OemMinus, true, false, false, 53)]
-    [InlineData ('q', ConsoleKey.Q, false, false, false, 16)]
-    [InlineData ('\0', ConsoleKey.F2, false, false, false, 60)]
-    [InlineData ('英', ConsoleKey.None, false, false, false, 0)]
-    [InlineData ('英', ConsoleKey.None, true, false, false, 0)]
+    [MemberData (nameof (GetScanCodeData))]
     public void GetScanCodeFromConsoleKeyInfo_Tests (
         char keyChar,
         ConsoleKey consoleKey,
@@ -477,6 +417,71 @@ public class ConsoleKeyMappingTests
         uint scanCode = GetScanCodeFromConsoleKeyInfo (consoleKeyInfo);
 
         Assert.Equal (scanCode, expectedScanCode);
+    }
+
+    public static IEnumerable<object []> GetScanCodeData ()
+    {
+        yield return ['a', ConsoleKey.A, false, false, false, 30];
+        yield return ['A', ConsoleKey.A, true, false, false, 30];
+        yield return ['á', ConsoleKey.A, false, false, false, 30];
+        yield return ['Á', ConsoleKey.A, true, false, false, 30];
+        yield return ['à', ConsoleKey.A, false, false, false, 30];
+        yield return ['À', ConsoleKey.A, true, false, false, 30];
+        yield return ['0', ConsoleKey.D0, false, false, false, 11];
+        yield return ['=', ConsoleKey.D0, true, false, false, 11];
+        yield return ['}', ConsoleKey.D0, false, true, true, 11];
+        yield return ['1', ConsoleKey.D1, false, false, false, 2];
+        yield return ['!', ConsoleKey.D1, true, false, false, 2];
+        yield return ['2', ConsoleKey.D2, false, false, false, 3];
+        yield return ['"', ConsoleKey.D2, true, false, false, 3];
+        yield return ['@', ConsoleKey.D2, false, true, true, 3];
+        yield return ['3', ConsoleKey.D3, false, false, false, 4];
+        yield return ['#', ConsoleKey.D3, true, false, false, 4];
+        yield return ['£', ConsoleKey.D3, false, true, true, 4];
+        yield return ['4', ConsoleKey.D4, false, false, false, 5];
+        yield return ['$', ConsoleKey.D4, true, false, false, 5];
+        yield return ['§', ConsoleKey.D4, false, true, true, 5];
+        yield return ['5', ConsoleKey.D5, false, false, false, 6];
+        yield return ['%', ConsoleKey.D5, true, false, false, 6];
+        yield return ['€', ConsoleKey.D5, false, true, true, 6];
+        yield return ['6', ConsoleKey.D6, false, false, false, 7];
+        yield return ['&', ConsoleKey.D6, true, false, false, 7];
+        yield return ['7', ConsoleKey.D7, false, false, false, 8];
+        yield return ['/', ConsoleKey.D7, true, false, false, 8];
+        yield return ['{', ConsoleKey.D7, false, true, true, 8];
+        yield return ['8', ConsoleKey.D8, false, false, false, 9];
+        yield return ['(', ConsoleKey.D8, true, false, false, 9];
+        yield return ['[', ConsoleKey.D8, false, true, true, 9];
+        yield return ['9', ConsoleKey.D9, false, false, false, 10];
+        yield return [')', ConsoleKey.D9, true, false, false, 10];
+        yield return [']', ConsoleKey.D9, false, true, true, 10];
+        yield return ['´', ConsoleKey.Oem1, false, false, false, 27];
+        yield return ['`', ConsoleKey.Oem1, true, false, false, 27];
+        yield return ['~', ConsoleKey.Oem2, false, false, false, 43];
+        yield return ['^', ConsoleKey.Oem2, true, false, false, 43];
+        yield return ['ç', ConsoleKey.Oem3, false, false, false, 39];
+        yield return ['Ç', ConsoleKey.Oem3, true, false, false, 39];
+        yield return ['\'', ConsoleKey.Oem4, false, false, false, 12];
+        yield return ['?', ConsoleKey.Oem4, true, false, false, 12];
+        yield return ['\\', ConsoleKey.Oem5, false, true, true, 41];
+        yield return ['|', ConsoleKey.Oem5, true, false, false, 41];
+        yield return ['«', ConsoleKey.Oem6, false, true, true, 13];
+        yield return ['»', ConsoleKey.Oem6, true, false, false, 13];
+        yield return ['º', ConsoleKey.Oem7, false, true, true, 40];
+        yield return ['ª', ConsoleKey.Oem7, true, false, false, 40];
+        yield return ['+', ConsoleKey.OemPlus, false, true, true, 26];
+        yield return ['*', ConsoleKey.OemPlus, true, false, false, 26];
+        yield return ['¨', ConsoleKey.OemPlus, false, true, true, 26];
+        yield return [',', ConsoleKey.OemComma, false, true, true, 51];
+        yield return [';', ConsoleKey.OemComma, true, false, false, 51];
+        yield return ['.', ConsoleKey.OemPeriod, false, true, true, 52];
+        yield return [':', ConsoleKey.OemPeriod, true, false, false, 52];
+        yield return ['-', ConsoleKey.OemMinus, false, true, true, 53];
+        yield return ['_', ConsoleKey.OemMinus, true, false, false, 53];
+        yield return ['q', ConsoleKey.Q, false, false, false, 16];
+        yield return ['\0', ConsoleKey.F2, false, false, false, 60];
+        yield return ['英', ConsoleKey.None, false, false, false, 0];
+        yield return ['英', ConsoleKey.None, true, false, false, 0];
     }
 
     [Theory]


### PR DESCRIPTION
## Fixes

- Fixes #3930

## Proposed Changes/Todos

- [x]  Overridden `Settings.Sources` needs to be cleared explicitly if `Application.Reset` or `Application.Shutdown` aren't called

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
