### PR TITLE
Fixes #4050 - `Select`->`Activate`

### DIFF
--- a/Terminal.Gui/Input/Command.cs
+++ b/Terminal.Gui/Input/Command.cs
@@ -48,12 +48,15 @@ public enum Command
     HotKey,
 
     /// <summary>
-    ///     Selects the View or an item in the View (e.g. a list item or menu item) without necessarily accepting it.
+    ///     Activates the View or an item in the View (e.g. a list item or menu item) without necessarily accepting it.
+    ///     <para>
+    ///         In some cases, activating a View just sets focus to it, while in others it may trigger an action.
+    ///     </para>
     ///     <para>
     ///         The default implementation in <see cref="View"/> calls <see cref="View.RaiseSelecting"/>.
     ///     </para>
     /// </summary>
-    Select,
+    Activate,
 
     #endregion
 

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -38,7 +38,7 @@ public partial class View // Command APIs
 
         // Space or single-click - Raise Selecting
         AddCommand (
-                    Command.Select,
+                    Command.Activate,
                     ctx =>
                     {
                         if (RaiseSelecting (ctx) is true)
@@ -203,9 +203,9 @@ public partial class View // Command APIs
     public event EventHandler<CommandEventArgs>? Accepting;
 
     /// <summary>
-    ///     Called when the user has performed an action (e.g. <see cref="Command.Select"/>) causing the View to change state.
+    ///     Called when the user has performed an action (e.g. <see cref="Command.Activate"/>) causing the View to change state.
     ///     Calls <see cref="OnSelecting"/> which can be cancelled; if not cancelled raises <see cref="Accepting"/>.
-    ///     event. The default <see cref="Command.Select"/> handler calls this method.
+    ///     event. The default <see cref="Command.Activate"/> handler calls this method.
     /// </summary>
     /// <remarks>
     ///     The <see cref="Selecting"/> event should be raised after the state of the View has been changed and before see
@@ -236,7 +236,7 @@ public partial class View // Command APIs
     }
 
     /// <summary>
-    ///     Called when the user has performed an action (e.g. <see cref="Command.Select"/>) causing the View to change state.
+    ///     Called when the user has performed an action (e.g. <see cref="Command.Activate"/>) causing the View to change state.
     ///     Set CommandEventArgs.Handled to <see langword="true"/> and return <see langword="true"/> to indicate the event was
     ///     handled and processing should stop.
     /// </summary>
@@ -245,7 +245,7 @@ public partial class View // Command APIs
     protected virtual bool OnSelecting (CommandEventArgs args) { return false; }
 
     /// <summary>
-    ///     Cancelable event raised when the user has performed an action (e.g. <see cref="Command.Select"/>) causing the View
+    ///     Cancelable event raised when the user has performed an action (e.g. <see cref="Command.Activate"/>) causing the View
     ///     to change state.
     ///     Set CommandEventArgs.Handled to <see langword="true"/> to indicate the event was handled and processing should
     ///     stop.

--- a/Terminal.Gui/ViewBase/View.Keyboard.cs
+++ b/Terminal.Gui/ViewBase/View.Keyboard.cs
@@ -10,7 +10,7 @@ public partial class View // Keyboard APIs
     private void SetupKeyboard ()
     {
         KeyBindings = new (this);
-        KeyBindings.Add (Key.Space, Command.Select);
+        KeyBindings.Add (Key.Space, Command.Activate);
         KeyBindings.Add (Key.Enter, Command.Accept);
 
         HotKeyBindings = new (this);

--- a/Terminal.Gui/ViewBase/View.Mouse.cs
+++ b/Terminal.Gui/ViewBase/View.Mouse.cs
@@ -13,11 +13,11 @@ public partial class View // Mouse APIs
         MouseBindings = new ();
 
         // TODO: Should the default really work with any button or just button1?
-        MouseBindings.Add (MouseFlags.Button1Clicked, Command.Select);
-        MouseBindings.Add (MouseFlags.Button2Clicked, Command.Select);
-        MouseBindings.Add (MouseFlags.Button3Clicked, Command.Select);
-        MouseBindings.Add (MouseFlags.Button4Clicked, Command.Select);
-        MouseBindings.Add (MouseFlags.Button1Clicked | MouseFlags.ButtonCtrl, Command.Select);
+        MouseBindings.Add (MouseFlags.Button1Clicked, Command.Activate);
+        MouseBindings.Add (MouseFlags.Button2Clicked, Command.Activate);
+        MouseBindings.Add (MouseFlags.Button3Clicked, Command.Activate);
+        MouseBindings.Add (MouseFlags.Button4Clicked, Command.Activate);
+        MouseBindings.Add (MouseFlags.Button1Clicked | MouseFlags.ButtonCtrl, Command.Activate);
     }
 
     /// <summary>

--- a/Terminal.Gui/Views/CharMap/CharMap.cs
+++ b/Terminal.Gui/Views/CharMap/CharMap.cs
@@ -43,7 +43,7 @@ public class CharMap : View, IDesignable
         AddCommand (Command.ScrollLeft, () => ScrollHorizontal (-1));
 
         AddCommand (Command.Accept, HandleAcceptCommand);
-        AddCommand (Command.Select, HandleSelectCommand);
+        AddCommand (Command.Activate, HandleSelectCommand);
         AddCommand (Command.Context, HandleContextCommand);
 
         KeyBindings.Add (Key.CursorUp, Command.Up);

--- a/Terminal.Gui/Views/CheckBox.cs
+++ b/Terminal.Gui/Views/CheckBox.cs
@@ -27,7 +27,7 @@ public class CheckBox : View
         CanFocus = true;
 
         // Select (Space key and single-click) - Advance state and raise Select event - DO NOT raise Accept
-        AddCommand (Command.Select, AdvanceAndSelect);
+        AddCommand (Command.Activate, AdvanceAndSelect);
 
         // Hotkey - Advance state and raise Select event - DO NOT raise Accept
         AddCommand (Command.HotKey, ctx =>

--- a/Terminal.Gui/Views/Color/ColorPicker.16.cs
+++ b/Terminal.Gui/Views/Color/ColorPicker.16.cs
@@ -195,7 +195,7 @@ public class ColorPicker16 : View
         AddCommand (Command.Up, (ctx) => MoveUp (ctx));
         AddCommand (Command.Down, (ctx) => MoveDown (ctx));
 
-        AddCommand (Command.Select, (ctx) =>
+        AddCommand (Command.Activate, (ctx) =>
                                     {
                                         var set = false;
 

--- a/Terminal.Gui/Views/FileDialogs/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialogs/FileDialog.cs
@@ -172,7 +172,7 @@ public class FileDialog : Dialog, IDesignable
             FullRowSelect = true,
         };
         _tableView.CollectionNavigator = new FileDialogCollectionNavigator (this, _tableView);
-        _tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Select);
+        _tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Activate);
         _tableView.MouseClick += OnTableViewMouseClick;
         _tableView.Style.InvertSelectedCellFirstCharacter = true;
         Style.TableStyle = _tableView.Style;

--- a/Terminal.Gui/Views/HexView.cs
+++ b/Terminal.Gui/Views/HexView.cs
@@ -57,7 +57,7 @@ public class HexView : View, IDesignable
         _leftSideHasFocus = true;
         _firstNibble = true;
 
-        AddCommand (Command.Select, HandleMouseClick);
+        AddCommand (Command.Activate, HandleMouseClick);
         AddCommand (Command.Left, () => MoveLeft ());
         AddCommand (Command.Right, () => MoveRight ());
         AddCommand (Command.Down, () => MoveDown (BytesPerLine));
@@ -101,8 +101,8 @@ public class HexView : View, IDesignable
         KeyBindings.Remove (Key.Enter);
 
         // The Select handler deals with both single and double clicks
-        MouseBindings.ReplaceCommands (MouseFlags.Button1Clicked, Command.Select);
-        MouseBindings.Add (MouseFlags.Button1DoubleClicked, Command.Select);
+        MouseBindings.ReplaceCommands (MouseFlags.Button1Clicked, Command.Activate);
+        MouseBindings.Add (MouseFlags.Button1DoubleClicked, Command.Activate);
         MouseBindings.Add (MouseFlags.WheeledUp, Command.ScrollUp);
         MouseBindings.Add (MouseFlags.WheeledDown, Command.ScrollDown);
 

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -106,7 +106,7 @@ public class ListView : View, IDesignable
                                     });
 
         // Select (Space key and single-click) - If markable, change mark and raise Select event
-        AddCommand (Command.Select, (ctx) =>
+        AddCommand (Command.Activate, (ctx) =>
                                     {
                                         if (_allowsMarking)
                                         {
@@ -168,7 +168,7 @@ public class ListView : View, IDesignable
         KeyBindings.Add (Key.End, Command.End);
 
         // Key.Space is already bound to Command.Select; this gives us select then move down
-        KeyBindings.Add (Key.Space.WithShift, [Command.Select, Command.Down]);
+        KeyBindings.Add (Key.Space.WithShift, [Command.Activate, Command.Down]);
 
         // Use the form of Add that lets us pass context to the handler
         KeyBindings.Add (Key.A.WithCtrl, new KeyBinding ([Command.SelectAll], true));

--- a/Terminal.Gui/Views/Menuv1/Menu.cs
+++ b/Terminal.Gui/Views/Menuv1/Menu.cs
@@ -56,7 +56,7 @@ internal sealed class Menu : View
                    );
 
         AddCommand (
-                    Command.Select,
+                    Command.Activate,
                     ctx =>
                     {
                         if (ctx is not CommandContext<KeyBinding> keyCommandContext)
@@ -133,7 +133,7 @@ internal sealed class Menu : View
 
                     if (menuItem.ShortcutKey != Key.Empty)
                     {
-                        KeyBinding keyBinding = new ([Command.Select], this, data: menuItem);
+                        KeyBinding keyBinding = new ([Command.Activate], this, data: menuItem);
 
                         // Remove an existent ShortcutKey
                         menuItem._menuBar.HotKeyBindings.Remove (menuItem.ShortcutKey!);

--- a/Terminal.Gui/Views/Menuv1/MenuBar.cs
+++ b/Terminal.Gui/Views/Menuv1/MenuBar.cs
@@ -143,7 +143,7 @@ public class MenuBar : View, IDesignable
                                                       }
                                                       return Select (Menus.IndexOf (keyCommandContext.Binding.Data));
                                                   });
-        AddCommand (Command.Select, ctx =>
+        AddCommand (Command.Activate, ctx =>
                                     {
                                         if (ctx is not CommandContext<KeyBinding> keyCommandContext)
                                         {
@@ -221,7 +221,7 @@ public class MenuBar : View, IDesignable
                     // Technically this will never run because MenuBarItems don't have shortcuts
                     // unless the IsTopLevel is true
                     HotKeyBindings.Remove (menuBarItem.ShortcutKey!);
-                    KeyBinding keyBinding = new ([Command.Select], this, data: menuBarItem);
+                    KeyBinding keyBinding = new ([Command.Activate], this, data: menuBarItem);
                     HotKeyBindings.Add (menuBarItem.ShortcutKey!, keyBinding);
                 }
 

--- a/Terminal.Gui/Views/Menuv1/MenuItem.cs
+++ b/Terminal.Gui/Views/Menuv1/MenuItem.cs
@@ -297,7 +297,7 @@ public class MenuItem
 
         if (ShortcutKey != Key.Empty)
         {
-            KeyBinding keyBinding = new ([Command.Select], null, data: this);
+            KeyBinding keyBinding = new ([Command.Activate], null, data: this);
             // Remove an existent ShortcutKey
             _menuBar.HotKeyBindings.Remove (ShortcutKey!);
             _menuBar.HotKeyBindings.Add (ShortcutKey!, keyBinding);

--- a/Terminal.Gui/Views/RadioGroup.cs
+++ b/Terminal.Gui/Views/RadioGroup.cs
@@ -16,7 +16,7 @@ public class RadioGroup : View, IDesignable, IOrientation
         Height = Dim.Auto (DimAutoStyle.Content);
 
         // Select (Space key or mouse click) - The default implementation sets focus. RadioGroup does not.
-        AddCommand (Command.Select, HandleSelectCommand);
+        AddCommand (Command.Activate, HandleSelectCommand);
 
         // Accept (Enter key or DoubleClick) - Raise Accept event - DO NOT advance state
         AddCommand (Command.Accept, HandleAcceptCommand);
@@ -59,7 +59,7 @@ public class RadioGroup : View, IDesignable, IOrientation
             if (item is null || HotKey == keyCommandContext.Binding.Key?.NoAlt.NoCtrl.NoShift!)
             {
                 // It's this.HotKey OR Another View (Label?) forwarded the hotkey command to us - Act just like `Space` (Select)
-                return InvokeCommand (Command.Select);
+                return InvokeCommand (Command.Activate);
             }
         }
 

--- a/Terminal.Gui/Views/ScrollBar/ScrollSlider.cs
+++ b/Terminal.Gui/Views/ScrollBar/ScrollSlider.cs
@@ -236,7 +236,7 @@ public class ScrollSlider : View, IOrientation, IDesignable
         OnScrolled (distance);
         Scrolled?.Invoke (this, new (in distance));
 
-        RaiseSelecting (new CommandContext<KeyBinding> (Command.Select, this, new KeyBinding ([Command.Select], null, distance)));
+        RaiseSelecting (new CommandContext<KeyBinding> (Command.Activate, this, new KeyBinding ([Command.Activate], null, distance)));
     }
 
     /// <summary>

--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -239,7 +239,7 @@ public class Shortcut : View, IOrientation, IDesignable
         // Hotkey -
         AddCommand (Command.HotKey, DispatchCommand);
         // Select (Space key or click) -
-        AddCommand (Command.Select, DispatchCommand);
+        AddCommand (Command.Activate, DispatchCommand);
     }
 
     /// <summary>
@@ -267,7 +267,7 @@ public class Shortcut : View, IOrientation, IDesignable
 
             Logging.Debug ($"{Title} ({commandContext?.Source?.Title}) - Invoking Select on CommandView ({CommandView.GetType ().Name}).");
 
-            CommandView.InvokeCommand (Command.Select, keyCommandContext);
+            CommandView.InvokeCommand (Command.Activate, keyCommandContext);
         }
 
         Logging.Debug ($"{Title} ({commandContext?.Source?.Title}) - RaiseSelecting ...");
@@ -459,7 +459,7 @@ public class Shortcut : View, IOrientation, IDesignable
                     e.Context is CommandContext<MouseBinding>)
                 {
                     // Forward command to ourselves
-                    InvokeCommand<KeyBinding> (Command.Select, new ([Command.Select], null, this));
+                    InvokeCommand<KeyBinding> (Command.Activate, new ([Command.Activate], null, this));
                 }
 
                 e.Handled = true;

--- a/Terminal.Gui/Views/Slider/Slider.cs
+++ b/Terminal.Gui/Views/Slider/Slider.cs
@@ -1425,7 +1425,7 @@ public class Slider<T> : View, IOrientation
         AddCommand (Command.RightEnd, () => MoveEnd ());
         AddCommand (Command.RightExtend, () => ExtendPlus ());
         AddCommand (Command.LeftExtend, () => ExtendMinus ());
-        AddCommand (Command.Select, () => Select ());
+        AddCommand (Command.Activate, () => Select ());
         AddCommand (Command.Accept, (ctx) => Accept (ctx));
 
         SetKeyBindings ();
@@ -1466,7 +1466,7 @@ public class Slider<T> : View, IOrientation
         KeyBindings.Remove (Key.Enter);
         KeyBindings.Add (Key.Enter, Command.Accept);
         KeyBindings.Remove (Key.Space);
-        KeyBindings.Add (Key.Space, Command.Select);
+        KeyBindings.Add (Key.Space, Command.Activate);
     }
 
     private Dictionary<int, SliderOption<T>> GetSetOptionDictionary () { return _setOptions.ToDictionary (e => e, e => _options [e]); }

--- a/Terminal.Gui/Views/TableView/CheckBoxTableSourceWrapper.cs
+++ b/Terminal.Gui/Views/TableView/CheckBoxTableSourceWrapper.cs
@@ -27,7 +27,7 @@ public abstract class CheckBoxTableSourceWrapperBase : ITableSource
         Wrapping = toWrap;
         this.tableView = tableView;
 
-        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Select);
+        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Activate);
 
         tableView.MouseClick += TableView_MouseClick;
         tableView.CellToggled += TableView_CellToggled;

--- a/Terminal.Gui/Views/TableView/TableSelection.cs
+++ b/Terminal.Gui/Views/TableView/TableSelection.cs
@@ -13,7 +13,7 @@ public class TableSelection
     }
 
     /// <summary>
-    ///     True if the selection was made through <see cref="Command.Select"/> and therefore should persist even
+    ///     True if the selection was made through <see cref="Command.Activate"/> and therefore should persist even
     ///     through keyboard navigation.
     /// </summary>
     public bool IsToggled { get; set; }

--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -242,7 +242,7 @@ public class TableView : View, IDesignable
         AddCommand (Command.Accept, () => OnCellActivated (new (Table, SelectedColumn, SelectedRow)));
 
         AddCommand (
-                    Command.Select, // was Command.ToggleChecked
+                    Command.Activate, // was Command.ToggleChecked
                     ctx =>
                     {
                         if (ToggleCurrentCellSelection () is true)
@@ -460,7 +460,7 @@ public class TableView : View, IDesignable
     /// </summary>
     public event EventHandler<CellActivatedEventArgs> CellActivated;
 
-    /// <summary>This event is raised when a cell is toggled (see <see cref="Command.Select"/></summary>
+    /// <summary>This event is raised when a cell is toggled (see <see cref="Command.Activate"/></summary>
     public event EventHandler<CellToggledEventArgs> CellToggled;
 
     /// <summary>
@@ -1574,7 +1574,7 @@ public class TableView : View, IDesignable
     /// <param name="pt1Y">Origin point for the selection in Y</param>
     /// <param name="pt2X">End point for the selection in X</param>
     /// <param name="pt2Y">End point for the selection in Y</param>
-    /// <param name="toggle">True if selection is result of <see cref="Command.Select"/></param>
+    /// <param name="toggle">True if selection is result of <see cref="Command.Activate"/></param>
     /// <returns></returns>
     private TableSelection CreateTableSelection (int pt1X, int pt1Y, int pt2X, int pt2Y, bool toggle = false)
     {

--- a/Terminal.Gui/Views/TreeView/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView/TreeView.cs
@@ -290,7 +290,7 @@ public class TreeView<T> : View, ITreeView where T : class
                     }
                    );
 
-        AddCommand (Command.Select, ActivateSelectedObjectIfAny);
+        AddCommand (Command.Activate, ActivateSelectedObjectIfAny);
         AddCommand (Command.Accept, ActivateSelectedObjectIfAny);
 
         // Default keybindings for this view
@@ -316,7 +316,7 @@ public class TreeView<T> : View, ITreeView where T : class
         KeyBindings.Add (Key.A.WithCtrl, Command.SelectAll);
 
         KeyBindings.Remove (ObjectActivationKey);
-        KeyBindings.Add (ObjectActivationKey, Command.Select);
+        KeyBindings.Add (ObjectActivationKey, Command.Activate);
     }
 
     /// <summary>

--- a/Tests/UnitTests/Views/CheckBoxTests.cs
+++ b/Tests/UnitTests/Views/CheckBoxTests.cs
@@ -586,7 +586,7 @@ public class CheckBoxTests (ITestOutputHelper output)
         ckb.Selecting += OnSelecting;
 
         Assert.Equal (initialState, ckb.CheckedState);
-        bool? ret = ckb.InvokeCommand (Command.Select);
+        bool? ret = ckb.InvokeCommand (Command.Activate);
         Assert.True (ret);
         Assert.True (checkedInvoked);
         Assert.NotEqual (initialState, ckb.CheckedState);

--- a/Tests/UnitTests/Views/TableViewTests.cs
+++ b/Tests/UnitTests/Views/TableViewTests.cs
@@ -3025,7 +3025,7 @@ A B C
         dt.Rows.Add (1, 2, 3, 4, 5, 6);
 
         tableView.MultiSelect = true;
-        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Select);
+        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Activate);
 
         Point selectedCell = tableView.GetAllSelectedCells ().Single ();
         Assert.Equal (0, selectedCell.X);
@@ -3097,7 +3097,7 @@ A B C
         dt.Rows.Add (1, 2, 3, 4, 5, 6);
         tableView.FullRowSelect = true;
         tableView.MultiSelect = true;
-        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Select);
+        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Activate);
 
         // Toggle Select Cell 0,0
         tableView.NewKeyDownEvent (new () { KeyCode = KeyCode.Space });
@@ -3135,7 +3135,7 @@ A B C
         dt.Rows.Add (1, 2, 3, 4, 5, 6);
         dt.Rows.Add (1, 2, 3, 4, 5, 6);
         tableView.MultiSelect = true;
-        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Select);
+        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Activate);
 
         // Make a square selection
         tableView.NewKeyDownEvent (new () { KeyCode = KeyCode.ShiftMask | KeyCode.CursorDown });
@@ -3176,7 +3176,7 @@ A B C
         dt.Rows.Add (1, 2, 3, 4, 5, 6);
         dt.Rows.Add (1, 2, 3, 4, 5, 6);
         tableView.MultiSelect = true;
-        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Select);
+        tableView.KeyBindings.ReplaceCommands (Key.Space, Command.Activate);
 
         // Make first square selection (0,0 to 1,1)
         tableView.NewKeyDownEvent (new () { KeyCode = KeyCode.ShiftMask | KeyCode.CursorDown });

--- a/Tests/UnitTestsParallelizable/View/ViewCommandTests.cs
+++ b/Tests/UnitTestsParallelizable/View/ViewCommandTests.cs
@@ -140,7 +140,7 @@ public class ViewCommandTests
         Assert.Equal (canFocus, view.CanFocus);
         Assert.False (view.HasFocus);
 
-        view.InvokeCommand (Command.Select);
+        view.InvokeCommand (Command.Activate);
 
         Assert.Equal (1, view.OnSelectingCount);
 
@@ -156,7 +156,7 @@ public class ViewCommandTests
         Assert.False (view.HasFocus);
 
         view.HandleOnSelecting = true;
-        Assert.True (view.InvokeCommand (Command.Select));
+        Assert.True (view.InvokeCommand (Command.Activate));
 
         Assert.Equal (1, view.OnSelectingCount);
 
@@ -171,7 +171,7 @@ public class ViewCommandTests
 
         view.Selecting += ViewOnSelect;
 
-        bool? ret = view.InvokeCommand (Command.Select);
+        bool? ret = view.InvokeCommand (Command.Activate);
         Assert.True (ret);
         Assert.True (selectingInvoked);
 
@@ -192,7 +192,7 @@ public class ViewCommandTests
 
         view.Selecting += ViewOnSelecting;
 
-        view.InvokeCommand (Command.Select);
+        view.InvokeCommand (Command.Activate);
         Assert.True (selecting);
 
         return;

--- a/Tests/UnitTestsParallelizable/Views/AllViewsTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/AllViewsTests.cs
@@ -70,7 +70,7 @@ public class AllViewsTests (ITestOutputHelper output) : TestsAllViews
         var acceptedCount = 0;
         view.Accepting += (s, e) => { acceptedCount++; };
 
-        if (view.InvokeCommand (Command.Select) == true)
+        if (view.InvokeCommand (Command.Activate) == true)
         {
             Assert.Equal (1, selectingCount);
             Assert.Equal (0, acceptedCount);


### PR DESCRIPTION
## Fixes

- Fixes #4050

## Proposed Changes/Todos

- [x] `Command.Select->Activate`
- [ ] Rename `Selecting` event to `Activating`, `OnSelecting` to `OnActivating`, and `RaiseSelecting` to `RaiseActivating` in the `View` class and all derived classes (e.g., `Menuv2`, `MenuItemv2`, `CheckBox`, `FlagSelector`).
- [ ] Update related code:
  - [ ] Modify `SetupCommands` in `View` to use `Command.Activate`.
  - [ ] Update `Shortcut.DispatchCommand` and other command handlers to reference `Activating`.
  - [ ] Ensure all event handlers and documentation reflect the new terminology.
- [ ] Introduce Targeted Propagation Model with `PropagateActivating`
- [ ] Update Documentation
  - [ ] Clarify `Activating` vs. `Accepting`:
  - [ ] Document propagation: Explain the targeted model with `PropagateActivating`, providing examples for `MenuBarv2` and potential `Toplevel` use cases.
  - [ ] Update view-specific docs:
