### PR TITLE
Cache parsed W3C colors

### DIFF
--- a/Terminal.Gui/Drawing/Color/ColorStrings.cs
+++ b/Terminal.Gui/Drawing/Color/ColorStrings.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Resources;
 using Terminal.Gui.Resources;
@@ -11,6 +12,10 @@ namespace Terminal.Gui;
 /// </summary>
 public static class ColorStrings
 {
+    // Concurrent dictionary is used instead of mutex lock because at worst case there is just extra parsing when a color is missing from the cache,
+    // i.e. prioritize throughput over cache hit accuracy.
+    private static readonly ConcurrentDictionary<string, Color> CachedParsedColors = new(StringComparer.OrdinalIgnoreCase);
+
     // PERFORMANCE: See https://stackoverflow.com/a/15521524/297526 for why GlobalResources.GetString is fast.
 
     /// <summary>
@@ -52,17 +57,47 @@ public static class ColorStrings
     /// <returns><see langword="true"/> if <paramref name="name"/> was parsed successfully.</returns>
     public static bool TryParseW3CColorName (string name, out Color color)
     {
-        foreach (DictionaryEntry entry in GlobalResources.GetResourceSet (CultureInfo.CurrentUICulture, true, true)!)
+        // Try to avoid looping through and parsing the same repeatedly requested colors.
+        if (CachedParsedColors.TryGetValue (name, out Color cachedColor))
         {
-            if (entry.Value is string colorName && colorName.Equals (name, StringComparison.OrdinalIgnoreCase))
+            color = cachedColor;
+            return true;
+        }
+
+        // TODO: Should the cache be purged if UI culture changes?
+        ResourceSet? resourceSet = GlobalResources.GetResourceSet (CultureInfo.CurrentUICulture, true, true);
+        if (resourceSet != null)
+        {
+            // Not very efficient.
+            // DictionaryEntry is struct which is boxed because ResourceSet uses archaic non-generic interfaces.
+            foreach (DictionaryEntry entry in resourceSet)
             {
-                return TryParseColorKey (entry.Key.ToString (), out color);
+                if (entry.Value is string colorName && colorName.Equals (name, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (TryParseColorKey (entry.Key.ToString (), out Color parsedEntryColor))
+                    {
+                        // The add failing is not critical.
+                        // It just means that multiple threads parsed the same value and tried adding it. 
+                        _ = CachedParsedColors.TryAdd (name, parsedEntryColor);
+                        color = parsedEntryColor;
+                        return true;
+                    }
+                    color = default;
+                    return false;
+                }
             }
         }
 
-        return TryParseColorKey (name, out color);
+        if (TryParseColorKey (name, out Color parsedRgbColor))
+        {
+            _ = CachedParsedColors.TryAdd (name, parsedRgbColor);
+            color = parsedRgbColor;
+            return true;
+        }
+        color = default;
+        return false;
 
-        bool TryParseColorKey (string? key, out Color color)
+        static bool TryParseColorKey (string? key, out Color color)
         {
             if (key != null && key.StartsWith ('#') && key.Length == 7)
             {


### PR DESCRIPTION
I wasn't sure if the ColorStrings is meant to be thread-safe or not but just to be sure I used concurrent dictionary to at least keep it internally consistent.

Also I'm not sure if the cache should be purged in case the UI culture is changed. I added TODO comment about it. In general it is quite error prone to switch the current UI culture on-the-fly anyways so I'm not sure we want to open that can of worms. In case it needs to be supported, I think I have a somewhat simple solution to it but I would first need to probably create microbenchmarks for it.

## Fixes

- Improves #2725 

## Proposed Changes/Todos

- [x] Cache parsed W3C colors in ColorStrings

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

## Allocations

String and DictionaryEntry allocations dropped nicely.

| Before | After |
|--------|-------|
| ![01 object-allocations before](https://github.com/user-attachments/assets/7aa5eee6-be1a-44fe-bd8f-647f5852d080) | ![02 object-allocations after](https://github.com/user-attachments/assets/912bebb8-84a0-489c-88d3-22141894bb76) |
| ![01 dictionary-entry before](https://github.com/user-attachments/assets/a16adbb5-fa62-4899-b6cb-ecea070c0090) | ![02 dictionary-entry after](https://github.com/user-attachments/assets/8c7a17de-fa5d-4ff9-8888-62f4ac2f0cd3) |

