### PR TITLE
Reduce string allocations in IConsoleOutput implementations

### DIFF
--- a/Benchmarks/ConsoleDrivers/EscSeqUtils/CSI_SetVsWrite.cs
+++ b/Benchmarks/ConsoleDrivers/EscSeqUtils/CSI_SetVsWrite.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using Tui = Terminal.Gui;
+
+namespace Terminal.Gui.Benchmarks.ConsoleDrivers.EscSeqUtils;
+
+[MemoryDiagnoser]
+// Hide useless column from results.
+[HideColumns ("writer")]
+public class CSI_SetVsWrite
+{
+    [Benchmark (Baseline = true)]
+    [ArgumentsSource (nameof (TextWriterSource))]
+    public TextWriter Set (TextWriter writer)
+    {
+        writer.Write (Tui.EscSeqUtils.CSI_SetCursorPosition (1, 1));
+        return writer;
+    }
+
+    [Benchmark]
+    [ArgumentsSource (nameof (TextWriterSource))]
+    public TextWriter Write (TextWriter writer)
+    {
+        Tui.EscSeqUtils.CSI_WriteCursorPosition (writer, 1, 1);
+        return writer;
+    }
+
+    public static IEnumerable<object> TextWriterSource ()
+    {
+        return [StringWriter.Null];
+    }
+}

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -1,5 +1,5 @@
 #nullable enable
-using Terminal.Gui.ConsoleDrivers;
+using System.Globalization;
 using static Terminal.Gui.ConsoleDrivers.ConsoleKeyMapping;
 
 namespace Terminal.Gui;
@@ -1686,6 +1686,32 @@ public static class EscSeqUtils
     {
         // InterpolatedStringHandler is composed in stack, skipping the string allocation.
         builder.Append ($"{CSI}{row};{col}H");
+    }
+
+    /// <summary>
+    ///     ESC [ y ; x H - CUP Cursor Position - Cursor moves to x ; y coordinate within the viewport, where x is the column
+    ///     of the y line
+    /// </summary>
+    /// <param name="writer">TextWriter where to write the cursor position sequence.</param>
+    /// <param name="row">Origin is (1,1).</param>
+    /// <param name="col">Origin is (1,1).</param>
+    public static void CSI_WriteCursorPosition (TextWriter writer, int row, int col)
+    {
+        const int maxInputBufferSize =
+            // CSI (2) + ';' + 'H'
+            4 +
+            // row + col (2x int sign + int max value)
+            2 + 20;
+        Span<char> buffer = stackalloc char[maxInputBufferSize];
+        if (!buffer.TryWrite (CultureInfo.InvariantCulture, $"{CSI}{row};{col}H", out int charsWritten))
+        {
+            string tooLongCursorPositionSequence = $"{CSI}{row};{col}H";
+            throw new InvalidOperationException (
+                $"{nameof(CSI_WriteCursorPosition)} buffer (len: {buffer.Length}) is too short for cursor position sequence '{tooLongCursorPositionSequence}' (len: {tooLongCursorPositionSequence.Length}).");
+        }
+
+        ReadOnlySpan<char> cursorPositionSequence = buffer[..charsWritten];
+        writer.Write (cursorPositionSequence);
     }
 
     //ESC [ <y> ; <x> f - HVP     Horizontal Vertical Position* Cursor moves to<x>; <y> coordinate within the viewport, where <x> is the column of the<y> line

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -154,13 +154,13 @@ public static class EscSeqUtils
     /// <summary>
     ///     Control sequence for disabling mouse events.
     /// </summary>
-    public static string CSI_DisableMouseEvents { get; set; } =
+    public static readonly string CSI_DisableMouseEvents =
         CSI_DisableAnyEventMouse + CSI_DisableUrxvtExtModeMouse + CSI_DisableSgrExtModeMouse;
 
     /// <summary>
     ///     Control sequence for enabling mouse events.
     /// </summary>
-    public static string CSI_EnableMouseEvents { get; set; } =
+    public static readonly string CSI_EnableMouseEvents =
         CSI_EnableAnyEventMouse + CSI_EnableUrxvtExtModeMouse + CSI_EnableSgrExtModeMouse;
 
     /// <summary>

--- a/Terminal.Gui/ConsoleDrivers/V2/IConsoleOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/IConsoleOutput.cs
@@ -11,7 +11,7 @@ public interface IConsoleOutput : IDisposable
     ///     <see cref="IOutputBuffer"/> overload.
     /// </summary>
     /// <param name="text"></param>
-    void Write (string text);
+    void Write (ReadOnlySpan<char> text);
 
     /// <summary>
     ///     Write the contents of the <paramref name="buffer"/> to the console

--- a/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
@@ -225,7 +225,7 @@ public class NetOutput : IConsoleOutput
 
         // + 1 is needed because non-Windows is based on 1 instead of 0 and
         // Console.CursorTop/CursorLeft isn't reliable.
-        Console.Out.Write (EscSeqUtils.CSI_SetCursorPosition (row + 1, col + 1));
+        EscSeqUtils.CSI_WriteCursorPosition (Console.Out, row + 1, col + 1);
 
         return true;
     }

--- a/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
@@ -118,21 +118,19 @@ public class NetOutput : IConsoleOutput
                     {
                         redrawAttr = attr;
 
-                        output.Append (
-                                       EscSeqUtils.CSI_SetForegroundColorRGB (
-                                                                              attr.Foreground.R,
-                                                                              attr.Foreground.G,
-                                                                              attr.Foreground.B
-                                                                             )
-                                      );
+                        EscSeqUtils.CSI_AppendForegroundColorRGB (
+                            output,
+                            attr.Foreground.R,
+                            attr.Foreground.G,
+                            attr.Foreground.B
+                        );
 
-                        output.Append (
-                                       EscSeqUtils.CSI_SetBackgroundColorRGB (
-                                                                              attr.Background.R,
-                                                                              attr.Background.G,
-                                                                              attr.Background.B
-                                                                             )
-                                      );
+                        EscSeqUtils.CSI_AppendBackgroundColorRGB (
+                            output,
+                            attr.Background.R,
+                            attr.Background.G,
+                            attr.Background.B
+                        );
                     }
 
                     outputWidth++;

--- a/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
@@ -60,6 +60,9 @@ public class NetOutput : IConsoleOutput
         CursorVisibility? savedVisibility = _cachedCursorVisibility;
         SetCursorVisibility (CursorVisibility.Invisible);
 
+        const int maxCharsPerRune = 2;
+        Span<char> runeBuffer = stackalloc char[maxCharsPerRune];
+
         for (int row = top; row < rows; row++)
         {
             if (Console.WindowHeight < 1)
@@ -134,8 +137,12 @@ public class NetOutput : IConsoleOutput
                     }
 
                     outputWidth++;
+
+                    // Avoid Rune.ToString() by appending the rune chars.
                     Rune rune = buffer.Contents [row, col].Rune;
-                    output.Append (rune);
+                    int runeCharsWritten = rune.EncodeToUtf16 (runeBuffer);
+                    ReadOnlySpan<char> runeChars = runeBuffer[..runeCharsWritten];
+                    output.Append (runeChars);
 
                     if (buffer.Contents [row, col].CombiningMarks.Count > 0)
                     {

--- a/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
@@ -163,7 +163,7 @@ public class NetOutput : IConsoleOutput
             if (output.Length > 0)
             {
                 SetCursorPositionImpl (lastCol, row);
-                Console.Write (output);
+                Console.Out.Write (output);
             }
         }
 
@@ -172,7 +172,7 @@ public class NetOutput : IConsoleOutput
             if (!string.IsNullOrWhiteSpace (s.SixelData))
             {
                 SetCursorPositionImpl (s.ScreenPosition.X, s.ScreenPosition.Y);
-                Console.Write (s.SixelData);
+                Console.Out.Write (s.SixelData);
             }
         }
 

--- a/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
@@ -188,7 +188,7 @@ public class NetOutput : IConsoleOutput
     private void WriteToConsole (StringBuilder output, ref int lastCol, int row, ref int outputWidth)
     {
         SetCursorPositionImpl (lastCol, row);
-        Console.Write (output);
+        Console.Out.Write (output);
         output.Clear ();
         lastCol += outputWidth;
         outputWidth = 0;

--- a/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
@@ -34,7 +34,10 @@ public class NetOutput : IConsoleOutput
     }
 
     /// <inheritdoc/>
-    public void Write (string text) { Console.Write (text); }
+    public void Write (ReadOnlySpan<char> text)
+    {
+        Console.Out.Write (text);
+    }
 
     /// <inheritdoc/>
     public void Write (IOutputBuffer buffer)

--- a/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
@@ -298,9 +298,10 @@ internal partial class WindowsOutput : IConsoleOutput
     /// <inheritdoc/>
     public void SetCursorVisibility (CursorVisibility visibility)
     {
-        var sb = new StringBuilder ();
-        sb.Append (visibility != CursorVisibility.Invisible ? EscSeqUtils.CSI_ShowCursor : EscSeqUtils.CSI_HideCursor);
-        Write (sb.ToString ());
+        string cursorVisibilitySequence = visibility != CursorVisibility.Invisible
+            ? EscSeqUtils.CSI_ShowCursor
+            : EscSeqUtils.CSI_HideCursor;
+        Write (cursorVisibilitySequence);
     }
 
     private Point _lastCursorPosition;

--- a/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System.Buffers;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
@@ -184,7 +185,6 @@ internal partial class WindowsOutput : IConsoleOutput
 
     public bool WriteToConsole (Size size, ExtendedCharInfo [] charInfoBuffer, Coord bufferSize, SmallRect window, bool force16Colors)
     {
-        var stringBuilder = new StringBuilder ();
 
         //Debug.WriteLine ("WriteToConsole");
 
@@ -214,7 +214,7 @@ internal partial class WindowsOutput : IConsoleOutput
         }
         else
         {
-            stringBuilder.Clear ();
+            StringBuilder stringBuilder = new();
 
             stringBuilder.Append (EscSeqUtils.CSI_SaveCursorPosition);
             EscSeqUtils.CSI_AppendCursorPosition (stringBuilder, 0, 0);
@@ -248,14 +248,20 @@ internal partial class WindowsOutput : IConsoleOutput
             stringBuilder.Append (EscSeqUtils.CSI_RestoreCursorPosition);
             stringBuilder.Append (EscSeqUtils.CSI_HideCursor);
 
-            var s = stringBuilder.ToString ();
+            // TODO: Potentially could stackalloc whenever reasonably small (<= 8 kB?) write buffer is needed.
+            char [] rentedWriteArray = ArrayPool<char>.Shared.Rent (minimumLength: stringBuilder.Length);
+            try
+            {
+                Span<char> writeBuffer = rentedWriteArray.AsSpan(0, stringBuilder.Length);
+                stringBuilder.CopyTo (0, writeBuffer, stringBuilder.Length);
 
-            // TODO: requires extensive testing if we go down this route
-            // If console output has changed
-            //if (s != _lastWrite)
-            //{
-            // supply console with the new content
-            result = WriteConsole (_screenBuffer, s, (uint)s.Length, out uint _, nint.Zero);
+                // Supply console with the new content.
+                result = WriteConsole (_screenBuffer, writeBuffer, (uint)writeBuffer.Length, out uint _, nint.Zero);
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return (rentedWriteArray);
+            }
 
             foreach (SixelToRender sixel in Application.Sixel)
             {

--- a/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
@@ -6,12 +6,13 @@ using static Terminal.Gui.WindowsConsole;
 
 namespace Terminal.Gui;
 
-internal class WindowsOutput : IConsoleOutput
+internal partial class WindowsOutput : IConsoleOutput
 {
-    [DllImport ("kernel32.dll", EntryPoint = "WriteConsole", SetLastError = true, CharSet = CharSet.Unicode)]
-    private static extern bool WriteConsole (
+    [LibraryImport ("kernel32.dll", EntryPoint = "WriteConsoleW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    [return: MarshalAs (UnmanagedType.Bool)]
+    private static partial bool WriteConsole (
         nint hConsoleOutput,
-        string lpbufer,
+        ReadOnlySpan<char> lpbufer,
         uint numberOfCharsToWriten,
         out uint lpNumberOfCharsWritten,
         nint lpReserved
@@ -84,7 +85,7 @@ internal class WindowsOutput : IConsoleOutput
         }
     }
 
-    public void Write (string str)
+    public void Write (ReadOnlySpan<char> str)
     {
         if (!WriteConsole (_screenBuffer, str, (uint)str.Length, out uint _, nint.Zero))
         {

--- a/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
@@ -217,7 +217,7 @@ internal partial class WindowsOutput : IConsoleOutput
             stringBuilder.Clear ();
 
             stringBuilder.Append (EscSeqUtils.CSI_SaveCursorPosition);
-            stringBuilder.Append (EscSeqUtils.CSI_SetCursorPosition (0, 0));
+            EscSeqUtils.CSI_AppendCursorPosition (stringBuilder, 0, 0);
 
             Attribute? prev = null;
 
@@ -228,8 +228,8 @@ internal partial class WindowsOutput : IConsoleOutput
                 if (attr != prev)
                 {
                     prev = attr;
-                    stringBuilder.Append (EscSeqUtils.CSI_SetForegroundColorRGB (attr.Foreground.R, attr.Foreground.G, attr.Foreground.B));
-                    stringBuilder.Append (EscSeqUtils.CSI_SetBackgroundColorRGB (attr.Background.R, attr.Background.G, attr.Background.B));
+                    EscSeqUtils.CSI_AppendForegroundColorRGB (stringBuilder, attr.Foreground.R, attr.Foreground.G, attr.Foreground.B);
+                    EscSeqUtils.CSI_AppendBackgroundColorRGB (stringBuilder, attr.Background.R, attr.Background.G, attr.Background.B);
                 }
 
                 if (info.Char != '\x1b')

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver/WindowsConsole.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver/WindowsConsole.cs
@@ -6,7 +6,7 @@ using Terminal.Gui.ConsoleDrivers;
 
 namespace Terminal.Gui;
 
-internal class WindowsConsole
+internal partial class WindowsConsole
 {
     private CancellationTokenSource? _inputReadyCancellationTokenSource;
     private readonly BlockingCollection<InputRecord> _inputQueue = new (new ConcurrentQueue<InputRecord> ());
@@ -926,10 +926,11 @@ internal class WindowsConsole
         ref SmallRect lpWriteRegion
     );
 
-    [DllImport ("kernel32.dll", EntryPoint = "WriteConsole", SetLastError = true, CharSet = CharSet.Unicode)]
-    private static extern bool WriteConsole (
+    [LibraryImport ("kernel32.dll", EntryPoint = "WriteConsoleW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    [return: MarshalAs (UnmanagedType.Bool)]
+    private static partial bool WriteConsole (
         nint hConsoleOutput,
-        string lpbufer,
+        ReadOnlySpan<char> lpbufer,
         uint NumberOfCharsToWriten,
         out uint lpNumberOfCharsWritten,
         nint lpReserved

--- a/Tests/UnitTests/Input/EscSeqUtilsTests.cs
+++ b/Tests/UnitTests/Input/EscSeqUtilsTests.cs
@@ -1,4 +1,4 @@
-﻿using JetBrains.Annotations;
+﻿using System.Text;
 using UnitTests;
 
 // ReSharper disable HeuristicUnreachableCode
@@ -685,7 +685,7 @@ public class EscSeqUtilsTests
         top.Add (view);
         Application.Begin (top);
 
-        Application.RaiseMouseEvent (new() { Position = new (0, 0), Flags = 0 });
+        Application.RaiseMouseEvent (new () { Position = new (0, 0), Flags = 0 });
 
         ClearAll ();
 
@@ -741,7 +741,7 @@ public class EscSeqUtilsTests
                                          // set Application.WantContinuousButtonPressedView to null
                                          view.WantContinuousButtonPressed = false;
 
-                                         Application.RaiseMouseEvent (new() { Position = new (0, 0), Flags = 0 });
+                                         Application.RaiseMouseEvent (new () { Position = new (0, 0), Flags = 0 });
 
                                          Application.RequestStop ();
                                      }
@@ -1546,6 +1546,21 @@ public class EscSeqUtilsTests
         }
 
         Assert.Equal (result, cki);
+    }
+
+    [Theory]
+    [InlineData (0, 0, $"{EscSeqUtils.CSI}0;0H")]
+    [InlineData (int.MaxValue, int.MaxValue, $"{EscSeqUtils.CSI}2147483647;2147483647H")]
+    [InlineData (int.MinValue, int.MinValue, $"{EscSeqUtils.CSI}-2147483648;-2147483648H")]
+    public void CSI_WriteCursorPosition_ReturnsCorrectEscSeq (int row, int col, string expected)
+    {
+        StringBuilder builder = new();
+        using StringWriter writer = new(builder);
+
+        EscSeqUtils.CSI_WriteCursorPosition (writer, row, col);
+
+        string actual = builder.ToString();
+        Assert.Equal (expected, actual);
     }
 
     private void ClearAll ()


### PR DESCRIPTION
## Fixes

- Improves #2725 

## Proposed Changes

- [x] Change `IConsoleOutput.Write(string)` to `IConsoleOutput.Write(ReadOnlySpan<char>)`.
    - More flexible buffer options for caller.
- [x] NetOutput allocation optimizations.
    - [x] Avoid Rune.ToString()
    - [x] Console.Write(object) -> StringBuilder.ToString() vs
           Console.Out.Write(StringBuilder) -> TextWriter.Write(StringBuilder).
- [x] WindowsOutput allocation optimizations.
    - [x] Change WriteConsole Interop to take ReadOnlySpan\<char\> instead of string.
        - Note that entry point name requires the A or W suffix because LibraryImport does not choose it automatically.
    - [x] Copy to rented array instead of StringBuilder.ToString() during write.
    - [x] Remove unnecessary StringBuilder from SetCursorVisibility.
- [x] Change WindowsConsole WriteConsole Interop to take ReadOnlySpan\<char\> instead of string.
    - For verifying that this alone does not cause regressions.
- [x] Use EscSeqUtils.CSI_Append(Foreground|Background)ColorRGB in IConsoleOutput implementations.
- [x] Add EscSeqUtils `void CSI_WriteCursorPosition(TextWriter, int, int)` alternative to `string CSI_SetCursorPosition(int, int)`.
- [x] Change EscSeqUtils.CSI_(Enable|Disable)MouseEvents static properties to readonly fields
    - Consistent with the other similar fields.
    - Cannot accidentally reassign the values on runtime.

## Pull Request Checklist

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

## UI Catalog benchmark

No noticeable change to times. Both v2win and v2net finished in ~03:48. I'm guessing the v2 application or drivers have input throttling/pacing which kind of makes the benchmark timings moot for them.

For comparison v1 Windows driver finished in ~00:35.

## Microbenchmarks

CSI_SetCursorPosition vs CSI_WriteCursorPosition

```

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5487/22H2/2022Update)
AMD Ryzen 7 5800X3D, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.406
  [Host]     : .NET 8.0.13 (8.0.1325.6609), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.13 (8.0.1325.6609), X64 RyuJIT AVX2

writer=Syste(...)riter [35]  

```
| Method | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------- |---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| Set    | 47.04 ns | 1.278 ns | 3.769 ns | 44.46 ns |  1.01 |    0.11 | 0.0008 |      40 B |        1.00 |
| Write  | 27.60 ns | 0.084 ns | 0.065 ns | 27.59 ns |  0.59 |    0.04 |      - |         - |        0.00 |

## Allocations

### v2net

Reduced string allocations nicely.

Before | After
--------|-------
![v2net-01 object-allocations strings-before](https://github.com/user-attachments/assets/dbcb05bb-f014-4892-9834-c172d8026686) | ![v2net-02 object-allocations strings-after](https://github.com/user-attachments/assets/7176354d-402b-423f-a014-d6ee9ea1b9df)

### v2win

Not that much improvement. Eliminated SetCursorVisibility char array and StringBuilder allocations.

Before | After
--------|-------
![v2win-01 object-allocations strings-before](https://github.com/user-attachments/assets/c7a1a1ba-f39f-4ce9-a743-e636281b7fd4) | ![v2win-02 object-allocations strings-after](https://github.com/user-attachments/assets/3fb38356-8855-4b5b-b21a-cbb41acc4225)
![v2win-01 object-allocations drilldown-string-ctor-ros-before](https://github.com/user-attachments/assets/f7fdd8a0-098b-4d60-8c72-f836b24e8ca0) | ![v2win-02 object-allocations drilldown-string-ctor-ros-after](https://github.com/user-attachments/assets/e3483de0-1256-40b4-87ca-3f61f9ae98c2)
![v2win-01 object-allocations drilldown-stringbuilder-before](https://github.com/user-attachments/assets/7dc77338-169e-4709-9ebe-973c44aada00) | ![v2win-02 object-allocations drilldown-stringbuilder-after](https://github.com/user-attachments/assets/f18b3a57-f168-40a6-9beb-e5149bebe050)
![v2win-01 object-allocations array-of-chars-before](https://github.com/user-attachments/assets/d6b5d373-26ac-457e-9c8e-a27bc78c234b) | ![v2win-02 object-allocations array-of-chars-after](https://github.com/user-attachments/assets/0eb13b3c-e2e3-42f9-b6f5-58e7b6b9a94a)
![v2win-01 object-allocations drilldown-array-of-chars-arraypool-before](https://github.com/user-attachments/assets/c60e1f85-1b4c-401a-ac56-5de8b15511c9) | ![v2win-02 object-allocations drilldown-array-of-chars-arraypool-after](https://github.com/user-attachments/assets/3d535d4f-eeb6-4dfb-93c5-3ee014e618e8)
