### PR TITLE
Fix Cell.CombiningMarks property getter rune list allocation

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/ConsoleDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/ConsoleDriver.cs
@@ -217,7 +217,7 @@ public abstract class ConsoleDriver : IConsoleDriver
                         if (Contents [Row, Col - 1].CombiningMarks.Count > 0)
                         {
                             // Just add this mark to the list
-                            Contents [Row, Col - 1].CombiningMarks.Add (rune);
+                            Contents [Row, Col - 1].AddCombiningMark (rune);
 
                             // Ignore. Don't move to next column (let the driver figure out what to do).
                         }
@@ -240,7 +240,7 @@ public abstract class ConsoleDriver : IConsoleDriver
                             else
                             {
                                 // It didn't normalize. Add it to the Cell to left's CM list
-                                Contents [Row, Col - 1].CombiningMarks.Add (rune);
+                                Contents [Row, Col - 1].AddCombiningMark (rune);
 
                                 // Ignore. Don't move to next column (let the driver figure out what to do).
                             }
@@ -298,7 +298,7 @@ public abstract class ConsoleDriver : IConsoleDriver
                         else if (!Clip.Contains (Col, Row))
                         {
                             // Our 1st column is outside the clip, so we can't display a wide character.
-                            Contents [Row, Col+1].Rune = Rune.ReplacementChar;
+                            Contents [Row, Col + 1].Rune = Rune.ReplacementChar;
                         }
                         else
                         {

--- a/Terminal.Gui/ConsoleDrivers/V2/OutputBuffer.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/OutputBuffer.cs
@@ -164,7 +164,7 @@ public class OutputBuffer : IOutputBuffer
                         if (Contents [Row, Col - 1].CombiningMarks.Count > 0)
                         {
                             // Just add this mark to the list
-                            Contents [Row, Col - 1].CombiningMarks.Add (rune);
+                            Contents [Row, Col - 1].AddCombiningMark (rune);
 
                             // Ignore. Don't move to next column (let the driver figure out what to do).
                         }
@@ -187,7 +187,7 @@ public class OutputBuffer : IOutputBuffer
                             else
                             {
                                 // It didn't normalize. Add it to the Cell to left's CM list
-                                Contents [Row, Col - 1].CombiningMarks.Add (rune);
+                                Contents [Row, Col - 1].AddCombiningMark (rune);
 
                                 // Ignore. Don't move to next column (let the driver figure out what to do).
                             }

--- a/Terminal.Gui/Drawing/Cell.cs
+++ b/Terminal.Gui/Drawing/Cell.cs
@@ -42,8 +42,8 @@ public record struct Cell (Attribute? Attribute = null, bool IsDirty = false, Ru
     /// </remarks>
     internal IReadOnlyList<Rune> CombiningMarks
     {
-        // PERFORMANCE: Downside of the interface return type that List<T> struct enumerator cannot be utilized, i.e. enumerator is allocated.
-        // If enumeration is heavily used in the future then might be better to expose the List<T> Enumerator directly via separate mechanism.
+        // PERFORMANCE: Downside of the interface return type is that List<T> struct enumerator cannot be utilized, i.e. enumerator is allocated.
+        // If enumeration is used heavily in the future then might be better to expose the List<T> Enumerator directly via separate mechanism.
         get
         {
             // Avoid unnecessary list allocation.

--- a/Terminal.Gui/Drawing/Cell.cs
+++ b/Terminal.Gui/Drawing/Cell.cs
@@ -1,4 +1,6 @@
-﻿namespace Terminal.Gui;
+﻿#nullable enable
+
+namespace Terminal.Gui;
 
 /// <summary>
 ///     Represents a single row/column in a Terminal.Gui rendering surface (e.g. <see cref="LineCanvas"/> and
@@ -23,12 +25,12 @@ public record struct Cell (Attribute? Attribute = null, bool IsDirty = false, Ru
         get => _rune;
         set
         {
-            CombiningMarks.Clear ();
+            _combiningMarks?.Clear ();
             _rune = value;
         }
     }
 
-    private List<Rune> _combiningMarks;
+    private List<Rune>? _combiningMarks;
 
     /// <summary>
     ///     The combining marks for <see cref="Rune"/> that when combined makes this Cell a combining sequence. If
@@ -38,10 +40,37 @@ public record struct Cell (Attribute? Attribute = null, bool IsDirty = false, Ru
     ///     Only valid in the rare case where <see cref="Rune"/> is a combining sequence that could not be normalized to a
     ///     single Rune.
     /// </remarks>
-    internal List<Rune> CombiningMarks
+    internal IReadOnlyList<Rune> CombiningMarks
     {
-        get => _combiningMarks ?? [];
-        private set => _combiningMarks = value ?? [];
+        // PERFORMANCE: Downside of the interface return type that List<T> struct enumerator cannot be utilized, i.e. enumerator is allocated.
+        // If enumeration is heavily used in the future then might be better to expose the List<T> Enumerator directly via separate mechanism.
+        get
+        {
+            // Avoid unnecessary list allocation.
+            if (_combiningMarks == null)
+            {
+                return Array.Empty<Rune> ();
+            }
+            return _combiningMarks;
+        }
+    }
+
+    /// <summary>
+    ///     Adds combining mark to the cell.
+    /// </summary>
+    /// <param name="combiningMark">The combining mark to add to the cell.</param>
+    internal void AddCombiningMark (Rune combiningMark)
+    {
+        _combiningMarks ??= [];
+        _combiningMarks.Add (combiningMark);
+    }
+
+    /// <summary>
+    ///     Clears combining marks of the cell.
+    /// </summary>
+    internal void ClearCombiningMarks ()
+    {
+        _combiningMarks?.Clear ();
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Cell.CombiningMarks getter would every time allocate a new list when the backing field is not assigned a value, which is most of the time.

## Fixes

- Improves #2725 

## Proposed Changes/Todos

- [x] Change Cell.CombiningMarks to readonly property.
- [x] Add separate Cell methods for editing the combining marks.
- [x] Make Cell.CombiningMarks backing field nullable.

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

## UI Catalog Benchmarks

Didn't bother for now.

## Allocations

Collected for v2win driver only to save time. Eliminates majority of list allocations.

Before | After
--------|-------
![01 ui-catalog-benchmarks object-allocations before](https://github.com/user-attachments/assets/e70f4805-b5da-4333-9271-ac22c8b44965) | ![02 ui-catalog-benchmarks object-allocations after](https://github.com/user-attachments/assets/182c20b8-efff-4a05-88dc-3dbc44b747eb)
