### PR TITLE
Fixes 4110. TextView's IsSelecting property not updating properly on mouse click

### DIFF
--- a/Terminal.Gui/Views/TextInput/TextView.cs
+++ b/Terminal.Gui/Views/TextInput/TextView.cs
@@ -1539,6 +1539,11 @@ public class TextView : View, IDesignable
             {
                 _isButtonReleased = false;
 
+                if (SelectedLength == 0)
+                {
+                    StopSelecting ();
+                }
+
                 return true;
             }
 

--- a/Tests/UnitTests/Views/TextViewTests.cs
+++ b/Tests/UnitTests/Views/TextViewTests.cs
@@ -9143,5 +9143,36 @@ ror       ";
         }
     }
 
+    [Fact]
+    [TextViewTestsAutoInitShutdown]
+    public void IsSelecting_False_If_SelectedLength_Is_Zero_On_Mouse_Click ()
+    {
+        _textView.Text = "This is the first line.";
+        var top = new Toplevel ();
+        top.Add (_textView);
+        Application.Begin (top);
+
+        Application.RaiseMouseEvent (new () { ScreenPosition = new (22, 0), Flags = MouseFlags.Button1Pressed });
+        Assert.Equal (22, _textView.CursorPosition.X);
+        Assert.Equal (0, _textView.CursorPosition.Y);
+        Assert.Equal (0, _textView.SelectedLength);
+        Assert.True (_textView.IsSelecting);
+
+        Application.RaiseMouseEvent (new () { ScreenPosition = new (22, 0), Flags = MouseFlags.Button1Released });
+        Assert.Equal (22, _textView.CursorPosition.X);
+        Assert.Equal (0, _textView.CursorPosition.Y);
+        Assert.Equal (0, _textView.SelectedLength);
+        Assert.True (_textView.IsSelecting);
+
+        Application.RaiseMouseEvent (new () { ScreenPosition = new (22, 0), Flags = MouseFlags.Button1Clicked });
+        Assert.Equal (22, _textView.CursorPosition.X);
+        Assert.Equal (0, _textView.CursorPosition.Y);
+        Assert.Equal (0, _textView.SelectedLength);
+        Assert.False (_textView.IsSelecting);
+
+        top.Dispose ();
+        Application.Shutdown ();
+    }
+
     private TextView CreateTextView () { return new () { Width = 30, Height = 10 }; }
 }


### PR DESCRIPTION
## Fixes

- Fixes #4110

## Proposed Changes/Todos

- [x] On mouse click the `IsSelecting` property must be set as false if the `SelectedLength` property is zero

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
