### PR TITLE
Fixes 3941 - Do not repeatedly raise new sets of keystrokes when modals pop (stack overflow)

### DIFF
--- a/UICatalog/Scenario.cs
+++ b/UICatalog/Scenario.cs
@@ -229,13 +229,20 @@ public class Scenario : IDisposable
         }
     }
 
+    private HashSet<Scenario> _scenariosRun = new HashSet<Scenario> ();
     private void OnApplicationNotifyNewRunState (object? sender, RunStateEventArgs e)
     {
+        // We are just returning to the same scenario
+        if (!_scenariosRun.Add (this))
+        {
+            return;
+        }
+
         SubscribeAllSubviews (Application.Top!);
 
         _currentDemoKey = 0;
         _demoKeys = GetDemoKeyStrokes ();
-
+        
         Application.AddTimeout (
                                 new TimeSpan (0, 0, 0, 0, BENCHMARK_KEY_PACING),
                                 () =>


### PR DESCRIPTION
This PR is to explore alternative to #3946

First Fix
---------
Do not repeatedly raise new sets of keystrokes when modals pop and trigger run state changes.

This fixes the infinite loop but now _with all drivers (v2 and original)_ the Scenarios hang on any scenario that fires up a modal dialog.


## Fixes

- Fixes #_____

## Proposed Changes/Todos

- [ ] Todo 1

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
