### PR TITLE
Addresses #4058. Basic support for non-color text styles.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -1849,6 +1849,117 @@ public static class EscSeqUtils
 
     #endregion
 
+    #region Text Styles
+
+    /// <summary>
+    /// Appends an ANSI SGR (Select Graphic Rendition) escape sequence to switch printed text from one <see cref="TextStyle"/> to another.
+    /// </summary>
+    /// <param name="output"><see cref="StringBuilder"/> to add escape sequence to.</param>
+    /// <param name="prev">Previous <see cref="TextStyle"/> to change away from.</param>
+    /// <param name="next">Next <see cref="TextStyle"/> to change to.</param>
+    /// <remarks>
+    /// <para>
+    /// Unlike colors, most text styling options are not mutually exclusive with each other, and can be applied independently. This creates a problem when
+    /// switching from one style to another: For instance, if your previous style is just bold, and your next style is just italic, then simply adding the
+    /// sequence to enable italic text would cause the text to remain bold. This method automatically handles this problem, enabling and disabling styles as
+    /// necessary to apply exactly the next style.
+    /// </para>
+    /// </remarks>
+    internal static void CSI_AppendTextStyleChange (StringBuilder output, TextStyle prev, TextStyle next)
+    {
+        // Do nothing if styles are the same, as no changes are necessary.
+        if (prev == next)
+        {
+            return;
+        }
+
+        // Bitwise operations to determine flag changes. A ^ B are the flags different between two flag sets. These different flags that exist in the next flag
+        // set (diff & next) are the ones that were enabled in the switch, those that exist in the previous flag set (diff & prev) are the ones that were
+        // disabled.
+        var diff = prev ^ next;
+        var enabled = diff & next;
+        var disabled = diff & prev;
+
+        // List of escape codes to apply.
+        var sgr = new List<int> ();
+
+        if (disabled != TextStyle.None)
+        {
+            // Special case: Unlike other styles, bold and faint text are mutually exclusive. They also both have the same disable code: ^[[22m
+            // This also means disabling codes must be put before enabling codes, so that you can disable bold/faint text and enable the other at the same time.
+            if (disabled.HasFlag (TextStyle.Bold | TextStyle.Faint))
+            {
+                sgr.Add (22);
+            }
+
+            if (disabled.HasFlag (TextStyle.Italic))
+            {
+                sgr.Add (23);
+            }
+
+            if (disabled.HasFlag (TextStyle.Underline))
+            {
+                sgr.Add (24);
+            }
+
+            if (disabled.HasFlag (TextStyle.Blink))
+            {
+                sgr.Add (25);
+            }
+
+            if (disabled.HasFlag (TextStyle.Reverse))
+            {
+                sgr.Add (27);
+            }
+
+            if (disabled.HasFlag (TextStyle.Strikethrough))
+            {
+                sgr.Add (29);
+            }
+        }
+
+        if (enabled != TextStyle.None)
+        {
+            // Special case: As before, bold and faint are mutually exclusive. Activating both will leave it up to the terminal to decide which to actually
+            // apply. So that behavior is always consistent, we'll enforce precedence of bold over faint, since bold is more commonly used.
+            if (enabled.HasFlag (TextStyle.Bold | TextStyle.Faint))
+            {
+                sgr.Add (enabled.HasFlag (TextStyle.Bold) ? 1 : 2);
+            }
+
+            if (enabled.HasFlag (TextStyle.Italic))
+            {
+                sgr.Add (3);
+            }
+
+            if (enabled.HasFlag (TextStyle.Underline))
+            {
+                sgr.Add (4);
+            }
+
+            if (enabled.HasFlag (TextStyle.Blink))
+            {
+                sgr.Add (5);
+            }
+
+            if (enabled.HasFlag (TextStyle.Reverse))
+            {
+                sgr.Add (7);
+            }
+
+            if (enabled.HasFlag (TextStyle.Strikethrough))
+            {
+                sgr.Add (9);
+            }
+        }
+
+        output.Append ("\x1b[");
+        output.Append (string.Join (';', sgr));
+        output.Append ('m');
+    }
+
+    #endregion Text Styles
+
     #region Requests
 
     /// <summary>

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -1972,11 +1972,6 @@ public static class EscSeqUtils
             }
         }
 
-        if (sgr.Count == 0)
-        {
-            return;
-        }
-
         output.Append ("\x1b[");
         output.Append (string.Join (';', sgr));
         output.Append ('m');

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -1953,6 +1953,11 @@ public static class EscSeqUtils
             }
         }
 
+        if (sgr.Count == 0)
+        {
+            return;
+        }
+
         output.Append ("\x1b[");
         output.Append (string.Join (';', sgr));
         output.Append ('m');

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -1885,11 +1885,27 @@ public static class EscSeqUtils
 
         if (disabled != TextStyle.None)
         {
-            // Special case: Unlike other styles, bold and faint text are mutually exclusive. They also both have the same disable code: ^[[22m
-            // This also means disabling codes must be put before enabling codes, so that you can disable bold/faint text and enable the other at the same time.
-            if (disabled.HasFlag (TextStyle.Bold) || disabled.HasFlag (TextStyle.Faint))
+            // Special case: Both bold and faint have the same disabling code. While unusual, it can be valid to have both enabled at the same time, so when
+            // one and only one of them is being disabled, we need to re-enable the other afterward. We can check what flags remain enabled by taking
+            // prev & next, as this is the set of flags both have.
+            if (disabled.HasFlag (TextStyle.Bold))
             {
                 sgr.Add (22);
+
+                if ((prev & next).HasFlag (TextStyle.Faint))
+                {
+                    sgr.Add (2);
+                }
+            }
+
+            if (disabled.HasFlag (TextStyle.Faint))
+            {
+                sgr.Add (22);
+
+                if ((prev & next).HasFlag (TextStyle.Bold))
+                {
+                    sgr.Add (1);
+                }
             }
 
             if (disabled.HasFlag (TextStyle.Italic))
@@ -1920,11 +1936,14 @@ public static class EscSeqUtils
 
         if (enabled != TextStyle.None)
         {
-            // Special case: As before, bold and faint are mutually exclusive. Activating both will leave it up to the terminal to decide which to actually
-            // apply. So that behavior is always consistent, we'll enforce precedence of bold over faint, since bold is more commonly used.
-            if (enabled.HasFlag (TextStyle.Bold) || enabled.HasFlag(TextStyle.Faint))
+            if (enabled.HasFlag (TextStyle.Bold))
             {
-                sgr.Add (enabled.HasFlag (TextStyle.Bold) ? 1 : 2);
+                sgr.Add (1);
+            }
+
+            if (enabled.HasFlag (TextStyle.Faint))
+            {
+                sgr.Add (2);
             }
 
             if (enabled.HasFlag (TextStyle.Italic))

--- a/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/ConsoleDrivers/EscSeqUtils/EscSeqUtils.cs
@@ -1887,7 +1887,7 @@ public static class EscSeqUtils
         {
             // Special case: Unlike other styles, bold and faint text are mutually exclusive. They also both have the same disable code: ^[[22m
             // This also means disabling codes must be put before enabling codes, so that you can disable bold/faint text and enable the other at the same time.
-            if (disabled.HasFlag (TextStyle.Bold | TextStyle.Faint))
+            if (disabled.HasFlag (TextStyle.Bold) || disabled.HasFlag (TextStyle.Faint))
             {
                 sgr.Add (22);
             }
@@ -1922,7 +1922,7 @@ public static class EscSeqUtils
         {
             // Special case: As before, bold and faint are mutually exclusive. Activating both will leave it up to the terminal to decide which to actually
             // apply. So that behavior is always consistent, we'll enforce precedence of bold over faint, since bold is more commonly used.
-            if (enabled.HasFlag (TextStyle.Bold | TextStyle.Faint))
+            if (enabled.HasFlag (TextStyle.Bold) || enabled.HasFlag(TextStyle.Faint))
             {
                 sgr.Add (enabled.HasFlag (TextStyle.Bold) ? 1 : 2);
             }

--- a/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
@@ -12,6 +12,9 @@ public class NetOutput : IConsoleOutput
 
     private CursorVisibility? _cachedCursorVisibility;
 
+    // Last text style used, for updating style with EscSeqUtils.CSI_AppendTextStyleChange().
+    private TextStyle _redrawTextStyle = TextStyle.None;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="NetOutput"/> class.
     /// </summary>
@@ -117,7 +120,7 @@ public class NetOutput : IConsoleOutput
                     Attribute attr = buffer.Contents [row, col].Attribute.Value;
 
                     // Performance: Only send the escape sequence if the attribute has changed.
-                    if (attr != redrawAttr)
+                    if (attr != redrawAttr || attr.TextStyle != _redrawTextStyle)
                     {
                         redrawAttr = attr;
 
@@ -134,6 +137,10 @@ public class NetOutput : IConsoleOutput
                             attr.Background.G,
                             attr.Background.B
                         );
+
+                        EscSeqUtils.CSI_AppendTextStyleChange (output, _redrawTextStyle, attr.TextStyle);
+
+                        _redrawTextStyle = attr.TextStyle;
                     }
 
                     outputWidth++;

--- a/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/NetOutput.cs
@@ -120,7 +120,7 @@ public class NetOutput : IConsoleOutput
                     Attribute attr = buffer.Contents [row, col].Attribute.Value;
 
                     // Performance: Only send the escape sequence if the attribute has changed.
-                    if (attr != redrawAttr || attr.TextStyle != _redrawTextStyle)
+                    if (attr != redrawAttr)
                     {
                         redrawAttr = attr;
 

--- a/Terminal.Gui/ConsoleDrivers/V2/OutputBuffer.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/OutputBuffer.cs
@@ -33,7 +33,8 @@ public class OutputBuffer : IOutputBuffer
             // TODO: This makes IConsoleDriver dependent on Application, which is not ideal. Once Attribute.PlatformColor is removed, this can be fixed.
             if (Application.Driver is { })
             {
-                _currentAttribute = new (value.Foreground, value.Background);
+                // TODO: Update this when attributes can include TextStyle in the constructor
+                _currentAttribute = new (value.Foreground, value.Background) { TextStyle = value.TextStyle };
 
                 return;
             }

--- a/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
+++ b/Terminal.Gui/ConsoleDrivers/V2/WindowsOutput.cs
@@ -58,6 +58,9 @@ internal partial class WindowsOutput : IConsoleOutput
 
     private readonly nint _screenBuffer;
 
+    // Last text style used, for updating style with EscSeqUtils.CSI_AppendTextStyleChange().
+    private TextStyle _redrawTextStyle = TextStyle.None;
+
     public WindowsOutput ()
     {
         Logging.Logger.LogInformation ($"Creating {nameof (WindowsOutput)}");
@@ -230,6 +233,8 @@ internal partial class WindowsOutput : IConsoleOutput
                     prev = attr;
                     EscSeqUtils.CSI_AppendForegroundColorRGB (stringBuilder, attr.Foreground.R, attr.Foreground.G, attr.Foreground.B);
                     EscSeqUtils.CSI_AppendBackgroundColorRGB (stringBuilder, attr.Background.R, attr.Background.G, attr.Background.B);
+                    EscSeqUtils.CSI_AppendTextStyleChange (stringBuilder, _redrawTextStyle, attr.TextStyle);
+                    _redrawTextStyle = attr.TextStyle;
                 }
 
                 if (info.Char != '\x1b')

--- a/Terminal.Gui/Drawing/Attribute.cs
+++ b/Terminal.Gui/Drawing/Attribute.cs
@@ -34,6 +34,10 @@ public readonly record struct Attribute : IEqualityOperators<Attribute, Attribut
     [JsonConverter (typeof (ColorJsonConverter))]
     public Color Background { get; }
 
+    // TODO: Add constructors which permit including a TextStyle.
+    /// <summary>The text style (bold, italic, underlined, etc.).</summary>
+    public TextStyle TextStyle { get; } = TextStyle.None;
+
     /// <summary>Initializes a new instance with default values.</summary>
     public Attribute ()
     {
@@ -103,6 +107,7 @@ public readonly record struct Attribute : IEqualityOperators<Attribute, Attribut
     /// <inheritdoc/>
     public override int GetHashCode () { return HashCode.Combine (PlatformColor, Foreground, Background); }
 
+    // TODO: Add TextStyle to Attribute.ToString(), modify unit tests to account
     /// <inheritdoc/>
     public override string ToString ()
     {

--- a/Terminal.Gui/Drawing/Attribute.cs
+++ b/Terminal.Gui/Drawing/Attribute.cs
@@ -36,7 +36,7 @@ public readonly record struct Attribute : IEqualityOperators<Attribute, Attribut
 
     // TODO: Add constructors which permit including a TextStyle.
     /// <summary>The text style (bold, italic, underlined, etc.).</summary>
-    public TextStyle TextStyle { get; } = TextStyle.None;
+    public TextStyle TextStyle { get; init; } = TextStyle.None;
 
     /// <summary>Initializes a new instance with default values.</summary>
     public Attribute ()

--- a/Terminal.Gui/Drawing/TextStyle.cs
+++ b/Terminal.Gui/Drawing/TextStyle.cs
@@ -12,6 +12,12 @@ namespace Terminal.Gui;
 ///         Multiple styles can be combined using bitwise operations. Use <see cref="Attribute.TextStyle"/>
 ///         to get or set these styles on an <see cref="Attribute"/>.
 ///     </para>
+///     <para>
+///         Note that <see cref="TextStyle.Bold"/> and <see cref="TextStyle.Faint"/> may be mutually exclusive depending on
+///         the user's terminal and its settings. For instance, if a terminal displays faint text as a darker color, and
+///         bold text as a lighter color, then both cannot
+///         be shown at the same time, and it will be up to the terminal to decide which to display.
+///     </para>
 /// </remarks>
 [Flags]
 public enum TextStyle : byte
@@ -25,13 +31,20 @@ public enum TextStyle : byte
     /// <summary>
     ///     Bold text.
     /// </summary>
-    /// <remarks>SGR code: 1 (Bold).</remarks>
+    /// <remarks>
+    ///     SGR code: 1 (Bold). May be mutually exclusive with <see cref="TextStyle.Faint"/>, see <see cref="TextStyle"/>
+    ///     remarks.
+    /// </remarks>
     Bold = 0b_0000_0001,
 
     /// <summary>
     ///     Faint (dim) text.
     /// </summary>
-    /// <remarks>SGR code: 2 (Faint). Not widely supported on all terminals.</remarks>
+    /// <remarks>
+    ///     SGR code: 2 (Faint). Not widely supported on all terminals. May be mutually exclusive with
+    ///     <see cref="TextStyle.Bold"/>, see
+    ///     <see cref="TextStyle"/> remarks.
+    /// </remarks>
     Faint = 0b_0000_0010,
 
     /// <summary>

--- a/Terminal.Gui/Drawing/TextStyle.cs
+++ b/Terminal.Gui/Drawing/TextStyle.cs
@@ -1,0 +1,66 @@
+namespace Terminal.Gui;
+
+/// <summary>
+///     Defines non-color text style flags for an <see cref="Attribute"/>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Only a subset of ANSI SGR (Select Graphic Rendition) styles are represented.
+///         Styles that are poorly supported, non-visual, or redundant with other APIs are omitted.
+///     </para>
+///     <para>
+///         Multiple styles can be combined using bitwise operations. Use <see cref="Attribute.TextStyle"/>
+///         to get or set these styles on an <see cref="Attribute"/>.
+///     </para>
+/// </remarks>
+[Flags]
+public enum TextStyle : byte
+{
+    /// <summary>
+    ///     No text style.
+    /// </summary>
+    /// <remarks>Corresponds to no active SGR styles.</remarks>
+    None = 0b_0000_0000,
+
+    /// <summary>
+    ///     Bold text.
+    /// </summary>
+    /// <remarks>SGR code: 1 (Bold).</remarks>
+    Bold = 0b_0000_0001,
+
+    /// <summary>
+    ///     Faint (dim) text.
+    /// </summary>
+    /// <remarks>SGR code: 2 (Faint). Not widely supported on all terminals.</remarks>
+    Faint = 0b_0000_0010,
+
+    /// <summary>
+    ///     Italic text.
+    /// </summary>
+    /// <remarks>SGR code: 3 (Italic). Some terminals may not support italic rendering.</remarks>
+    Italic = 0b_0000_0100,
+
+    /// <summary>
+    ///     Underlined text.
+    /// </summary>
+    /// <remarks>SGR code: 4 (Underline).</remarks>
+    Underline = 0b_0000_1000,
+
+    /// <summary>
+    ///     Slow blinking text.
+    /// </summary>
+    /// <remarks>SGR code: 5 (Slow Blink). Support varies; blinking is often disabled in modern terminals.</remarks>
+    Blink = 0b_0001_0000,
+
+    /// <summary>
+    ///     Reverse video (swaps foreground and background colors).
+    /// </summary>
+    /// <remarks>SGR code: 7 (Reverse Video).</remarks>
+    Reverse = 0b_0010_0000,
+
+    /// <summary>
+    ///     Strikethrough (crossed-out) text.
+    /// </summary>
+    /// <remarks>SGR code: 9 (Crossed-out / Strikethrough).</remarks>
+    Strikethrough = 0b_0100_0000
+}


### PR DESCRIPTION
## Changes:

- Adds `TextStyle` enum
- Adds `EscSeqUtils.CSI_AppendTextStyleChange()` method, which emits the ANSI escape codes for a text style
- Adds `TextStyle` property to `Attribute`
- Adds handling for `TextStyle`s to `OutputBuffer`, `NetOutput`, and `WindowsOutput`, allowing styled text to be displayed with the `NetOutput` and `WindowsOutput` drivers

Example:
![image](https://github.com/user-attachments/assets/2d37780c-4931-4bdf-869b-ce14a5de258a)

Title says "addresses" and not "fixes" #4058 because this definitely doesn't completely resolve that issue, only fully completing the first proposed change, and partially completing the second. I think it's still worthwhile as a good stepping-off point for more comprehensive updates. 

This pull request isn't necessarily final at time of creation, and there are a couple notable improvements I haven't made yet, but am willing to make after feedback:
- `Attribute.TextStyle` is only settable as an `init` property, there are no new constructors including it yet. I didn't add any due to it already having quite a few constructors, I wasn't sure if I should double them by adding variants with an extra `TextStyle` field.
- Only the V2 `NetOutput` and `WindowsOutput` drivers were updated to handle text styles. In order for them to have any effect, you'll have to explicitly create a V2 application and use either one of those drivers.
- No unit tests. The changes in this are surprisingly simple, and I'm not sure what there is that _can_ be tested. The only thing that comes to mind is making sure `EscSeqUtils.CSI_AppendTextStyleChange()` produces correct escape sequences, but I'm not sure what a good set of test cases for that is.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
