### PR TITLE
Fixes #4076 cursor text field

### DIFF
--- a/Terminal.Gui/FileServices/FileDialogStyle.cs
+++ b/Terminal.Gui/FileServices/FileDialogStyle.cs
@@ -10,7 +10,6 @@ namespace Terminal.Gui;
 public class FileDialogStyle
 {
     private readonly IFileSystem _fileSystem;
-    private bool _preserveFilenameOnDirectoryChanges;
 
     /// <summary>Creates a new instance of the <see cref="FileDialogStyle"/> class.</summary>
     public FileDialogStyle (IFileSystem fileSystem)

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -1110,7 +1110,7 @@ public class TextField : View
             TextModel.SetCol (ref col, Viewport.Width - 1, cols);
         }
 
-        int pos = col - ScrollOffset + Math.Min (Viewport.X, 0);
+        int pos = col + Math.Min (Viewport.X, 0);
         Move (pos, 0);
 
         return new Point (pos, 0);

--- a/Tests/IntegrationTests/FluentTests/TextFieldFluentTests.cs
+++ b/Tests/IntegrationTests/FluentTests/TextFieldFluentTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terminal.Gui;
+using TerminalGuiFluentTesting;
+using TerminalGuiFluentTestingXunit;
+using Xunit.Abstractions;
+
+namespace IntegrationTests.FluentTests;
+public class TextFieldFluentTests
+{
+    private readonly TextWriter _out;
+
+    public TextFieldFluentTests (ITestOutputHelper outputHelper)
+    {
+        _out = new TestOutputWriter (outputHelper);
+    }
+
+    [Theory]
+    [ClassData (typeof (V2TestDrivers))]
+    public void TextField_Cursor_AtEnd_WhenTyping (V2TestDriver d)
+    {
+        using var c = With.A<Window> (100, 20, d)
+                          .Add (new TextField () { Width = 3 })
+                          .Focus<TextField> ()
+                          .WaitIteration ()
+                          .AssertCursorPosition (new Point (1, 1)) // Initial cursor position (because Window has border)
+                          .RaiseKeyDownEvent (Key.A)
+                          .WaitIteration ()
+                          .ScreenShot ("After typing first letter", _out)
+                          .AssertCursorPosition (new Point (2, 1)) // Cursor moves along as letter is pressed
+                          .RaiseKeyDownEvent (Key.B)
+                          .WaitIteration ()
+                          .AssertCursorPosition (new Point (3, 1)) // Cursor moves along as letter is pressed
+                          .RaiseKeyDownEvent (Key.C)
+                          .WaitIteration ()
+                          .ScreenShot ("After typing all letters",_out)
+                          .AssertCursorPosition (new Point (3, 1)) // Cursor stays where it is because we are at end of TextField
+                          .WriteOutLogs (_out)
+                          .Stop ();
+    }
+}

--- a/Tests/IntegrationTests/FluentTests/TextFieldFluentTests.cs
+++ b/Tests/IntegrationTests/FluentTests/TextFieldFluentTests.cs
@@ -24,6 +24,7 @@ public class TextFieldFluentTests
     [ClassData (typeof (V2TestDrivers))]
     public void TextField_Cursor_AtEnd_WhenTyping (V2TestDriver d)
     {
+        // Simulates typing abcd into a TextField with width 3 (wide enough to render 2 characters only)
         using var c = With.A<Window> (100, 20, d)
                           .Add (new TextField () { Width = 3 })
                           .Focus<TextField> ()
@@ -40,6 +41,10 @@ public class TextFieldFluentTests
                           .WaitIteration ()
                           .ScreenShot ("After typing all letters",_out)
                           .AssertCursorPosition (new Point (3, 1)) // Cursor stays where it is because we are at end of TextField
+                          .RaiseKeyDownEvent (Key.D)
+                          .WaitIteration ()
+                          .ScreenShot ("Typing one more letter", _out)
+                          .AssertCursorPosition (new Point (3, 1)) // Cursor still stays at end of TextField
                           .WriteOutLogs (_out)
                           .Stop ();
     }

--- a/Tests/TerminalGuiFluentTesting/FakeOutput.cs
+++ b/Tests/TerminalGuiFluentTesting/FakeOutput.cs
@@ -24,5 +24,10 @@ internal class FakeOutput : IConsoleOutput
     public void SetCursorVisibility (CursorVisibility visibility) { }
 
     /// <inheritdoc/>
-    public void SetCursorPosition (int col, int row) { }
+    public void SetCursorPosition (int col, int row) { CursorPosition = new Point (col, row); }
+
+    /// <summary>
+    /// The last value set by calling <see cref="SetCursorPosition"/>
+    /// </summary>
+    public Point CursorPosition { get; private set; }
 }

--- a/Tests/TerminalGuiFluentTesting/GuiTestContext.cs
+++ b/Tests/TerminalGuiFluentTesting/GuiTestContext.cs
@@ -706,10 +706,14 @@ public class GuiTestContext : IDisposable
     ///     is found (of Type T) or all views are looped through (back to the beginning)
     ///     in which case triggers hard stop and Exception
     /// </summary>
+    /// <param name="evaluator">Delegate that returns true if the passed View is the one
+    /// you are trying to focus. Leave <see langword="null"/> to focus the first view of type
+    /// <typeparamref name="T"/></param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    public GuiTestContext Focus<T> (Func<T, bool> evaluator) where T : View
+    public GuiTestContext Focus<T> (Func<T, bool>? evaluator = null) where T : View
     {
+        evaluator ??= _ => true;
         Toplevel? t = Application.Top;
 
         HashSet<View> seen = new ();
@@ -815,5 +819,14 @@ public class GuiTestContext : IDisposable
         }
 
         return this;
+    }
+
+    /// <summary>
+    /// Returns the last set position of the cursor.
+    /// </summary>
+    /// <returns></returns>
+    public Point GetCursorPosition ()
+    {
+        return _output.CursorPosition;
     }
 }

--- a/Tests/TerminalGuiFluentTestingXunit/XunitContextExtensions.cs
+++ b/Tests/TerminalGuiFluentTestingXunit/XunitContextExtensions.cs
@@ -1,4 +1,5 @@
-﻿using TerminalGuiFluentTesting;
+﻿using System.Drawing;
+using TerminalGuiFluentTesting;
 using Xunit;
 
 namespace TerminalGuiFluentTestingXunit;
@@ -6,4 +7,27 @@ namespace TerminalGuiFluentTestingXunit;
 public static partial class XunitContextExtensions
 {
     // Placeholder
+
+
+    /// <summary>
+    /// Asserts that the last set cursor position matches <paramref name="expected"/>
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="expected"></param>
+    /// <returns></returns>
+    public static GuiTestContext AssertCursorPosition (this GuiTestContext context, Point expected)
+    {
+        try
+        {
+            Assert.Equal (expected, context.GetCursorPosition ());
+        }
+        catch (Exception)
+        {
+            context.HardStop ();
+
+            throw;
+        }
+
+        return context;
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #4076

So far this is just a test to confirm the bad behaviour of TextField when typing characters at the end of a TextField. 

The problem is that the cursor starts moving backwards through the TextField rather than staying at the end.

![bad-cursor](https://github.com/user-attachments/assets/a68ce953-5809-474c-99be-fae2e6645469)


## Proposed Changes/Todos

- Adds cursor tracking to fluent library
- Adds new Assert for cursor position
- Adds test that replicates cursor moving backwards bug
- Remove unused field `_preserveFilenameOnDirectoryChanges`
- Fix bug (thanks @BDisp)

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
