### PR TITLE
Fixes #4066 - Selecting OpenMode "Directory" in FileDialog scenario causes exception

### DIFF
--- a/Examples/UICatalog/Scenarios/FileDialogExamples.cs
+++ b/Examples/UICatalog/Scenarios/FileDialogExamples.cs
@@ -164,7 +164,15 @@ public class FileDialogExamples : Scenario
         var fd = new FileDialog
         {
             OpenMode = Enum.Parse<OpenMode> (
-                                             _rgOpenMode.RadioLabels.Select (l => TextFormatter.RemoveHotKeySpecifier(l, 0, _rgOpenMode.HotKeySpecifier)).ToArray() [_rgOpenMode.SelectedItem]
+                                             _rgOpenMode.RadioLabels
+                                                        .Select (l => TextFormatter.FindHotKey (l, _rgOpenMode.HotKeySpecifier, out int hotPos, out Key _)
+
+                                                                          // Remove the hotkey specifier at the found position
+                                                                          ? TextFormatter.RemoveHotKeySpecifier (l, hotPos, _rgOpenMode.HotKeySpecifier)
+
+                                                                          // No hotkey found, return the label as is
+                                                                          : l)
+                                                        .ToArray () [_rgOpenMode.SelectedItem]
                                             ),
             MustExist = _cbMustExist.CheckedState == CheckState.Checked,
             AllowsMultipleSelection = _cbAllowMultipleSelection.CheckedState == CheckState.Checked


### PR DESCRIPTION
Allow hotkey specifier to be at any position in label

"D_irectory" doesn't work because hotPos is hardcoded 0

## Fixes

- Fixes #4066 - Selecting OpenMode "Directory" in FileDialog scenario causes exception


## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
