### PR TITLE
Reduce TextFormatter allocations

### DIFF
--- a/Benchmarks/Text/StringExtensions/ToStringEnumerable.cs
+++ b/Benchmarks/Text/StringExtensions/ToStringEnumerable.cs
@@ -22,7 +22,7 @@ public class ToStringEnumerable
     }
 
     /// <summary>
-    /// Benchmark for current implementation with stackalloc char buffer and
+    /// Benchmark for current implementation with char buffer and
     /// fallback to rune chars appending to StringBuilder.
     /// </summary>
     /// <param name="runes"></param>

--- a/Benchmarks/Text/StringExtensions/ToStringEnumerable.cs
+++ b/Benchmarks/Text/StringExtensions/ToStringEnumerable.cs
@@ -16,27 +16,28 @@ public class ToStringEnumerable
     /// </summary>
     [Benchmark]
     [ArgumentsSource (nameof (DataSource))]
-    public string Previous (IEnumerable<Rune> runes, int size)
+    public string Previous (IEnumerable<Rune> runes, int len)
     {
-        return StringAppendInLoop (runes);
+        return StringConcatInLoop (runes);
     }
 
     /// <summary>
-    /// Benchmark for current implementation with rune chars appending to StringBuilder.
+    /// Benchmark for current implementation with stackalloc char buffer and
+    /// fallback to rune chars appending to StringBuilder.
     /// </summary>
     /// <param name="runes"></param>
     /// <returns></returns>
     [Benchmark (Baseline = true)]
     [ArgumentsSource (nameof (DataSource))]
-    public string Current (IEnumerable<Rune> runes, int size)
+    public string Current (IEnumerable<Rune> runes, int len)
     {
         return Tui.StringExtensions.ToString (runes);
     }
 
     /// <summary>
-    /// Previous implementation with string append in a loop.
+    /// Previous implementation with string concatenation in a loop.
     /// </summary>
-    private static string StringAppendInLoop (IEnumerable<Rune> runes)
+    private static string StringConcatInLoop (IEnumerable<Rune> runes)
     {
         var str = string.Empty;
 
@@ -50,21 +51,34 @@ public class ToStringEnumerable
 
     public IEnumerable<object []> DataSource ()
     {
+        // Extra length argument as workaround for the summary grouping
+        // different length collections to same baseline making comparison difficult.
+        foreach (string text in GetTextData ())
+        {
+            Rune [] runes = [..text.EnumerateRunes ()];
+            yield return [runes, runes.Length];
+        }
+    }
+
+    private IEnumerable<string> GetTextData ()
+    {
         string textSource =
             """
-			Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ.
-			Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé.
-			Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.
-			Óŕćí v́áŕíúś ńát́όq́úé ṕéńát́íb́úś ét́ ḿáǵńíś d́íś ṕáŕt́úŕíéńt́ ḿόńt́éś, ńáśćét́úŕ ŕíd́íćúĺúś ḿúś. F́úśćé át́ éx́ b́ĺáńd́ít́, ćόńv́áĺĺíś q́úáḿ ét́, v́úĺṕút́át́é ĺáćúś.
-			Śúśṕéńd́íśśé śít́ áḿét́ áŕćú út́ áŕćú f́áúćíb́úś v́áŕíúś. V́ív́áḿúś śít́ áḿét́ ḿáx́íḿúś d́íáḿ. Ńáḿ éx́ ĺéό, ṕh́áŕét́ŕá éú ĺόb́όŕt́íś át́, t́ŕíśt́íq́úé út́ f́éĺíś.
-			""";
+            Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ.
+            Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé.
+            Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.
+            Óŕćí v́áŕíúś ńát́όq́úé ṕéńát́íb́úś ét́ ḿáǵńíś d́íś ṕáŕt́úŕíéńt́ ḿόńt́éś, ńáśćét́úŕ ŕíd́íćúĺúś ḿúś. F́úśćé át́ éx́ b́ĺáńd́ít́, ćόńv́áĺĺíś q́úáḿ ét́, v́úĺṕút́át́é ĺáćúś.
+            Śúśṕéńd́íśśé śít́ áḿét́ áŕćú út́ áŕćú f́áúćíb́úś v́áŕíúś. V́ív́áḿúś śít́ áḿét́ ḿáx́íḿúś d́íáḿ. Ńáḿ éx́ ĺéό, ṕh́áŕét́ŕá éú ĺόb́όŕt́íś át́, t́ŕíśt́íq́úé út́ f́éĺíś.
+            """;
 
-        // Extra argument as workaround for the summary grouping different length collections to same baseline making comparison difficult.
-        int[] sizes = [1, 10, 100, textSource.Length / 2, textSource.Length];
+        int[] lengths = [1, 10, 100, textSource.Length / 2, textSource.Length];
 
-        foreach (int size in sizes)
+        foreach (int length in lengths)
         {
-            yield return [textSource.EnumerateRunes ().Take (size).ToArray (), size];
+            yield return textSource [..length];
         }
+
+        string textLongerThanStackallocThreshold = string.Concat(Enumerable.Repeat(textSource, 10));
+        yield return textLongerThanStackallocThreshold;
     }
 }

--- a/Benchmarks/Text/StringExtensions/ToStringEnumerable.cs
+++ b/Benchmarks/Text/StringExtensions/ToStringEnumerable.cs
@@ -1,0 +1,70 @@
+﻿using System.Text;
+using BenchmarkDotNet.Attributes;
+using Tui = Terminal.Gui;
+
+namespace Terminal.Gui.Benchmarks.Text.StringExtensions;
+
+/// <summary>
+/// Benchmarks for <see cref="Tui.StringExtensions.ToString(IEnumerable{Rune})"/> performance fine-tuning.
+/// </summary>
+[MemoryDiagnoser]
+public class ToStringEnumerable
+{
+
+    /// <summary>
+    /// Benchmark for previous implementation.
+    /// </summary>
+    [Benchmark]
+    [ArgumentsSource (nameof (DataSource))]
+    public string Previous (IEnumerable<Rune> runes, int size)
+    {
+        return StringAppendInLoop (runes);
+    }
+
+    /// <summary>
+    /// Benchmark for current implementation with rune chars appending to StringBuilder.
+    /// </summary>
+    /// <param name="runes"></param>
+    /// <returns></returns>
+    [Benchmark (Baseline = true)]
+    [ArgumentsSource (nameof (DataSource))]
+    public string Current (IEnumerable<Rune> runes, int size)
+    {
+        return Tui.StringExtensions.ToString (runes);
+    }
+
+    /// <summary>
+    /// Previous implementation with string append in a loop.
+    /// </summary>
+    private static string StringAppendInLoop (IEnumerable<Rune> runes)
+    {
+        var str = string.Empty;
+
+        foreach (Rune rune in runes)
+        {
+            str += rune.ToString ();
+        }
+
+        return str;
+    }
+
+    public IEnumerable<object []> DataSource ()
+    {
+        string textSource =
+            """
+			Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ.
+			Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé.
+			Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.
+			Óŕćí v́áŕíúś ńát́όq́úé ṕéńát́íb́úś ét́ ḿáǵńíś d́íś ṕáŕt́úŕíéńt́ ḿόńt́éś, ńáśćét́úŕ ŕíd́íćúĺúś ḿúś. F́úśćé át́ éx́ b́ĺáńd́ít́, ćόńv́áĺĺíś q́úáḿ ét́, v́úĺṕút́át́é ĺáćúś.
+			Śúśṕéńd́íśśé śít́ áḿét́ áŕćú út́ áŕćú f́áúćíb́úś v́áŕíúś. V́ív́áḿúś śít́ áḿét́ ḿáx́íḿúś d́íáḿ. Ńáḿ éx́ ĺéό, ṕh́áŕét́ŕá éú ĺόb́όŕt́íś át́, t́ŕíśt́íq́úé út́ f́éĺíś.
+			""";
+
+        // Extra argument as workaround for the summary grouping different length collections to same baseline making comparison difficult.
+        int[] sizes = [1, 10, 100, textSource.Length / 2, textSource.Length];
+
+        foreach (int size in sizes)
+        {
+            yield return [textSource.EnumerateRunes ().Take (size).ToArray (), size];
+        }
+    }
+}

--- a/Benchmarks/Text/TextFormatter/RemoveHotKeySpecifier.cs
+++ b/Benchmarks/Text/TextFormatter/RemoveHotKeySpecifier.cs
@@ -1,0 +1,97 @@
+﻿using System.Text;
+using BenchmarkDotNet.Attributes;
+using Tui = Terminal.Gui;
+
+namespace Terminal.Gui.Benchmarks.Text.TextFormatter;
+
+/// <summary>
+/// Benchmarks for <see cref="Tui.TextFormatter.RemoveHotKeySpecifier"/> performance fine-tuning.
+/// </summary>
+[MemoryDiagnoser]
+[BenchmarkCategory (nameof(Tui.TextFormatter))]
+public class RemoveHotKeySpecifier
+{
+    // Omit from summary table.
+    private static readonly Rune HotkeySpecifier = (Rune)'_';
+
+    /// <summary>
+    /// Benchmark for previous implementation.
+    /// </summary>
+    [Benchmark]
+    [ArgumentsSource (nameof (DataSource))]
+    public string Previous (string text, int hotPos)
+    {
+        return StringConcatLoop (text, hotPos, HotkeySpecifier);
+    }
+
+    /// <summary>
+    /// Benchmark for current implementation with stackalloc char buffer and fallback to rented array.
+    /// </summary>
+    [Benchmark (Baseline = true)]
+    [ArgumentsSource (nameof (DataSource))]
+    public string Current (string text, int hotPos)
+    {
+        return Tui.TextFormatter.RemoveHotKeySpecifier (text, hotPos, HotkeySpecifier);
+    }
+
+    /// <summary>
+    /// Previous implementation with string concatenation in a loop.
+    /// </summary>
+    public static string StringConcatLoop (string text, int hotPos, Rune hotKeySpecifier)
+    {
+        if (string.IsNullOrEmpty (text))
+        {
+            return text;
+        }
+
+        // Scan 
+        var start = string.Empty;
+        var i = 0;
+
+        foreach (Rune c in text.EnumerateRunes ())
+        {
+            if (c == hotKeySpecifier && i == hotPos)
+            {
+                i++;
+
+                continue;
+            }
+
+            start += c;
+            i++;
+        }
+
+        return start;
+    }
+
+    public IEnumerable<object []> DataSource ()
+    {
+        string[] texts = [
+            "",
+			// Typical scenario.
+			"_Save file (Ctrl+S)",
+			// Medium text, hotkey specifier somewhere in the middle.
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed euismod metus. _Phasellus lectus metus, ultricies a commodo quis, facilisis vitae nulla.",
+			// Long text, hotkey specifier almost at the beginning.
+			"Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. _Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ. " +
+            "Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé. " +
+            "Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.",
+			// Long text, hotkey specifier almost at the end.
+			"Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ. " +
+            "Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé. " +
+            "Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. _Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.",
+        ];
+
+        foreach (string text in texts)
+        {
+            int hotPos = text.EnumerateRunes()
+                .Select((r, i) => r == HotkeySpecifier ? i : -1)
+                .FirstOrDefault(i => i > -1, -1);
+
+            yield return [text, hotPos];
+        }
+
+        // Typical scenario but without hotkey and with misleading position.
+        yield return ["Save file (Ctrl+S)", 3];
+    }
+}

--- a/Benchmarks/Text/TextFormatter/ReplaceCRLFWithSpace.cs
+++ b/Benchmarks/Text/TextFormatter/ReplaceCRLFWithSpace.cs
@@ -8,6 +8,7 @@ namespace Terminal.Gui.Benchmarks.Text.TextFormatter;
 /// Benchmarks for <see cref="Tui.TextFormatter.ReplaceCRLFWithSpace"/> performance fine-tuning.
 /// </summary>
 [MemoryDiagnoser]
+[BenchmarkCategory (nameof (Tui.TextFormatter))]
 public class ReplaceCRLFWithSpace
 {
 

--- a/Benchmarks/Text/TextFormatter/ReplaceCRLFWithSpace.cs
+++ b/Benchmarks/Text/TextFormatter/ReplaceCRLFWithSpace.cs
@@ -1,0 +1,89 @@
+﻿using System.Text;
+using BenchmarkDotNet.Attributes;
+using Tui = Terminal.Gui;
+
+namespace Terminal.Gui.Benchmarks.Text.TextFormatter;
+
+/// <summary>
+/// Benchmarks for <see cref="Tui.TextFormatter.ReplaceCRLFWithSpace"/> performance fine-tuning.
+/// </summary>
+[MemoryDiagnoser]
+public class ReplaceCRLFWithSpace
+{
+
+    /// <summary>
+    /// Benchmark for previous implementation.
+    /// </summary>
+    [Benchmark]
+    [ArgumentsSource (nameof (DataSource))]
+    public string Previous (string str)
+    {
+        return ToRuneListReplaceImplementation (str);
+    }
+
+    /// <summary>
+    /// Benchmark for current implementation.
+    /// </summary>
+    [Benchmark (Baseline = true)]
+    [ArgumentsSource (nameof (DataSource))]
+    public string Current (string str)
+    {
+        return Tui.TextFormatter.ReplaceCRLFWithSpace (str);
+    }
+
+    /// <summary>
+    /// Previous implementation with intermediate rune list.
+    /// </summary>
+    /// <param name="str"></param>
+    /// <returns></returns>
+    private static string ToRuneListReplaceImplementation (string str)
+    {
+        var runes = str.ToRuneList ();
+        for (int i = 0; i < runes.Count; i++)
+        {
+            switch (runes [i].Value)
+            {
+                case '\n':
+                    runes [i] = (Rune)' ';
+                    break;
+
+                case '\r':
+                    if ((i + 1) < runes.Count && runes [i + 1].Value == '\n')
+                    {
+                        runes [i] = (Rune)' ';
+                        runes.RemoveAt (i + 1);
+                        i++;
+                    }
+                    else
+                    {
+                        runes [i] = (Rune)' ';
+                    }
+                    break;
+            }
+        }
+        return Tui.StringExtensions.ToString (runes);
+    }
+
+    public IEnumerable<object> DataSource ()
+    {
+        // Extreme newline scenario
+        yield return "E\r\nx\r\nt\r\nr\r\ne\r\nm\r\ne\r\nn\r\ne\r\nw\r\nl\r\ni\r\nn\r\ne\r\ns\r\nc\r\ne\r\nn\r\na\r\nr\r\ni\r\no\r\n";
+        // Long text with few line endings
+        yield return
+            """
+			Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ.
+			Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé.
+			Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.
+			Óŕćí v́áŕíúś ńát́όq́úé ṕéńát́íb́úś ét́ ḿáǵńíś d́íś ṕáŕt́úŕíéńt́ ḿόńt́éś, ńáśćét́úŕ ŕíd́íćúĺúś ḿúś. F́úśćé át́ éx́ b́ĺáńd́ít́, ćόńv́áĺĺíś q́úáḿ ét́, v́úĺṕút́át́é ĺáćúś.
+			Śúśṕéńd́íśśé śít́ áḿét́ áŕćú út́ áŕćú f́áúćíb́úś v́áŕíúś. V́ív́áḿúś śít́ áḿét́ ḿáx́íḿúś d́íáḿ. Ńáḿ éx́ ĺéό, ṕh́áŕét́ŕá éú ĺόb́όŕt́íś át́, t́ŕíśt́íq́úé út́ f́éĺíś.
+			"""
+            // Consistent line endings between systems for more consistent performance evaluation.
+            .ReplaceLineEndings ("\r\n");
+        // Long text without line endings
+        yield return
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed euismod metus. Phasellus lectus metus, ultricies a commodo quis, facilisis vitae nulla. " +
+            "Curabitur mollis ex nisl, vitae mattis nisl consequat at. Aliquam dolor lectus, tincidunt ac nunc eu, elementum molestie lectus. Donec lacinia eget dolor a scelerisque. " +
+            "Aenean elementum molestie rhoncus. Duis id ornare lorem. Nam eget porta sapien. Etiam rhoncus dignissim leo, ac suscipit magna finibus eu. Curabitur hendrerit elit erat, sit amet suscipit felis condimentum ut. " +
+            "Nullam semper tempor mi, nec semper quam fringilla eu. Aenean sit amet pretium augue, in posuere ante. Aenean convallis porttitor purus, et posuere velit dictum eu.";
+    }
+}

--- a/Benchmarks/Text/TextFormatter/StripCRLF.cs
+++ b/Benchmarks/Text/TextFormatter/StripCRLF.cs
@@ -8,6 +8,7 @@ namespace Terminal.Gui.Benchmarks.Text.TextFormatter;
 /// Benchmarks for <see cref="Tui.TextFormatter.StripCRLF"/> performance fine-tuning.
 /// </summary>
 [MemoryDiagnoser]
+[BenchmarkCategory (nameof (Tui.TextFormatter))]
 public class StripCRLF
 {
     /// <summary>

--- a/Benchmarks/Text/TextFormatter/StripCRLF.cs
+++ b/Benchmarks/Text/TextFormatter/StripCRLF.cs
@@ -4,6 +4,9 @@ using Tui = Terminal.Gui;
 
 namespace Terminal.Gui.Benchmarks.Text.TextFormatter;
 
+/// <summary>
+/// Benchmarks for <see cref="Tui.TextFormatter.StripCRLF"/> performance fine-tuning.
+/// </summary>
 [MemoryDiagnoser]
 public class StripCRLF
 {
@@ -31,7 +34,7 @@ public class StripCRLF
     }
 
     /// <summary>
-    /// Previous implementation with intermediate list allocation.
+    /// Previous implementation with intermediate rune list.
     /// </summary>
     private static string RuneListToString (string str, bool keepNewLine = false)
     {
@@ -98,7 +101,7 @@ public class StripCRLF
             "Nullam semper tempor mi, nec semper quam fringilla eu. Aenean sit amet pretium augue, in posuere ante. Aenean convallis porttitor purus, et posuere velit dictum eu."
         ];
 
-        bool[] newLinePermutations = { true, false };
+        bool[] newLinePermutations = [true, false];
 
         foreach (string text in textPermutations)
         {

--- a/Benchmarks/Text/TextFormatter/StripCRLF.cs
+++ b/Benchmarks/Text/TextFormatter/StripCRLF.cs
@@ -1,0 +1,102 @@
+﻿using System.Text;
+using BenchmarkDotNet.Attributes;
+using Tui = Terminal.Gui;
+
+namespace Terminal.Gui.Benchmarks.Text.TextFormatter;
+
+[MemoryDiagnoser]
+public class StripCRLF
+{
+    /// <summary>
+    /// Benchmark for previous implementation.
+    /// </summary>
+    /// <param name="str"></param>
+    /// <param name="keepNewLine"></param>
+    /// <returns></returns>
+    [Benchmark]
+    [ArgumentsSource (nameof (DataSource))]
+    public string Previous (string str, bool keepNewLine)
+    {
+        return RuneListToString (str, keepNewLine);
+    }
+
+    /// <summary>
+    /// Benchmark for current implementation with StringBuilder and char span index of search.
+    /// </summary>
+    [Benchmark (Baseline = true)]
+    [ArgumentsSource (nameof (DataSource))]
+    public string Current (string str, bool keepNewLine)
+    {
+        return Tui.TextFormatter.StripCRLF (str, keepNewLine);
+    }
+
+    /// <summary>
+    /// Previous implementation with intermediate list allocation.
+    /// </summary>
+    private static string RuneListToString (string str, bool keepNewLine = false)
+    {
+        List<Rune> runes = str.ToRuneList ();
+
+        for (var i = 0; i < runes.Count; i++)
+        {
+            switch ((char)runes [i].Value)
+            {
+                case '\n':
+                    if (!keepNewLine)
+                    {
+                        runes.RemoveAt (i);
+                    }
+
+                    break;
+
+                case '\r':
+                    if (i + 1 < runes.Count && runes [i + 1].Value == '\n')
+                    {
+                        runes.RemoveAt (i);
+
+                        if (!keepNewLine)
+                        {
+                            runes.RemoveAt (i);
+                        }
+
+                        i++;
+                    }
+                    else
+                    {
+                        if (!keepNewLine)
+                        {
+                            runes.RemoveAt (i);
+                        }
+                    }
+
+                    break;
+            }
+        }
+
+        return StringExtensions.ToString (runes);
+    }
+
+    public IEnumerable<object []> DataSource ()
+    {
+        string textSource =
+                """
+				Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ.
+				Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé.
+				Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.
+				Óŕćí v́áŕíúś ńát́όq́úé ṕéńát́íb́úś ét́ ḿáǵńíś d́íś ṕáŕt́úŕíéńt́ ḿόńt́éś, ńáśćét́úŕ ŕíd́íćúĺúś ḿúś. F́úśćé át́ éx́ b́ĺáńd́ít́, ćόńv́áĺĺíś q́úáḿ ét́, v́úĺṕút́át́é ĺáćúś.
+				Śúśṕéńd́íśśé śít́ áḿét́ áŕćú út́ áŕćú f́áúćíb́úś v́áŕíúś. V́ív́áḿúś śít́ áḿét́ ḿáx́íḿúś d́íáḿ. Ńáḿ éx́ ĺéό, ṕh́áŕét́ŕá éú ĺόb́όŕt́íś át́, t́ŕíśt́íq́úé út́ f́éĺíś.
+				""";
+        // Consistent line endings between systems keeps performance evaluation more consistent.
+        textSource = textSource.ReplaceLineEndings ("\r\n");
+
+        bool[] permutations = [true, false];
+        foreach (bool keepNewLine in permutations)
+        {
+            yield return [textSource [..1], keepNewLine];
+            yield return [textSource [..10], keepNewLine];
+            yield return [textSource [..100], keepNewLine];
+            yield return [textSource [..(textSource.Length / 2)], keepNewLine];
+            yield return [textSource, keepNewLine];
+        }
+    }
+}

--- a/Benchmarks/Text/TextFormatter/StripCRLF.cs
+++ b/Benchmarks/Text/TextFormatter/StripCRLF.cs
@@ -78,25 +78,34 @@ public class StripCRLF
 
     public IEnumerable<object []> DataSource ()
     {
-        string textSource =
-                """
-				Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ.
-				Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé.
-				Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.
-				Óŕćí v́áŕíúś ńát́όq́úé ṕéńát́íb́úś ét́ ḿáǵńíś d́íś ṕáŕt́úŕíéńt́ ḿόńt́éś, ńáśćét́úŕ ŕíd́íćúĺúś ḿúś. F́úśćé át́ éx́ b́ĺáńd́ít́, ćόńv́áĺĺíś q́úáḿ ét́, v́úĺṕút́át́é ĺáćúś.
-				Śúśṕéńd́íśśé śít́ áḿét́ áŕćú út́ áŕćú f́áúćíb́úś v́áŕíúś. V́ív́áḿúś śít́ áḿét́ ḿáx́íḿúś d́íáḿ. Ńáḿ éx́ ĺéό, ṕh́áŕét́ŕá éú ĺόb́όŕt́íś át́, t́ŕíśt́íq́úé út́ f́éĺíś.
-				""";
-        // Consistent line endings between systems keeps performance evaluation more consistent.
-        textSource = textSource.ReplaceLineEndings ("\r\n");
+        string[] textPermutations = [
+            // Extreme newline scenario
+            "E\r\nx\r\nt\r\nr\r\ne\r\nm\r\ne\r\nn\r\ne\r\nw\r\nl\r\ni\r\nn\r\ne\r\ns\r\nc\r\ne\r\nn\r\na\r\nr\r\ni\r\no\r\n",
+            // Long text with few line endings
+            """
+            Ĺόŕéḿ íṕśúḿ d́όĺόŕ śít́ áḿét́, ćόńśéćt́ét́úŕ ád́íṕíśćíńǵ éĺít́. Ṕŕáéśéńt́ q́úíś ĺúćt́úś éĺít́. Íńt́éǵéŕ út́ áŕćú éǵét́ d́όĺόŕ śćéĺéŕíśq́úé ḿát́t́íś áć ét́ d́íáḿ.
+            Ṕéĺĺéńt́éśq́úé śéd́ d́áṕíb́úś ḿáśśá, v́éĺ t́ŕíśt́íq́úé d́úí. Śéd́ v́ít́áé ńéq́úé éú v́éĺít́ όŕńáŕé áĺíq́úét́. Út́ q́úíś όŕćí t́éḿṕόŕ, t́éḿṕόŕ t́úŕṕíś íd́, t́éḿṕúś ńéq́úé.
+            Ṕŕáéśéńt́ śáṕíéń t́úŕṕíś, όŕńáŕé v́éĺ ḿáúŕíś át́, v́áŕíúś śúśćíṕít́ áńt́é. Út́ ṕúĺv́íńáŕ t́úŕṕíś ḿáśśá, q́úíś ćúŕśúś áŕćú f́áúćíb́úś íń.
+            Óŕćí v́áŕíúś ńát́όq́úé ṕéńát́íb́úś ét́ ḿáǵńíś d́íś ṕáŕt́úŕíéńt́ ḿόńt́éś, ńáśćét́úŕ ŕíd́íćúĺúś ḿúś. F́úśćé át́ éx́ b́ĺáńd́ít́, ćόńv́áĺĺíś q́úáḿ ét́, v́úĺṕút́át́é ĺáćúś.
+            Śúśṕéńd́íśśé śít́ áḿét́ áŕćú út́ áŕćú f́áúćíb́úś v́áŕíúś. V́ív́áḿúś śít́ áḿét́ ḿáx́íḿúś d́íáḿ. Ńáḿ éx́ ĺéό, ṕh́áŕét́ŕá éú ĺόb́όŕt́íś át́, t́ŕíśt́íq́úé út́ f́éĺíś.
+            """
+            // Consistent line endings between systems for more consistent performance evaluation.
+            .ReplaceLineEndings ("\r\n"),
+            // Long text without line endings
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed euismod metus. Phasellus lectus metus, ultricies a commodo quis, facilisis vitae nulla. " +
+            "Curabitur mollis ex nisl, vitae mattis nisl consequat at. Aliquam dolor lectus, tincidunt ac nunc eu, elementum molestie lectus. Donec lacinia eget dolor a scelerisque. " +
+            "Aenean elementum molestie rhoncus. Duis id ornare lorem. Nam eget porta sapien. Etiam rhoncus dignissim leo, ac suscipit magna finibus eu. Curabitur hendrerit elit erat, sit amet suscipit felis condimentum ut. " +
+            "Nullam semper tempor mi, nec semper quam fringilla eu. Aenean sit amet pretium augue, in posuere ante. Aenean convallis porttitor purus, et posuere velit dictum eu."
+        ];
 
-        bool[] permutations = [true, false];
-        foreach (bool keepNewLine in permutations)
+        bool[] newLinePermutations = { true, false };
+
+        foreach (string text in textPermutations)
         {
-            yield return [textSource [..1], keepNewLine];
-            yield return [textSource [..10], keepNewLine];
-            yield return [textSource [..100], keepNewLine];
-            yield return [textSource [..(textSource.Length / 2)], keepNewLine];
-            yield return [textSource, keepNewLine];
+            foreach (bool keepNewLine in newLinePermutations)
+            {
+                yield return [text, keepNewLine];
+            }
         }
     }
 }

--- a/Benchmarks/Text/TextFormatter/StripCRLF.cs
+++ b/Benchmarks/Text/TextFormatter/StripCRLF.cs
@@ -77,7 +77,7 @@ public class StripCRLF
             }
         }
 
-        return StringExtensions.ToString (runes);
+        return Tui.StringExtensions.ToString (runes);
     }
 
     public IEnumerable<object []> DataSource ()

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -78,9 +78,10 @@
         <Using Include="Terminal.Gui.EnumExtensions" />
     </ItemGroup>
     <!-- =================================================================== -->
-    <!-- Assembliy names for which internal items are visible -->
+    <!-- Assembly names for which internal items are visible -->
     <!-- =================================================================== -->
     <ItemGroup>
+        <InternalsVisibleTo Include="Benchmarks"/>
         <InternalsVisibleTo Include="UnitTests" />
         <InternalsVisibleTo Include="UnitTests.Parallelizable" />
         <InternalsVisibleTo Include="StressTests" />

--- a/Terminal.Gui/Text/StringExtensions.cs
+++ b/Terminal.Gui/Text/StringExtensions.cs
@@ -124,14 +124,16 @@ public static class StringExtensions
     /// <returns></returns>
     public static string ToString (IEnumerable<Rune> runes)
     {
-        var str = string.Empty;
-
+        StringBuilder stringBuilder = new();
+        const int maxCharsPerRune = 2;
+        Span<char> charBuffer = stackalloc char[maxCharsPerRune];
         foreach (Rune rune in runes)
         {
-            str += rune.ToString ();
+            int charsWritten = rune.EncodeToUtf16 (charBuffer);
+            ReadOnlySpan<char> runeChars = charBuffer [..charsWritten];
+            stringBuilder.Append (runeChars);
         }
-
-        return str;
+        return stringBuilder.ToString ();
     }
 
     /// <summary>Converts a byte generic collection into a string in the provided encoding (default is UTF8)</summary>

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -442,7 +442,7 @@ public class TextFormatter
             }
         }
     }
-    
+
     /// <summary>
     ///     Determines if the viewport width will be used or only the text width will be used,
     ///     If <see langword="true"/> all the viewport area will be filled with whitespaces and the same background color
@@ -942,67 +942,67 @@ public class TextFormatter
             {
                 // Horizontal Alignment
                 case Alignment.End when isVertical:
-                {
-                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, line, linesFormatted.Count - line, TabWidth);
-                    x = screen.Right - runesWidth;
+                    {
+                        int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, line, linesFormatted.Count - line, TabWidth);
+                        x = screen.Right - runesWidth;
 
-                    break;
-                }
+                        break;
+                    }
                 case Alignment.End:
-                {
-                    int runesWidth = StringExtensions.ToString (runes).GetColumns ();
-                    x = screen.Right - runesWidth;
+                    {
+                        int runesWidth = StringExtensions.ToString (runes).GetColumns ();
+                        x = screen.Right - runesWidth;
 
-                    break;
-                }
+                        break;
+                    }
                 case Alignment.Start when isVertical:
-                {
-                    int runesWidth = line > 0
+                    {
+                        int runesWidth = line > 0
                                          ? GetColumnsRequiredForVerticalText (linesFormatted, 0, line, TabWidth)
                                          : 0;
-                    x = screen.Left + runesWidth;
+                        x = screen.Left + runesWidth;
 
-                    break;
-                }
+                        break;
+                    }
                 case Alignment.Start:
                     x = screen.Left;
 
                     break;
                 case Alignment.Fill when isVertical:
-                {
-                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, 0, linesFormatted.Count, TabWidth);
-                    int prevLineWidth = line > 0 ? GetColumnsRequiredForVerticalText (linesFormatted, line - 1, 1, TabWidth) : 0;
-                    int firstLineWidth = GetColumnsRequiredForVerticalText (linesFormatted, 0, 1, TabWidth);
-                    int lastLineWidth = GetColumnsRequiredForVerticalText (linesFormatted, linesFormatted.Count - 1, 1, TabWidth);
-                    var interval = (int)Math.Round ((double)(screen.Width + firstLineWidth + lastLineWidth) / linesFormatted.Count);
+                    {
+                        int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, 0, linesFormatted.Count, TabWidth);
+                        int prevLineWidth = line > 0 ? GetColumnsRequiredForVerticalText (linesFormatted, line - 1, 1, TabWidth) : 0;
+                        int firstLineWidth = GetColumnsRequiredForVerticalText (linesFormatted, 0, 1, TabWidth);
+                        int lastLineWidth = GetColumnsRequiredForVerticalText (linesFormatted, linesFormatted.Count - 1, 1, TabWidth);
+                        var interval = (int)Math.Round ((double)(screen.Width + firstLineWidth + lastLineWidth) / linesFormatted.Count);
 
-                    x = line == 0
-                            ? screen.Left
-                            : line < linesFormatted.Count - 1
-                                ? screen.Width - runesWidth <= lastLineWidth ? screen.Left + prevLineWidth : screen.Left + line * interval
-                                : screen.Right - lastLineWidth;
+                        x = line == 0
+                                ? screen.Left
+                                : line < linesFormatted.Count - 1
+                                    ? screen.Width - runesWidth <= lastLineWidth ? screen.Left + prevLineWidth : screen.Left + line * interval
+                                    : screen.Right - lastLineWidth;
 
-                    break;
-                }
+                        break;
+                    }
                 case Alignment.Fill:
                     x = screen.Left;
 
                     break;
                 case Alignment.Center when isVertical:
-                {
-                    int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, 0, linesFormatted.Count, TabWidth);
-                    int linesWidth = GetColumnsRequiredForVerticalText (linesFormatted, 0, line, TabWidth);
-                    x = screen.Left + linesWidth + (screen.Width - runesWidth) / 2;
+                    {
+                        int runesWidth = GetColumnsRequiredForVerticalText (linesFormatted, 0, linesFormatted.Count, TabWidth);
+                        int linesWidth = GetColumnsRequiredForVerticalText (linesFormatted, 0, line, TabWidth);
+                        x = screen.Left + linesWidth + (screen.Width - runesWidth) / 2;
 
-                    break;
-                }
+                        break;
+                    }
                 case Alignment.Center:
-                {
-                    int runesWidth = StringExtensions.ToString (runes).GetColumns ();
-                    x = screen.Left + (screen.Width - runesWidth) / 2;
+                    {
+                        int runesWidth = StringExtensions.ToString (runes).GetColumns ();
+                        x = screen.Left + (screen.Width - runesWidth) / 2;
 
-                    break;
-                }
+                        break;
+                    }
                 default:
                     Debug.WriteLine ($"Unsupported Alignment: {nameof (VerticalAlignment)}");
 
@@ -1033,28 +1033,28 @@ public class TextFormatter
 
                     break;
                 case Alignment.Fill:
-                {
-                    var interval = (int)Math.Round ((double)(screen.Height + 2) / linesFormatted.Count);
+                    {
+                        var interval = (int)Math.Round ((double)(screen.Height + 2) / linesFormatted.Count);
 
-                    y = line == 0 ? screen.Top :
-                        line < linesFormatted.Count - 1 ? screen.Height - interval <= 1 ? screen.Top + 1 : screen.Top + line * interval : screen.Bottom - 1;
+                        y = line == 0 ? screen.Top :
+                            line < linesFormatted.Count - 1 ? screen.Height - interval <= 1 ? screen.Top + 1 : screen.Top + line * interval : screen.Bottom - 1;
 
-                    break;
-                }
+                        break;
+                    }
                 case Alignment.Center when isVertical:
-                {
-                    int s = (screen.Height - runes.Length) / 2;
-                    y = screen.Top + s;
+                    {
+                        int s = (screen.Height - runes.Length) / 2;
+                        y = screen.Top + s;
 
-                    break;
-                }
+                        break;
+                    }
                 case Alignment.Center:
-                {
-                    int s = (screen.Height - linesFormatted.Count) / 2;
-                    y = screen.Top + line + s;
+                    {
+                        int s = (screen.Height - linesFormatted.Count) / 2;
+                        y = screen.Top + line + s;
 
-                    break;
-                }
+                        break;
+                    }
                 default:
                     Debug.WriteLine ($"Unsupported Alignment: {nameof (VerticalAlignment)}");
 
@@ -1144,48 +1144,48 @@ public class TextFormatter
     public static bool IsHorizontalDirection (TextDirection textDirection)
     {
         return textDirection switch
-               {
-                   TextDirection.LeftRight_TopBottom => true,
-                   TextDirection.LeftRight_BottomTop => true,
-                   TextDirection.RightLeft_TopBottom => true,
-                   TextDirection.RightLeft_BottomTop => true,
-                   _ => false
-               };
+        {
+            TextDirection.LeftRight_TopBottom => true,
+            TextDirection.LeftRight_BottomTop => true,
+            TextDirection.RightLeft_TopBottom => true,
+            TextDirection.RightLeft_BottomTop => true,
+            _ => false
+        };
     }
 
     /// <summary>Check if it is a vertical direction</summary>
     public static bool IsVerticalDirection (TextDirection textDirection)
     {
         return textDirection switch
-               {
-                   TextDirection.TopBottom_LeftRight => true,
-                   TextDirection.TopBottom_RightLeft => true,
-                   TextDirection.BottomTop_LeftRight => true,
-                   TextDirection.BottomTop_RightLeft => true,
-                   _ => false
-               };
+        {
+            TextDirection.TopBottom_LeftRight => true,
+            TextDirection.TopBottom_RightLeft => true,
+            TextDirection.BottomTop_LeftRight => true,
+            TextDirection.BottomTop_RightLeft => true,
+            _ => false
+        };
     }
 
     /// <summary>Check if it is Left to Right direction</summary>
     public static bool IsLeftToRight (TextDirection textDirection)
     {
         return textDirection switch
-               {
-                   TextDirection.LeftRight_TopBottom => true,
-                   TextDirection.LeftRight_BottomTop => true,
-                   _ => false
-               };
+        {
+            TextDirection.LeftRight_TopBottom => true,
+            TextDirection.LeftRight_BottomTop => true,
+            _ => false
+        };
     }
 
     /// <summary>Check if it is Top to Bottom direction</summary>
     public static bool IsTopToBottom (TextDirection textDirection)
     {
         return textDirection switch
-               {
-                   TextDirection.TopBottom_LeftRight => true,
-                   TextDirection.TopBottom_RightLeft => true,
-                   _ => false
-               };
+        {
+            TextDirection.TopBottom_LeftRight => true,
+            TextDirection.TopBottom_RightLeft => true,
+            _ => false
+        };
     }
 
     // TODO: Move to StringExtensions?
@@ -1259,34 +1259,60 @@ public class TextFormatter
     // TODO: Move to StringExtensions?
     internal static string ReplaceCRLFWithSpace (string str)
     {
-        List<Rune> runes = str.ToRuneList ();
-
-        for (var i = 0; i < runes.Count; i++)
+        ReadOnlySpan<char> remaining = str.AsSpan ();
+        int firstNewlineCharIndex = remaining.IndexOfAny (NewlineSearchValues);
+        // Early exit to avoid StringBuilder allocation if there are no newline characters.
+        if (firstNewlineCharIndex < 0)
         {
-            switch (runes [i].Value)
-            {
-                case '\n':
-                    runes [i] = (Rune)' ';
-
-                    break;
-
-                case '\r':
-                    if (i + 1 < runes.Count && runes [i + 1].Value == '\n')
-                    {
-                        runes [i] = (Rune)' ';
-                        runes.RemoveAt (i + 1);
-                        i++;
-                    }
-                    else
-                    {
-                        runes [i] = (Rune)' ';
-                    }
-
-                    break;
-            }
+            return str;
         }
 
-        return StringExtensions.ToString (runes);
+        StringBuilder stringBuilder = new();
+        ReadOnlySpan<char> firstSegment = remaining[..firstNewlineCharIndex];
+        stringBuilder.Append (firstSegment);
+
+        // The first newline is not yet skipped because the newline type has not been evaluated.
+        // This means there will be 1 extra iteration because the same newline index is checked again in the loop.
+        remaining = remaining [firstNewlineCharIndex..];
+
+        while (remaining.Length > 0)
+        {
+            int newlineCharIndex = remaining.IndexOfAny (NewlineSearchValues);
+            if (newlineCharIndex == -1)
+            {
+                break;
+            }
+
+            ReadOnlySpan<char> segment = remaining[..newlineCharIndex];
+            stringBuilder.Append (segment);
+
+            int stride = segment.Length;
+            // Replace newlines
+            char newlineChar = remaining [newlineCharIndex];
+            if (newlineChar == '\n')
+            {
+                stride++;
+                stringBuilder.Append (' ');
+            }
+            else // '\r'
+            {
+                int nextCharIndex = newlineCharIndex + 1;
+                bool crlf = nextCharIndex < remaining.Length && remaining [nextCharIndex] == '\n';
+                if (crlf)
+                {
+                    stride += 2;
+                    stringBuilder.Append (' ');
+                }
+                else
+                {
+                    stride++;
+                    stringBuilder.Append (' ');
+                }
+            }
+            remaining = remaining [stride..];
+        }
+        stringBuilder.Append (remaining);
+        return stringBuilder.ToString ();
     }
 
     // TODO: Move to StringExtensions?
@@ -1598,21 +1624,21 @@ public class TextFormatter
                     case ' ':
                         return GetNextWhiteSpace (to + 1, cWidth, out incomplete, length);
                     case '\t':
-                    {
-                        length += tabWidth + 1;
-
-                        if (length == tabWidth && tabWidth > cWidth)
                         {
-                            return to + 1;
-                        }
+                            length += tabWidth + 1;
 
-                        if (length > cWidth && tabWidth > cWidth)
-                        {
-                            return to;
-                        }
+                            if (length == tabWidth && tabWidth > cWidth)
+                            {
+                                return to + 1;
+                            }
 
-                        return GetNextWhiteSpace (to + 1, cWidth, out incomplete, length);
-                    }
+                            if (length > cWidth && tabWidth > cWidth)
+                            {
+                                return to;
+                            }
+
+                            return GetNextWhiteSpace (to + 1, cWidth, out incomplete, length);
+                        }
                     default:
                         to++;
 
@@ -1621,11 +1647,11 @@ public class TextFormatter
             }
 
             return cLength switch
-                   {
-                       > 0 when to < runes.Count && runes [to].Value != ' ' && runes [to].Value != '\t' => from,
-                       > 0 when to < runes.Count && (runes [to].Value == ' ' || runes [to].Value == '\t') => from,
-                       _ => to
-                   };
+            {
+                > 0 when to < runes.Count && runes [to].Value != ' ' && runes [to].Value != '\t' => from,
+                > 0 when to < runes.Count && (runes [to].Value == ' ' || runes [to].Value == '\t') => from,
+                _ => to
+            };
         }
 
         if (start < text.GetRuneCount ())
@@ -2061,13 +2087,13 @@ public class TextFormatter
     private static string PerformCorrectFormatDirection (TextDirection textDirection, string line)
     {
         return textDirection switch
-               {
-                   TextDirection.RightLeft_BottomTop
-                       or TextDirection.RightLeft_TopBottom
-                       or TextDirection.BottomTop_LeftRight
-                       or TextDirection.BottomTop_RightLeft => StringExtensions.ToString (line.EnumerateRunes ().Reverse ()),
-                   _ => line
-               };
+        {
+            TextDirection.RightLeft_BottomTop
+                or TextDirection.RightLeft_TopBottom
+                or TextDirection.BottomTop_LeftRight
+                or TextDirection.BottomTop_RightLeft => StringExtensions.ToString (line.EnumerateRunes ().Reverse ()),
+            _ => line
+        };
     }
 
     private static List<Rune> PerformCorrectFormatDirection (TextDirection textDirection, List<Rune> runes)
@@ -2078,13 +2104,13 @@ public class TextFormatter
     private static List<string> PerformCorrectFormatDirection (TextDirection textDirection, List<string> lines)
     {
         return textDirection switch
-               {
-                   TextDirection.TopBottom_RightLeft
-                       or TextDirection.LeftRight_BottomTop
-                       or TextDirection.RightLeft_BottomTop
-                       or TextDirection.BottomTop_RightLeft => lines.ToArray ().Reverse ().ToList (),
-                   _ => lines
-               };
+        {
+            TextDirection.TopBottom_RightLeft
+                or TextDirection.LeftRight_BottomTop
+                or TextDirection.RightLeft_BottomTop
+                or TextDirection.BottomTop_RightLeft => lines.ToArray ().Reverse ().ToList (),
+            _ => lines
+        };
     }
 
     /// <summary>

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -2444,7 +2444,7 @@ public class TextFormatter
             return text;
         }
 
-        const int maxStackallocCharBufferSize = 512; // ~1 kiB
+        const int maxStackallocCharBufferSize = 512; // ~1 kB
         char[]? rentedBufferArray = null;
         try
         {

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -11,7 +11,7 @@ namespace Terminal.Gui;
 public class TextFormatter
 {
     // Utilized in CRLF related helper methods for faster newline char index search.
-    private static readonly SearchValues<char> NewLineSearchValues = SearchValues.Create(['\r', '\n']);
+    private static readonly SearchValues<char> NewlineSearchValues = SearchValues.Create(['\r', '\n']);
 
     private Key _hotKey = new ();
     private int _hotKeyPos = -1;
@@ -1191,31 +1191,39 @@ public class TextFormatter
     // TODO: Move to StringExtensions?
     internal static string StripCRLF (string str, bool keepNewLine = false)
     {
-        StringBuilder stringBuilder = new();
-
         ReadOnlySpan<char> remaining = str.AsSpan ();
+        int firstNewlineCharIndex = remaining.IndexOfAny (NewlineSearchValues);
+        // Early exit to avoid StringBuilder allocation if there are no newline characters.
+        if (firstNewlineCharIndex < 0)
+        {
+            return str;
+        }
+
+        StringBuilder stringBuilder = new();
+        ReadOnlySpan<char> firstSegment = remaining[..firstNewlineCharIndex];
+        stringBuilder.Append (firstSegment);
+
+        // The first newline is not yet skipped because the "keepNewLine" condition has not been evaluated.
+        // This means there will be 1 extra iteration because the same newline index is checked again in the loop.
+        remaining = remaining [firstNewlineCharIndex..];
+
         while (remaining.Length > 0)
         {
-            int nextLineBreakIndex = remaining.IndexOfAny (NewLineSearchValues);
-            if (nextLineBreakIndex == -1)
+            int newlineCharIndex = remaining.IndexOfAny (NewlineSearchValues);
+            if (newlineCharIndex == -1)
             {
-                if (str.Length == remaining.Length)
-                {
-                    return str;
-                }
-                stringBuilder.Append (remaining);
                 break;
             }
 
-            ReadOnlySpan<char> slice = remaining.Slice (0, nextLineBreakIndex);
-            stringBuilder.Append (slice);
+            ReadOnlySpan<char> segment = remaining[..newlineCharIndex];
+            stringBuilder.Append (segment);
 
+            int stride = segment.Length;
             // Evaluate how many line break characters to preserve.
-            int stride;
-            char lineBreakChar = remaining [nextLineBreakIndex];
-            if (lineBreakChar == '\n')
+            char newlineChar = remaining [newlineCharIndex];
+            if (newlineChar == '\n')
             {
-                stride = 1;
+                stride++;
                 if (keepNewLine)
                 {
                     stringBuilder.Append ('\n');
@@ -1223,10 +1231,11 @@ public class TextFormatter
             }
             else // '\r'
             {
-                bool crlf = (nextLineBreakIndex + 1) < remaining.Length && remaining [nextLineBreakIndex + 1] == '\n';
+                int nextCharIndex = newlineCharIndex + 1;
+                bool crlf = nextCharIndex < remaining.Length && remaining [nextCharIndex] == '\n';
                 if (crlf)
                 {
-                    stride = 2;
+                    stride += 2;
                     if (keepNewLine)
                     {
                         stringBuilder.Append ('\n');
@@ -1234,15 +1243,16 @@ public class TextFormatter
                 }
                 else
                 {
-                    stride = 1;
+                    stride++;
                     if (keepNewLine)
                     {
                         stringBuilder.Append ('\r');
                     }
                 }
             }
-            remaining = remaining.Slice (slice.Length + stride);
+            remaining = remaining [stride..];
         }
+        stringBuilder.Append (remaining);
         return stringBuilder.ToString ();
     }
 

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -1185,7 +1185,7 @@ public class TextFormatter
     }
 
     // TODO: Move to StringExtensions?
-    private static string StripCRLF (string str, bool keepNewLine = false)
+    internal static string StripCRLF (string str, bool keepNewLine = false)
     {
         List<Rune> runes = str.ToRuneList ();
 
@@ -1229,7 +1229,7 @@ public class TextFormatter
     }
 
     // TODO: Move to StringExtensions?
-    private static string ReplaceCRLFWithSpace (string str)
+    internal static string ReplaceCRLFWithSpace (string str)
     {
         List<Rune> runes = str.ToRuneList ();
 

--- a/Tests/UnitTestsParallelizable/Text/TextFormatterTests.cs
+++ b/Tests/UnitTestsParallelizable/Text/TextFormatterTests.cs
@@ -2886,4 +2886,77 @@ public class TextFormatterTests
         Assert.Equal (resultLines, wrappedLines);
     }
 
+
+
+    [Theory]
+    [InlineData ("No crlf", "No crlf")]
+    // CRLF
+    [InlineData ("\r\nThis has crlf in the beginning", "This has crlf in the beginning")]
+    [InlineData ("This has crlf\r\nin the middle", "This has crlfin the middle")]
+    [InlineData ("This has crlf in the end\r\n", "This has crlf in the end")]
+    // LFCR
+    [InlineData ("\n\rThis has lfcr in the beginning", "\rThis has lfcr in the beginning")]
+    [InlineData ("This has lfcr\n\rin the middle", "This has lfcr\rin the middle")]
+    [InlineData ("This has lfcr in the end\n\r", "This has lfcr in the end\r")]
+    // CR
+    [InlineData ("\rThis has cr in the beginning", "This has cr in the beginning")]
+    [InlineData ("This has cr\rin the middle", "This has crin the middle")]
+    [InlineData ("This has cr in the end\r", "This has cr in the end")]
+    // LF
+    [InlineData ("\nThis has lf in the beginning", "This has lf in the beginning")]
+    [InlineData ("This has lf\nin the middle", "This has lfin the middle")]
+    [InlineData ("This has lf in the end\n", "This has lf in the end")]
+    public void StripCRLF_RemovesCrLf (string input, string expected)
+    {
+        string actual = TextFormatter.StripCRLF(input, keepNewLine: false);
+        Assert.Equal (expected, actual);
+    }
+
+    [Theory]
+    [InlineData ("No crlf", "No crlf")]
+    // CRLF
+    [InlineData ("\r\nThis has crlf in the beginning", "\nThis has crlf in the beginning")]
+    [InlineData ("This has crlf\r\nin the middle", "This has crlf\nin the middle")]
+    [InlineData ("This has crlf in the end\r\n", "This has crlf in the end\n")]
+    // LFCR
+    [InlineData ("\n\rThis has lfcr in the beginning", "\n\rThis has lfcr in the beginning")]
+    [InlineData ("This has lfcr\n\rin the middle", "This has lfcr\n\rin the middle")]
+    [InlineData ("This has lfcr in the end\n\r", "This has lfcr in the end\n\r")]
+    // CR
+    [InlineData ("\rThis has cr in the beginning", "\rThis has cr in the beginning")]
+    [InlineData ("This has cr\rin the middle", "This has cr\rin the middle")]
+    [InlineData ("This has cr in the end\r", "This has cr in the end\r")]
+    // LF
+    [InlineData ("\nThis has lf in the beginning", "\nThis has lf in the beginning")]
+    [InlineData ("This has lf\nin the middle", "This has lf\nin the middle")]
+    [InlineData ("This has lf in the end\n", "This has lf in the end\n")]
+    public void StripCRLF_KeepNewLine_RemovesCarriageReturnFromCrLf (string input, string expected)
+    {
+        string actual = TextFormatter.StripCRLF(input, keepNewLine: true);
+        Assert.Equal (expected, actual);
+    }
+
+    [Theory]
+    [InlineData ("No crlf", "No crlf")]
+    // CRLF
+    [InlineData ("\r\nThis has crlf in the beginning", " This has crlf in the beginning")]
+    [InlineData ("This has crlf\r\nin the middle", "This has crlf in the middle")]
+    [InlineData ("This has crlf in the end\r\n", "This has crlf in the end ")]
+    // LFCR
+    [InlineData ("\n\rThis has lfcr in the beginning", "  This has lfcr in the beginning")]
+    [InlineData ("This has lfcr\n\rin the middle", "This has lfcr  in the middle")]
+    [InlineData ("This has lfcr in the end\n\r", "This has lfcr in the end  ")]
+    // CR
+    [InlineData ("\rThis has cr in the beginning", " This has cr in the beginning")]
+    [InlineData ("This has cr\rin the middle", "This has cr in the middle")]
+    [InlineData ("This has cr in the end\r", "This has cr in the end ")]
+    // LF
+    [InlineData ("\nThis has lf in the beginning", " This has lf in the beginning")]
+    [InlineData ("This has lf\nin the middle", "This has lf in the middle")]
+    [InlineData ("This has lf in the end\n", "This has lf in the end ")]
+    public void ReplaceCRLFWithSpace_ReplacesCrLfWithSpace (string input, string expected)
+    {
+        string actual = TextFormatter.ReplaceCRLFWithSpace(input);
+        Assert.Equal (expected, actual);
+    }
 }

--- a/Tests/UnitTestsParallelizable/Text/TextFormatterTests.cs
+++ b/Tests/UnitTestsParallelizable/Text/TextFormatterTests.cs
@@ -2895,9 +2895,9 @@ public class TextFormatterTests
     [InlineData ("This has crlf\r\nin the middle", "This has crlfin the middle")]
     [InlineData ("This has crlf in the end\r\n", "This has crlf in the end")]
     // LFCR
-    [InlineData ("\n\rThis has lfcr in the beginning", "\rThis has lfcr in the beginning")]
-    [InlineData ("This has lfcr\n\rin the middle", "This has lfcr\rin the middle")]
-    [InlineData ("This has lfcr in the end\n\r", "This has lfcr in the end\r")]
+    [InlineData ("\n\rThis has lfcr in the beginning", "This has lfcr in the beginning")]
+    [InlineData ("This has lfcr\n\rin the middle", "This has lfcrin the middle")]
+    [InlineData ("This has lfcr in the end\n\r", "This has lfcr in the end")]
     // CR
     [InlineData ("\rThis has cr in the beginning", "This has cr in the beginning")]
     [InlineData ("This has cr\rin the middle", "This has crin the middle")]


### PR DESCRIPTION
Reduces intermediate allocations in the simplest top of the chart TextFormatter helper methods, and StringExtensions.ToString(IEnumerable\<Rune\>), which is used everywhere.

## Fixes

- Improves #2725 

## Proposed Changes

- [x] Rewrite various TextFormatter helper methods to reduce allocations.
    - [x] RemoveHotKeySpecifier
        - The usual char stackalloc char buffer with rented array as alternative.
    - [x] ReplaceCRLFWithSpace
        -  StringBuilder append with early original string return if no newlines found.
    - [x] StripCRLF
        -  Almost identical to ReplaceCRLFWithSpace.
- [x] Rewrite StringExtensions.ToString(IEnumerable\<Rune\>) to reduce allocations.
    - Again the usual stackalloc char buffer with rented array as alternative. StringBuilder is used as fallback if element count is not available without enumeration.
- [x] Change ReplaceCRLFWithSpace and StripCRLF accessibility level from private to internal.
- [x] Add test cases for ReplaceCRLFWithSpace and StripCRLF.

## Pull Request Checklist

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

## Microbenchmarks

### StringExtensions.ToString(IEnumerable\<Rune\>)

Note that this only benchmarks the non-StringBuilder-fallback side. Most of the call sites use Rune[] or List\<Rune\> anyways so the fallback is not that relevant. Might add benchmarks for the fallback later.

The input lengths are a bit overkill but you get the idea.

```

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5608/22H2/2022Update)
AMD Ryzen 7 5800X3D, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.407
  [Host]     : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2

```
| Method   | runes      | len  | Mean            | Error         | StdDev        | Ratio | RatioSD | Gen0      | Gen1    | Allocated  | Alloc Ratio |
|--------- |----------- |----- |----------------:|--------------:|--------------:|------:|--------:|----------:|--------:|-----------:|------------:|
| **Previous** | **Rune[1]**    | **1**    |        **10.24 ns** |      **0.247 ns** |      **0.469 ns** |  **0.39** |    **0.02** |    **0.0011** |       **-** |       **56 B** |        **1.00** |
| Current  | Rune[1]    | 1    |        25.97 ns |      0.138 ns |      0.116 ns |  1.00 |    0.01 |    0.0011 |       - |       56 B |        1.00 |
|          |            |      |                 |               |               |       |         |           |         |            |             |
| **Previous** | **Rune[10]**   | **10**   |       **118.36 ns** |      **0.350 ns** |      **0.273 ns** |  **2.01** |    **0.02** |    **0.0119** |       **-** |      **608 B** |        **7.60** |
| Current  | Rune[10]   | 10   |        58.89 ns |      0.577 ns |      0.511 ns |  1.00 |    0.01 |    0.0015 |       - |       80 B |        1.00 |
|          |            |      |                 |               |               |       |         |           |         |            |             |
| **Previous** | **Rune[100]**  | **100**  |     **1,415.36 ns** |     **19.094 ns** |     **17.861 ns** |  **3.62** |    **0.08** |    **0.2975** |       **-** |    **15008 B** |       **58.62** |
| Current  | Rune[100]  | 100  |       391.48 ns |      7.686 ns |      7.190 ns |  1.00 |    0.03 |    0.0048 |       - |      256 B |        1.00 |
|          |            |      |                 |               |               |       |         |           |         |            |             |
| **Previous** | **Rune[401]**  | **401**  |     **9,011.12 ns** |     **51.757 ns** |     **45.881 ns** |  **6.20** |    **0.03** |    **3.6011** |       **-** |   **180856 B** |      **211.28** |
| Current  | Rune[401]  | 401  |     1,453.04 ns |      2.656 ns |      2.073 ns |  1.00 |    0.00 |    0.0153 |       - |      856 B |        1.00 |
|          |            |      |                 |               |               |       |         |           |         |            |             |
| **Previous** | **Rune[802]**  | **802**  |    **27,098.45 ns** |    **175.132 ns** |    **163.819 ns** |  **9.43** |    **0.09** |   **13.6108** |  **0.0305** |   **683312 B** |      **410.64** |
| Current  | Rune[802]  | 802  |     2,873.37 ns |     23.531 ns |     20.860 ns |  1.00 |    0.01 |    0.0305 |       - |     1664 B |        1.00 |
|          |            |      |                 |               |               |       |         |           |         |            |             |
| **Previous** | **Rune[8020]** | **8020** | **2,042,258.31 ns** | **19,643.001 ns** | **17,413.008 ns** | **72.38** |    **0.61** | **1289.0625** | **50.7813** | **64721410 B** |    **4,020.96** |
| Current  | Rune[8020] | 8020 |    28,215.83 ns |     52.173 ns |     43.567 ns |  1.00 |    0.00 |    0.3052 |       - |    16096 B |        1.00 |

### TextFormatter.RemoveHotKeySpecifier

```

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5608/22H2/2022Update)
AMD Ryzen 7 5800X3D, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.407
  [Host]     : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2

```
| Method   | text                | hotPos | Mean           | Error       | StdDev      | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------- |-------------------- |------- |---------------:|------------:|------------:|------:|--------:|-------:|----------:|------------:|
| **Previous** | ****                    | **-1**     |      **0.9392 ns** |   **0.0499 ns** |   **0.0466 ns** |  **0.54** |    **0.03** |      **-** |         **-** |          **NA** |
| Current  |                     | -1     |      1.7463 ns |   0.0687 ns |   0.0643 ns |  1.00 |    0.05 |      - |         - |          NA |
|          |                     |        |                |             |             |       |         |        |           |             |
| **Previous** | **_Save file (Ctrl+S)** | **0**      |    **218.4687 ns** |   **2.5621 ns** |   **2.2713 ns** |  **3.19** |    **0.05** | **0.0238** |    **1200 B** |       **18.75** |
| Current  | _Save file (Ctrl+S) | 0      |     68.3901 ns |   0.8073 ns |   0.7551 ns |  1.00 |    0.02 | 0.0012 |      64 B |        1.00 |
|          |                     |        |                |             |             |       |         |        |           |             |
| **Previous** | **Lore(...)lla. [155]** | **82**     |  **2,525.6022 ns** |  **12.5621 ns** |  **10.4899 ns** |  **5.53** |    **0.02** | **0.6218** |   **31392 B** |       **93.43** |
| Current  | Lore(...)lla. [155] | 82     |    456.4663 ns |   0.7380 ns |   0.5762 ns |  1.00 |    0.00 | 0.0067 |     336 B |        1.00 |
|          |                     |        |                |             |             |       |         |        |           |             |
| **Previous** | **Ĺόŕé(...) íń. [471]** | **64**     | **11,531.7165 ns** | **198.1963 ns** | **175.6959 ns** |  **7.91** |    **0.12** | **4.8676** |  **244376 B** |      **252.45** |
| Current  | Ĺόŕé(...) íń. [471] | 64     |  1,458.4510 ns |   3.5958 ns |   3.1876 ns |  1.00 |    0.00 | 0.0191 |     968 B |        1.00 |
|          |                     |        |                |             |             |       |         |        |           |             |
| **Previous** | **Ĺόŕé(...) íń. [471]** | **409**    | **11,517.6575 ns** | **210.3947 ns** | **196.8033 ns** |  **7.86** |    **0.15** | **4.8676** |  **244376 B** |      **252.45** |
| Current  | Ĺόŕé(...) íń. [471] | 409    |  1,466.2623 ns |  17.0662 ns |  15.1287 ns |  1.00 |    0.01 | 0.0191 |     968 B |        1.00 |
|          |                     |        |                |             |             |       |         |        |           |             |
| **Previous** | **Save file (Ctrl+S)**  | **3**      |    **220.2640 ns** |   **3.0005 ns** |   **2.8067 ns** |  **4.00** |    **0.05** | **0.0238** |    **1200 B** |          **NA** |
| Current  | Save file (Ctrl+S)  | 3      |     55.0176 ns |   0.1739 ns |   0.1358 ns |  1.00 |    0.00 |      - |         - |          NA |

### TextFormatter.ReplaceCRLFWithSpace

```

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5608/22H2/2022Update)
AMD Ryzen 7 5800X3D, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.407
  [Host]     : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2

```
| Method   | str                         | Mean        | Error     | StdDev    | Ratio  | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------- |---------------------------- |------------:|----------:|----------:|-------:|--------:|-------:|----------:|------------:|
| **Previous** | **E\r\nx\r(...)\r\no\r\n [66]** |   **745.67 ns** |  **4.089 ns** |  **3.625 ns** |   **3.62** |    **0.02** | **0.0277** |    **1400 B** |        **3.07** |
| Current  | E\r\nx\r(...)\r\no\r\n [66] |   206.13 ns |  0.823 ns |  0.730 ns |   1.00 |    0.00 | 0.0091 |     456 B |        1.00 |
|          |                             |             |           |           |        |         |        |           |             |
| **Previous** | **Lore(...) eu. [698]**         | **5,651.54 ns** | **30.978 ns** | **24.185 ns** | **462.17** |    **3.45** | **0.1984** |    **9952 B** |          **NA** |
| Current  | Lore(...) eu. [698]         |    12.23 ns |  0.095 ns |  0.079 ns |   1.00 |    0.01 |      - |         - |          NA |
|          |                             |             |           |           |        |         |        |           |             |
| **Previous** | **Ĺόŕé(...)ĺíś. [806]**         | **6,662.39 ns** | **42.272 ns** | **35.299 ns** |  **28.36** |    **0.20** | **0.1984** |   **10160 B** |        **2.22** |
| Current  | Ĺόŕé(...)ĺíś. [806]         |   234.91 ns |  1.447 ns |  1.208 ns |   1.00 |    0.01 | 0.0913 |    4584 B |        1.00 |

### TextFormatter.StripCRLF

```

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5608/22H2/2022Update)
AMD Ryzen 7 5800X3D, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.407
  [Host]     : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2

```
| Method   | str                         | keepNewLine | Mean        | Error     | StdDev    | Ratio  | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|--------- |---------------------------- |------------ |------------:|----------:|----------:|-------:|--------:|-------:|-------:|----------:|------------:|
| **Previous** | **E\r\nx\r(...)\r\no\r\n [66]** | **False**       |   **844.14 ns** |  **4.025 ns** |  **3.361 ns** |   **4.70** |    **0.05** | **0.0267** |      **-** |    **1376 B** |        **4.91** |
| Current  | E\r\nx\r(...)\r\no\r\n [66] | False       |   179.70 ns |  2.091 ns |  1.956 ns |   1.00 |    0.01 | 0.0055 |      - |     280 B |        1.00 |
|          |                             |             |             |           |           |        |         |        |        |           |             |
| **Previous** | **E\r\nx\r(...)\r\no\r\n [66]** | **True**        |   **742.83 ns** |  **1.616 ns** |  **1.262 ns** |   **3.57** |    **0.02** | **0.0277** |      **-** |    **1400 B** |        **3.07** |
| Current  | E\r\nx\r(...)\r\no\r\n [66] | True        |   207.93 ns |  1.654 ns |  1.381 ns |   1.00 |    0.01 | 0.0091 |      - |     456 B |        1.00 |
|          |                             |             |             |           |           |        |         |        |        |           |             |
| **Previous** | **Lore(...) eu. [698]**         | **False**       | **5,746.73 ns** | **64.305 ns** | **57.005 ns** | **425.75** |    **4.13** | **0.1984** |      **-** |    **9952 B** |          **NA** |
| Current  | Lore(...) eu. [698]         | False       |    13.50 ns |  0.028 ns |  0.022 ns |   1.00 |    0.00 |      - |      - |         - |          NA |
|          |                             |             |             |           |           |        |         |        |        |           |             |
| **Previous** | **Lore(...) eu. [698]**         | **True**        | **5,511.28 ns** | **14.646 ns** | **12.230 ns** | **403.05** |    **7.69** | **0.1984** |      **-** |    **9952 B** |          **NA** |
| Current  | Lore(...) eu. [698]         | True        |    13.68 ns |  0.291 ns |  0.272 ns |   1.00 |    0.03 |      - |      - |         - |          NA |
|          |                             |             |             |           |           |        |         |        |        |           |             |
| **Previous** | **Ĺόŕé(...)ĺíś. [806]**         | **False**       | **6,463.90 ns** | **38.463 ns** | **30.030 ns** |  **28.00** |    **0.31** | **0.1984** |      **-** |   **10152 B** |        **2.18** |
| Current  | Ĺόŕé(...)ĺíś. [806]         | False       |   230.89 ns |  2.605 ns |  2.436 ns |   1.00 |    0.01 | 0.0925 | 0.0005 |    4648 B |        1.00 |
|          |                             |             |             |           |           |        |         |        |        |           |             |
| **Previous** | **Ĺόŕé(...)ĺíś. [806]**         | **True**        | **6,667.01 ns** | **34.121 ns** | **26.640 ns** |  **28.22** |    **0.12** | **0.1984** |      **-** |   **10160 B** |        **2.22** |
| Current  | Ĺόŕé(...)ĺíś. [806]         | True        |   236.23 ns |  0.579 ns |  0.452 ns |   1.00 |    0.00 | 0.0913 |      - |    4584 B |        1.00 |

## Allocations

Overall nice reduction in string allocations. Naturally StringBuilder (and its internal char[]) allocations increased a bit because they are now used in ReplaceCRLFWithSpace and StripCRLF.

| Before | After |
| ------- | ------ |
| ![01 string-allocations before](https://github.com/user-attachments/assets/9de98266-eaa1-45d0-89e1-e7ccbef8707c) | ![02 string-allocations after](https://github.com/user-attachments/assets/046a3759-3349-4fe8-9739-f6c0193a37c3) |
| ![01-01 drilldown-string-concat before](https://github.com/user-attachments/assets/6547e544-b9b5-4c4a-9b88-b320e1fafcad) | ![02-01 drilldown-string-concat after](https://github.com/user-attachments/assets/e5254cd4-47d9-433a-8e2d-357e046519a1) |
| ![01-02 drilldown-string-extensions before](https://github.com/user-attachments/assets/096bbf2a-a254-4aba-ab28-c4d05611d4f5) | ![02-02 drilldown-string-extensions after](https://github.com/user-attachments/assets/3a959a8d-645e-4efd-a6a9-5e7a302a5040) |
| ![01-03 string-builder-allocations before](https://github.com/user-attachments/assets/6bfadc4a-b372-4bfa-8085-83b69e5d7768) | ![02-03 string-builder-allocations after](https://github.com/user-attachments/assets/726ff198-e548-4a3a-b197-9eef722f022f) |
| ![01-04 drilldown-string-builder before](https://github.com/user-attachments/assets/5de24686-f86a-43c0-af10-344baabc6fd3) | ![02-04 drilldown-string-builder after](https://github.com/user-attachments/assets/bef527ec-9b59-48ab-a0e1-42a50d7f3aca) |
| ![01-05 drilldown-char-array before](https://github.com/user-attachments/assets/cae0d031-733c-417c-97da-3a790b7b6d27) | ![02-05 drilldown-char-array after](https://github.com/user-attachments/assets/41a0636a-8c5b-4f19-8e81-ebe78b8f26d4) |




