### PR TITLE
Fixes #3974. TabView steals keypresses from active ContextMenu

### DIFF
--- a/Terminal.Gui/Views/TabView/TabView.cs
+++ b/Terminal.Gui/Views/TabView/TabView.cs
@@ -105,15 +105,14 @@ public class TabView : View
 
                                 if (mostFocused is { })
                                 {
-                                    for (int? i = mostFocused.SuperView?.InternalSubViews.IndexOf (mostFocused) - 1; i > -1; i--)
+                                    for (int? i = mostFocused.SuperView?.SubViews.IndexOf (mostFocused) - 1; i > -1; i--)
                                     {
-                                        var view = mostFocused.SuperView?.InternalSubViews [(int)i];
+                                        var view = mostFocused.SuperView?.SubViews.ElementAt ((int)i);
 
                                         if (view is { CanFocus: true, Enabled: true, Visible: true })
                                         {
-                                            view.SetFocus ();
-
-                                            return true;
+                                            // Let toplevel handle it
+                                            return false;
                                         }
                                     }
                                 }
@@ -140,15 +139,14 @@ public class TabView : View
 
                                 if (mostFocused is { })
                                 {
-                                    for (int? i = mostFocused.SuperView?.InternalSubViews.IndexOf (mostFocused) + 1; i < mostFocused.SuperView?.InternalSubViews.Count; i++)
+                                    for (int? i = mostFocused.SuperView?.SubViews.IndexOf (mostFocused) + 1; i < mostFocused.SuperView?.SubViews.Count; i++)
                                     {
-                                        var view = mostFocused.SuperView?.InternalSubViews [(int)i];
+                                        var view = mostFocused.SuperView?.SubViews.ElementAt ((int)i);
 
                                         if (view is { CanFocus: true, Enabled: true, Visible: true })
                                         {
-                                            view.SetFocus ();
-
-                                            return true;
+                                            // Let toplevel handle it
+                                            return false;
                                         }
                                     }
                                 }

--- a/Terminal.Gui/Views/TabView/TabView.cs
+++ b/Terminal.Gui/Views/TabView/TabView.cs
@@ -84,6 +84,94 @@ public class TabView : View
                     }
                    );
 
+        AddCommand (
+                    Command.Up,
+                    () =>
+                    {
+                        if (_style.TabsOnBottom)
+                        {
+                            if (_tabsBar is { HasFocus: true } && _containerView.CanFocus)
+                            {
+                                _containerView.SetFocus ();
+
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            if (_containerView is { HasFocus: true })
+                            {
+                                var mostFocused = _containerView.MostFocused;
+
+                                if (mostFocused is { })
+                                {
+                                    for (int? i = mostFocused.SuperView?.InternalSubViews.IndexOf (mostFocused) - 1; i > -1; i--)
+                                    {
+                                        var view = mostFocused.SuperView?.InternalSubViews [(int)i];
+
+                                        if (view is { CanFocus: true, Enabled: true, Visible: true })
+                                        {
+                                            view.SetFocus ();
+
+                                            return true;
+                                        }
+                                    }
+                                }
+
+                                SelectedTab?.SetFocus ();
+
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+                   );
+
+        AddCommand (
+                    Command.Down,
+                    () =>
+                    {
+                        if (_style.TabsOnBottom)
+                        {
+                            if (_containerView is { HasFocus: true })
+                            {
+                                var mostFocused = _containerView.MostFocused;
+
+                                if (mostFocused is { })
+                                {
+                                    for (int? i = mostFocused.SuperView?.InternalSubViews.IndexOf (mostFocused) + 1; i < mostFocused.SuperView?.InternalSubViews.Count; i++)
+                                    {
+                                        var view = mostFocused.SuperView?.InternalSubViews [(int)i];
+
+                                        if (view is { CanFocus: true, Enabled: true, Visible: true })
+                                        {
+                                            view.SetFocus ();
+
+                                            return true;
+                                        }
+                                    }
+                                }
+
+                                SelectedTab?.SetFocus ();
+
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            if (_tabsBar is { HasFocus: true } && _containerView.CanFocus)
+                            {
+                                _containerView.SetFocus ();
+
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+                   );
+
         // Default keybindings for this view
         KeyBindings.Add (Key.CursorLeft, Command.Left);
         KeyBindings.Add (Key.CursorRight, Command.Right);
@@ -91,6 +179,8 @@ public class TabView : View
         KeyBindings.Add (Key.End, Command.RightEnd);
         KeyBindings.Add (Key.PageDown, Command.PageDown);
         KeyBindings.Add (Key.PageUp, Command.PageUp);
+        KeyBindings.Add (Key.CursorUp, Command.Up);
+        KeyBindings.Add (Key.CursorDown, Command.Down);
     }
 
     /// <summary>
@@ -155,7 +245,7 @@ public class TabView : View
 
     private bool TabCanSetFocus ()
     {
-        return IsInitialized && SelectedTab is { } && (_selectedTabHasFocus || !_containerView.CanFocus);
+        return IsInitialized && SelectedTab is { } && (HasFocus || (bool)_containerView?.HasFocus) && (_selectedTabHasFocus || !_containerView.CanFocus);
     }
 
     private void ContainerViewCanFocus (object sender, EventArgs eventArgs)
@@ -518,7 +608,7 @@ public class TabView : View
         {
             SelectedTab?.SetFocus ();
         }
-        else
+        else if (HasFocus)
         {
             SelectedTab?.View?.SetFocus ();
         }

--- a/Tests/UnitTests/Views/TabViewTests.cs
+++ b/Tests/UnitTests/Views/TabViewTests.cs
@@ -434,9 +434,8 @@ public class TabViewTests (ITestOutputHelper output)
         Assert.Equal (btnSubView, top.MostFocused);
 
         Assert.True (Application.RaiseKeyDownEvent (Key.CursorUp));
-        // TabRow now has TabGroup which only F6 is allowed
-        Assert.NotEqual (tab2, top.MostFocused);
-        Assert.Equal (btn, top.MostFocused);
+        Assert.Equal (tab2, top.MostFocused);
+        Assert.NotEqual (btn, top.MostFocused);
 
         Assert.True (Application.RaiseKeyDownEvent (Key.CursorUp));
         Assert.Equal (btnSubView, top.MostFocused);
@@ -459,7 +458,8 @@ public class TabViewTests (ITestOutputHelper output)
         // Press the cursor up key to focus the selected tab which it's the only way to do that
         Assert.True (Application.RaiseKeyDownEvent (Key.CursorUp));
         Assert.Equal (tab2, tv.SelectedTab);
-        Assert.Equal (btn, top.Focused);
+        Assert.False (tab2.View.HasFocus);
+        Assert.Equal (tv, top.Focused);
 
         Assert.True (Application.RaiseKeyDownEvent (Key.CursorUp));
         Assert.Equal (tv, top.Focused);


### PR DESCRIPTION
## Fixes

- Fixes #3974

## Proposed Changes/Todos

- [x] Add TabView KeyBindings for CursorUp and Cursor Down

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
