### PR TITLE
Fixes 4132. .editorconfig has ambiguous configuration with same files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1881,8 +1881,3 @@ tab_width = 4
 indent_style = space
 indent_size = 2
 tab_width = 2
-
-[*.{appxmanifest,axaml,axml,build,config,cs,csproj,dbml,discomap,dtd,jsproj,lsproj,njsproj,nuspec,paml,proj,props,resw,resx,StyleCop,targets,tasks,vb,vbproj,xaml,xamlx,xml,xoml,xsd}]
-indent_style = space
-indent_size = 4
-tab_width = 4


### PR DESCRIPTION
## Fixes

- Fixes #4132

## Proposed Changes/Todos

- [x] Remove ambiguous configurations causing conflicts with the format of same files

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
