### PR TITLE
Fixes #3986. ContextMenu crashing with right and left arrows

### DIFF
--- a/Terminal.Gui/Views/Menu/MenuBar.cs
+++ b/Terminal.Gui/Views/Menu/MenuBar.cs
@@ -743,6 +743,11 @@ public class MenuBar : View, IDesignable
                     return;
                 }
 
+                if (_selected == -1)
+                {
+                    return;
+                }
+
                 OpenMenu (_selected);
 
                 SelectEnabledItem (
@@ -980,6 +985,11 @@ public class MenuBar : View, IDesignable
                 }
 
                 if (_selected > -1 && !CloseMenu (true, false, ignoreUseSubMenusSingleFrame))
+                {
+                    return;
+                }
+
+                if (_selected == -1)
                 {
                     return;
                 }

--- a/Tests/UnitTests/Views/ContextMenuTests.cs
+++ b/Tests/UnitTests/Views/ContextMenuTests.cs
@@ -2105,4 +2105,34 @@ public class ContextMenuTests (ITestOutputHelper output)
 
         top.Dispose ();
     }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void Menu_Without_SubMenu_Is_Closed_When_Pressing_Key_Right_Or_Key_Left ()
+    {
+        var cm = new ContextMenu ();
+
+        var menuItems = new MenuBarItem (
+                                         [
+                                             new ("_New", string.Empty, null),
+                                             new ("_Save", string.Empty, null)
+                                         ]
+                                        );
+        var top = new Toplevel ();
+        Application.Begin (top);
+
+        cm.Show (menuItems);
+        Assert.True (cm.MenuBar!.IsMenuOpen);
+
+        Assert.True (Application.RaiseKeyDownEvent (Key.CursorRight));
+        Assert.False (cm.MenuBar!.IsMenuOpen);
+
+        cm.Show (menuItems);
+        Assert.True (cm.MenuBar!.IsMenuOpen);
+
+        Assert.True (Application.RaiseKeyDownEvent (Key.CursorLeft));
+        Assert.False (cm.MenuBar!.IsMenuOpen);
+
+        top.Dispose ();
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #3986

## Proposed Changes/Todos

- [x] Close menu if selected menu is -1 which mean no menu selected.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
