### PR TITLE
Fixes #4080. TabGroup not always navigate correctly across groups

### DIFF
--- a/Terminal.Gui/Application/Application.Keyboard.cs
+++ b/Terminal.Gui/Application/Application.Keyboard.cs
@@ -97,17 +97,11 @@ public static partial class Application // Keyboard handling
             }
             else
             {
-                // BUGBUG: this seems unneeded.
-                if (!KeyBindings.TryGet (key, out KeyBinding keybinding))
-                {
-                    return null;
-                }
-
                 bool? toReturn = null;
 
-                foreach (Command command in keybinding.Commands)
+                foreach (Command command in binding.Commands)
                 {
-                    toReturn = InvokeCommand (command, key, keybinding);
+                    toReturn = InvokeCommand (command, key, binding);
                 }
 
                 handled = toReturn ?? true;

--- a/Terminal.Gui/View/View.Hierarchy.cs
+++ b/Terminal.Gui/View/View.Hierarchy.cs
@@ -447,6 +447,26 @@ public partial class View // SuperView/SubView hierarchy management (SuperView, 
     #region SubViewOrdering
 
     /// <summary>
+    ///     Moves <paramref name="subview"/> to the end of the <see cref="SubViews"/> list keeping the original sorting.
+    /// </summary>
+    /// <param name="subview">The subview to move.</param>
+    public void MoveOverlappedSubViewToEnd (View subview)
+    {
+        PerformActionForSubView (
+                                 subview,
+                                 x =>
+                                 {
+                                     while (InternalSubViews!.IndexOf (x) != InternalSubViews.Count - 1)
+                                     {
+                                         var v = InternalSubViews [0];
+                                         InternalSubViews!.Remove (v);
+                                         InternalSubViews.Add (v);
+                                     }
+                                 }
+                                );
+    }
+
+    /// <summary>
     ///     Moves <paramref name="subview"/> one position towards the end of the <see cref="SubViews"/> list.
     /// </summary>
     /// <param name="subview">The subview to move.</param>

--- a/Terminal.Gui/View/View.Navigation.cs
+++ b/Terminal.Gui/View/View.Navigation.cs
@@ -61,14 +61,31 @@ public partial class View // Focus and cross-view navigation management (TabStop
             if (direction == NavigationDirection.Forward && focused == focusChain [^1] && SuperView is null)
             {
                 // We're at the top of the focus chain. Go back down the focus chain and focus the first TabGroup
-                View [] views = GetFocusChain (NavigationDirection.Forward, TabBehavior.TabGroup);
-
-                if (views.Length > 0)
+                if (focusChain.Length > 0)
                 {
-                    View [] subViews = views [0].GetFocusChain (NavigationDirection.Forward, TabBehavior.TabStop);
+                    // Get the index of the currently focused view
+                    int focusedTabGroupIndex = focusChain.IndexOf (Focused); // Will return -1 if Focused can't be found or is null
+
+                    if (focusedTabGroupIndex + 1 > focusChain.Length - 1)
+                    {
+                        focusedTabGroupIndex = 0;
+                    }
+                    else
+                    {
+                        focusedTabGroupIndex++;
+                    }
+
+                    View [] subViews = focusChain [focusedTabGroupIndex].GetFocusChain (NavigationDirection.Forward, TabBehavior.TabStop);
 
                     if (subViews.Length > 0)
                     {
+                        if (focusChain [focusedTabGroupIndex]._previouslyFocused is { }
+                            && subViews.Any (v => v == focusChain [focusedTabGroupIndex]._previouslyFocused))
+                        {
+                            return focusChain [focusedTabGroupIndex]._previouslyFocused!.SetFocus ();
+                        }
+
+                        // We have a subview that can be focused
                         if (subViews [0].SetFocus ())
                         {
                             return true;
@@ -77,17 +94,34 @@ public partial class View // Focus and cross-view navigation management (TabStop
                 }
             }
 
-            if (direction == NavigationDirection.Backward && focused == focusChain [0])
+            if (direction == NavigationDirection.Backward && focused == focusChain [0] && SuperView is null)
             {
                 // We're at the bottom of the focus chain
-                View [] views = GetFocusChain (NavigationDirection.Forward, TabBehavior.TabGroup);
-
-                if (views.Length > 0)
+                if (focusChain.Length > 0)
                 {
-                    View [] subViews = views [^1].GetFocusChain (NavigationDirection.Forward, TabBehavior.TabStop);
+                    // Get the index of the currently focused view
+                    int focusedTabGroupIndex = focusChain.IndexOf (Focused); // Will return -1 if Focused can't be found or is null
+
+                    if (focusedTabGroupIndex + 1 > focusChain.Length - 1)
+                    {
+                        focusedTabGroupIndex = 0;
+                    }
+                    else
+                    {
+                        focusedTabGroupIndex++;
+                    }
+
+                    View [] subViews = focusChain [focusedTabGroupIndex].GetFocusChain (NavigationDirection.Forward, TabBehavior.TabStop);
 
                     if (subViews.Length > 0)
                     {
+                        if (focusChain [focusedTabGroupIndex]._previouslyFocused is { }
+                            && subViews.Any (v => v == focusChain [focusedTabGroupIndex]._previouslyFocused))
+                        {
+                            return focusChain [focusedTabGroupIndex]._previouslyFocused!.SetFocus ();
+                        }
+
+                        // We have a subview that can be focused
                         if (subViews [0].SetFocus ())
                         {
                             return true;
@@ -619,7 +653,7 @@ public partial class View // Focus and cross-view navigation management (TabStop
 
         if (Arrangement.HasFlag (ViewArrangement.Overlapped))
         {
-            SuperView?.MoveSubViewToEnd (this);
+            SuperView?.MoveOverlappedSubViewToEnd (this);
         }
 
         // Focus work is done. Notify.

--- a/Tests/IntegrationTests/FluentTests/BasicFluentAssertionTests.cs
+++ b/Tests/IntegrationTests/FluentTests/BasicFluentAssertionTests.cs
@@ -143,4 +143,76 @@ public class BasicFluentAssertionTests
                                      .WriteOutLogs (_out);
         Assert.True (clicked);
     }
+
+    [Theory]
+    [ClassData (typeof (V2TestDrivers))]
+    public void Toplevel_TabGroup_Forward_Backward (V2TestDriver d)
+    {
+        var v1 = new View { Id = "v1", CanFocus = true };
+        var v2 = new View { Id = "v2", CanFocus = true };
+        var v3 = new View { Id = "v3", CanFocus = true };
+        var v4 = new View { Id = "v4", CanFocus = true };
+        var v5 = new View { Id = "v5", CanFocus = true };
+        var v6 = new View { Id = "v6", CanFocus = true };
+
+        using GuiTestContext c = With.A<Window> (50, 20, d)
+                                     .Then (
+                                            () =>
+                                            {
+                                                var w1 = new Window { Id = "w1" };
+                                                w1.Add (v1, v2);
+                                                var w2 = new Window { Id = "w2" };
+                                                w2.Add (v3, v4);
+                                                var w3 = new Window { Id = "w3" };
+                                                w3.Add (v5, v6);
+                                                Toplevel top = Application.Top!;
+                                                Application.Top!.Add (w1, w2, w3);
+                                            })
+                                     .WaitIteration ()
+                                     .Then (() => Assert.True (v5.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6)
+                                     .Then (() => Assert.True (v1.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6)
+                                     .Then (() => Assert.True (v3.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6.WithShift)
+                                     .Then (() => Assert.True (v1.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6.WithShift)
+                                     .Then (() => Assert.True (v5.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6.WithShift)
+                                     .Then (() => Assert.True (v3.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6)
+                                     .Then (() => Assert.True (v5.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6)
+                                     .Then (() => Assert.True (v1.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6)
+                                     .Then (() => Assert.True (v3.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6.WithShift)
+                                     .Then (() => Assert.True (v1.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6.WithShift)
+                                     .Then (() => Assert.True (v5.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6.WithShift)
+                                     .Then (() => Assert.True (v3.HasFocus))
+                                     .RaiseKeyDownEvent (Key.Tab)
+                                     .Then (() => Assert.True (v4.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6)
+                                     .Then (() => Assert.True (v5.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6)
+                                     .Then (() => Assert.True (v1.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6.WithShift)
+                                     .Then (() => Assert.True (v5.HasFocus))
+                                     .RaiseKeyDownEvent (Key.Tab)
+                                     .Then (() => Assert.True (v6.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6.WithShift)
+                                     .Then (() => Assert.True (v4.HasFocus))
+                                     .RaiseKeyDownEvent (Key.F6)
+                                     .Then (() => Assert.True (v6.HasFocus))
+                                     .WriteOutLogs (_out)
+                                     .Stop ();
+        Assert.False (v1.HasFocus);
+        Assert.False (v2.HasFocus);
+        Assert.False (v3.HasFocus);
+        Assert.False (v4.HasFocus);
+        Assert.False (v5.HasFocus);
+        Assert.False (v6.HasFocus);
+    }
 }

--- a/Tests/UnitTests/Application/KeyboardTests.cs
+++ b/Tests/UnitTests/Application/KeyboardTests.cs
@@ -215,7 +215,7 @@ public class KeyboardTests
                                      Assert.True (v3.HasFocus);
 
                                      Application.RaiseKeyDownEvent (Key.F6);
-                                     Assert.True (v1.HasFocus);
+                                     Assert.True (v2.HasFocus); // previously focused view was preserved
 
                                      Application.RequestStop ();
                                  };

--- a/Tests/UnitTestsParallelizable/View/SubviewTests.cs
+++ b/Tests/UnitTestsParallelizable/View/SubviewTests.cs
@@ -119,6 +119,38 @@ public class SubViewTests
     }
 
     [Fact]
+    public void MoveOverlappedSubViewToEnd ()
+    {
+        View superView = new ();
+
+        var subview1 = new View
+        {
+            Id = "subview1"
+        };
+
+        var subview2 = new View
+        {
+            Id = "subview2"
+        };
+
+        var subview3 = new View
+        {
+            Id = "subview3"
+        };
+
+        superView.Add (subview1, subview2, subview3);
+
+        superView.MoveOverlappedSubViewToEnd (subview1);
+        Assert.Equal ([subview2, subview3, subview1], superView.SubViews.ToArray ());
+
+        superView.MoveOverlappedSubViewToEnd (subview2);
+        Assert.Equal ([subview3, subview1, subview2], superView.SubViews.ToArray ());
+
+        superView.MoveOverlappedSubViewToEnd (subview3);
+        Assert.Equal ([subview1, subview2, subview3], superView.SubViews.ToArray ());
+    }
+
+    [Fact]
     public void MoveSubViewToStart ()
     {
         View superView = new ();


### PR DESCRIPTION
## Fixes

- Fixes #4080

## Proposed Changes/Todos

- [x] Added new method `MoveOverlappedSubViewToEnd`
- [x] Fix and added 2 more unit tests

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
