### PR TITLE
Fixes #3950. Revisit v2 Cancelable Event Pattern - was KeyDown and MouseEvent no longer fires for Listbox

### DIFF
--- a/Terminal.Gui/View/View.Keyboard.cs
+++ b/Terminal.Gui/View/View.Keyboard.cs
@@ -319,28 +319,30 @@ public partial class View // Keyboard APIs
 
         bool RaiseKeyDown (Key k)
         {
-            // Before (fire the cancellable event)
-            if (OnKeyDown (k) || k.Handled)
+            // First fire event
+            KeyDown?.Invoke (this, k);
+
+            if (k.Handled)
             {
                 return true;
             }
 
-            // fire event
-            KeyDown?.Invoke (this, k);
-
-            return k.Handled;
+            // After (fire the cancellable event)
+            return OnKeyDown (k);
         }
 
         bool RaiseKeyDownNotHandled (Key k)
         {
-            if (OnKeyDownNotHandled (k) || k.Handled)
+            // First fire event
+            KeyDownNotHandled?.Invoke (this, k);
+
+            if (k.Handled)
             {
                 return true;
             }
 
-            KeyDownNotHandled?.Invoke (this, k);
-
-            return false;
+            // After (fire the cancellable event)
+            return OnKeyDownNotHandled (k);
         }
     }
 
@@ -453,16 +455,16 @@ public partial class View // Keyboard APIs
 
         bool RaiseKeyUp (Key k)
         {
-            // Before (fire the cancellable event)
-            if (OnKeyUp (k) || k.Handled)
+            // First fire event
+            KeyUp?.Invoke (this, k);
+
+            if (k.Handled)
             {
                 return true;
             }
 
-            // fire event
-            KeyUp?.Invoke (this, k);
-
-            return k.Handled;
+            // After (fire the cancellable event)
+            return OnKeyUp (k);
         }
     }
 

--- a/Terminal.Gui/View/View.Mouse.cs
+++ b/Terminal.Gui/View/View.Mouse.cs
@@ -335,14 +335,16 @@ public partial class View // Mouse APIs
     /// <returns><see langword="true"/>, if the event was handled, <see langword="false"/> otherwise.</returns>
     public bool RaiseMouseEvent (MouseEventArgs mouseEvent)
     {
-        if (OnMouseEvent (mouseEvent) || mouseEvent.Handled)
+        // First fire event
+        MouseEvent?.Invoke (this, mouseEvent);
+
+        if (mouseEvent.Handled)
         {
             return true;
         }
 
-        MouseEvent?.Invoke (this, mouseEvent);
-
-        return mouseEvent.Handled;
+        // After (fire the cancellable event)
+        return OnMouseEvent (mouseEvent);
     }
 
     /// <summary>Called when a mouse event occurs within the view's <see cref="Viewport"/>.</summary>

--- a/Terminal.Gui/Views/MessageBox.cs
+++ b/Terminal.Gui/Views/MessageBox.cs
@@ -374,6 +374,10 @@ public static class MessageBox
                                        {
                                            Clicked = (int)btn.Data!;
                                        }
+                                       else
+                                       {
+                                           Clicked = defaultButton;
+                                       }
 
                                        e.Cancel = true;
                                        Application.RequestStop ();

--- a/UnitTests/Dialogs/MessageBoxTests.cs
+++ b/UnitTests/Dialogs/MessageBoxTests.cs
@@ -502,5 +502,19 @@ public class MessageBoxTests
         Application.Run (top);
         top.Dispose ();
     }
+
+    [Fact]
+    [SetupFakeDriver]
+    public void Button_IsDefault_True_Return_His_Index_On_Accepting ()
+    {
+        Application.Init ();
+
+        Application.Iteration += (_, _) => Assert.True (Application.RaiseKeyDownEvent (Key.Enter));
+        var res = MessageBox.Query ("hey", "IsDefault", "Yes", "No");
+
+        Assert.Equal (0, res);
+
+        Application.Shutdown ();
+    }
 }
 

--- a/UnitTests/View/Keyboard/KeyboardEventTests.cs
+++ b/UnitTests/View/Keyboard/KeyboardEventTests.cs
@@ -102,7 +102,7 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
                             Assert.Equal (alt, e.IsAlt);
                             Assert.Equal (control, e.IsCtrl);
                             Assert.False (keyDown);
-                            Assert.True (view.OnKeyDownCalled);
+                            Assert.False (view.OnKeyDownCalled);
                             keyDown = true;
                         };
         view.KeyDownNotHandled += (s, e) => { keyDownNotHandled = true; };
@@ -114,7 +114,7 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
                           Assert.Equal (alt, e.IsAlt);
                           Assert.Equal (control, e.IsCtrl);
                           Assert.False (keyUp);
-                          Assert.True (view.OnKeyUpCalled);
+                          Assert.False (view.OnKeyUpCalled);
                           keyUp = true;
                       };
 
@@ -147,6 +147,7 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
     {
         var keyDown = false;
         var keyDownNotHandled = false;
+        var keyHandled = false;
 
         var view = new OnNewKeyTestView ();
         Assert.True (view.CanFocus);
@@ -156,8 +157,8 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
                         {
                             Assert.Equal (KeyCode.A, e.KeyCode);
                             Assert.False (keyDown);
-                            Assert.True (view.OnKeyDownCalled);
-                            e.Handled = true;
+                            Assert.False (view.OnKeyDownCalled);
+                            e.Handled = keyHandled;
                             keyDown = true;
                         };
 
@@ -167,15 +168,29 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
                                    Assert.Equal (KeyCode.A, e.KeyCode);
                                    Assert.False (keyDownNotHandled);
                                    Assert.False (view.OnProcessKeyDownCalled);
-                                   e.Handled = true;
+                                   e.Handled = keyHandled;
                                    keyDownNotHandled = true;
                                };
 
         view.NewKeyDownEvent (Key.A);
         Assert.True (keyDown);
-        Assert.False (keyDownNotHandled);
+        Assert.True (keyDownNotHandled);
 
         Assert.True (view.OnKeyDownCalled);
+        Assert.True (view.OnProcessKeyDownCalled);
+
+        keyDown = false;
+        keyDownNotHandled = false;
+        keyHandled = true;
+        view.CancelVirtualMethods = true;
+        view.OnKeyDownCalled = false;
+        view.OnProcessKeyDownCalled = false;
+
+        view.NewKeyDownEvent (Key.A);
+        Assert.True (keyDown);
+        Assert.False (keyDownNotHandled);
+
+        Assert.False (view.OnKeyDownCalled);
         Assert.False (view.OnProcessKeyDownCalled);
     }
 
@@ -223,7 +238,7 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
                         {
                             Assert.Equal (KeyCode.A, e.KeyCode);
                             Assert.False (keyDown);
-                            Assert.True (view.OnKeyDownCalled);
+                            Assert.False (view.OnKeyDownCalled);
                             e.Handled = false;
                             keyDown = true;
                         };
@@ -232,7 +247,7 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
                                {
                                    Assert.Equal (KeyCode.A, e.KeyCode);
                                    Assert.False (keyDownNotHandled);
-                                   Assert.True (view.OnProcessKeyDownCalled);
+                                   Assert.False (view.OnProcessKeyDownCalled);
                                    e.Handled = true;
                                    keyDownNotHandled = true;
                                };
@@ -242,13 +257,14 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
         Assert.True (keyDownNotHandled);
 
         Assert.True (view.OnKeyDownCalled);
-        Assert.True (view.OnProcessKeyDownCalled);
+        Assert.False (view.OnProcessKeyDownCalled);
     }
 
     [Fact]
     public void NewKeyUpEvent_KeyUp_Handled_True_Stops_Processing ()
     {
         var keyUp = false;
+        var keyHandled = false;
 
         var view = new OnNewKeyTestView ();
         Assert.True (view.CanFocus);
@@ -259,7 +275,7 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
                           Assert.Equal (KeyCode.A, e.KeyCode);
                           Assert.False (keyUp);
                           Assert.False (view.OnProcessKeyDownCalled);
-                          e.Handled = true;
+                          e.Handled = keyHandled;
                           keyUp = true;
                       };
 
@@ -267,6 +283,18 @@ public class KeyboardEventTests (ITestOutputHelper output) : TestsAllViews
         Assert.True (keyUp);
 
         Assert.True (view.OnKeyUpCalled);
+        Assert.False (view.OnKeyDownCalled);
+        Assert.False (view.OnProcessKeyDownCalled);
+
+        keyUp = false;
+        keyHandled = true;
+        view.CancelVirtualMethods = true;
+        view.OnKeyUpCalled = false;
+
+        view.NewKeyUpEvent (Key.A);
+        Assert.True (keyUp);
+
+        Assert.False (view.OnKeyUpCalled);
         Assert.False (view.OnKeyDownCalled);
         Assert.False (view.OnProcessKeyDownCalled);
     }


### PR DESCRIPTION
## Fixes

- Fixes #3950

## Proposed Changes/Todos

- [x] Events must be raised before the virtual method.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
