### PR TITLE
Fixes #3976. SixLabors.ImageSharp nuget package is reporting as vulnerable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,16 +7,16 @@
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[8,9)" />
 
 		<PackageVersion Include="ColorHelper" Version="[1.8.1,2)" />
-		<PackageVersion Include="JetBrains.Annotations" Version="[2024.2.0,)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis" Version="[4.10,5)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="[4.10,5)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[4.10,5)" />
-		<PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageVersion Include="System.IO.Abstractions" Version="[21.0.22,22)" />
+		<PackageVersion Include="JetBrains.Annotations" Version="[2024.3.0,)" />
+		<PackageVersion Include="Microsoft.CodeAnalysis" Version="[4.13,5)" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="[4.13,5)" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[4.13,5)" />
+		<PackageVersion Include="Microsoft.Extensions.Logging" Version="[9.0.2,10)" />
+		<PackageVersion Include="System.IO.Abstractions" Version="[22.0.11,23)" />
 		<PackageVersion Include="System.Text.Json" Version="[8.0.5,9)" />
 		<PackageVersion Include="Wcwidth" Version="[2,3)" />
 
-		<PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="[1.21,2)" />
+		<PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="[1.21.2,2)" />
 		<PackageVersion Include="Serilog" Version="4.2.0" />
 		<PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.0" />
 		<PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
@@ -28,20 +28,20 @@
 
 		<PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
 
-		<PackageVersion Include="CommunityToolkit.Mvvm" Version="[8.2.2,9)" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[8,9)" />	
-		<PackageVersion Include="ReactiveUI" Version="[20.1.1,21)" />
+		<PackageVersion Include="CommunityToolkit.Mvvm" Version="[8.4.0,9)" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[9.0.2,10)" />	
+		<PackageVersion Include="ReactiveUI" Version="[20.1.63,21)" />
 		<PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="[1.3.1,2)" />
-		<PackageVersion Include="ReactiveUI.SourceGenerators" Version="[1.0.3,2)"/>	
+		<PackageVersion Include="ReactiveUI.SourceGenerators" Version="[2.1.8,3)"/>	
 
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.10,18)" />
-		<PackageVersion Include="Moq" Version="[4.20.70,5)" />
-		<PackageVersion Include="ReportGenerator" Version="[5.3.8,6)" />
-		<PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="[21.0.29,22)" />
-		<PackageVersion Include="xunit" Version="[2.9.0,3)" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.13,18)" />
+		<PackageVersion Include="Moq" Version="[4.20.72,5)" />
+		<PackageVersion Include="ReportGenerator" Version="[5.4.4,6)" />
+		<PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="[22.0.11,23)" />
+		<PackageVersion Include="xunit" Version="[2.9.3,3)" />
 		<PackageVersion Include="Xunit.Combinatorial" Version="[1.6.24,2)" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="[2.8.2,3)"/> 
-		<PackageVersion Include="coverlet.collector" Version="[6.0.2,7)" />
+		<PackageVersion Include="coverlet.collector" Version="[6.0.4,7)" />
 		
 	</ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
 		<PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.0" />
 		<PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
 		<PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-		<PackageVersion Include="SixLabors.ImageSharp" Version="[3.1.5,4)" />
+		<PackageVersion Include="SixLabors.ImageSharp" Version="[3.1.7,4)" />
 		<PackageVersion Include="CsvHelper" Version="[33.0.1,34)" />
 		<PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="[3.1.6,4)" />
 		<PackageVersion Include="System.CommandLine" Version="[2.0.0-beta4.22272.1,3)" />

--- a/ReactiveExample/LoginViewModel.cs
+++ b/ReactiveExample/LoginViewModel.cs
@@ -40,7 +40,6 @@ public partial class LoginViewModel : ReactiveObject
 
     public LoginViewModel ()
     {
-        InitializeCommands ();
         IObservable<bool> canLogin = this.WhenAnyValue
             (
                 x => x.Username,


### PR DESCRIPTION
## Fixes

- Fixes #3976

## Proposed Changes/Todos

- [x] Updated to version 3.1.7

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
