### PR TITLE
Fixes #4120. ConfigurationEditor is handle No button the same as Cancel button

### DIFF
--- a/Examples/UICatalog/Scenarios/ConfigurationEditor.cs
+++ b/Examples/UICatalog/Scenarios/ConfigurationEditor.cs
@@ -168,7 +168,9 @@ public class ConfigurationEditor : Scenario
 
                     break;
 
-                default:
+                case 1:
+                    // user decided not save changes
+                    break;
                 case -1 or 2:
                     // user cancelled
                     return;


### PR DESCRIPTION
## Fixes

- Fixes #4120

## Proposed Changes/Todos

- [x] Allow quit the scenario after the ESC key was pressed and all the No buttons are clicked

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
