### PR TITLE
Fixes #4102. Add AOT version of Tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1881,8 +1881,3 @@ tab_width = 4
 indent_style = space
 indent_size = 2
 tab_width = 2
-
-[*.{appxmanifest,axaml,axml,build,config,cs,csproj,dbml,discomap,dtd,jsproj,lsproj,njsproj,nuspec,paml,proj,props,resw,resx,StyleCop,targets,tasks,vb,vbproj,xaml,xamlx,xml,xoml,xsd}]
-indent_style = space
-indent_size = 4
-tab_width = 4

--- a/Examples/NativeAot/Properties/launchSettings.json
+++ b/Examples/NativeAot/Properties/launchSettings.json
@@ -3,10 +3,34 @@
     "NativeAot": {
       "commandName": "Project"
     },
+    "NativeAot --driver NetDriver": {
+      "commandName": "Project",
+      "commandLineArgs": "--driver NetDriver"
+    },
+    "NativeAot --driver v2win": {
+      "commandName": "Project",
+      "commandLineArgs": "--driver v2win -dl Trace"
+    },
+    "NativeAot --driver v2net": {
+      "commandName": "Project",
+      "commandLineArgs": "--driver v2net -dl Trace"
+    },
     "WSL : NativeAot": {
       "commandName": "Executable",
       "executablePath": "wsl",
       "commandLineArgs": "dotnet NativeAot.dll",
+      "distributionName": ""
+    },
+    "WSL: NativeAot --driver NetDriver": {
+      "commandName": "Executable",
+      "executablePath": "wsl",
+      "commandLineArgs": "dotnet NativeAot.dll --driver NetDriver",
+      "distributionName": ""
+    },
+    "WSL: NativeAot --driver v2net": {
+      "commandName": "Executable",
+      "executablePath": "wsl",
+      "commandLineArgs": "dotnet NativeAot.dll --driver v2net -dl Trace",
       "distributionName": ""
     }
   }

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -82,6 +82,7 @@
     <ItemGroup>
         <InternalsVisibleTo Include="Benchmarks" />
         <InternalsVisibleTo Include="UnitTests" />
+        <InternalsVisibleTo Include="UnitTests.AOT" />
         <InternalsVisibleTo Include="UnitTests.Parallelizable" />
         <InternalsVisibleTo Include="StressTests" />
         <InternalsVisibleTo Include="IntegrationTests" />
@@ -162,9 +163,9 @@
     </Target>-->
         
     <Target Name="CopyNuGetPackagesToLocalPackagesFolder" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release'">
-	    <!-- Remove older NuGet Package from Global Cache -->
-	    <Exec Command="rmdir /s /q &quot;$(UserProfile)\.nuget\packages\terminal.gui\2.0.0&quot;" Condition=" '$(OS)' == 'Windows_NT' " />
-	    <Exec Command="rm -rf ~/.nuget/packages/terminal.gui/2.0.0" Condition=" '$(OS)' != 'Windows_NT' " />
+        <!-- Remove older NuGet Package from Global Cache -->
+        <Exec Command="rmdir /s /q &quot;$(UserProfile)\.nuget\packages\terminal.gui\2.0.0&quot;" Condition=" '$(OS)' == 'Windows_NT' " />
+        <Exec Command="rm -rf ~/.nuget/packages/terminal.gui/2.0.0" Condition=" '$(OS)' != 'Windows_NT' " />
 
         <PropertyGroup>
             <!-- Define the path for local_packages relative to the project directory -->

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -75,6 +75,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerminalGuiFluentTestingXun
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerminalGuiFluentTestingXunit.Generator", "Tests\TerminalGuiFluentTestingXunit.Generator\TerminalGuiFluentTestingXunit.Generator.csproj", "{199F27D8-A905-4DDC-82CA-1FE1A90B1788}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests.AOT", "Tests\UnitTests.AOT\UnitTests.AOT.csproj", "{F9E1362D-29EC-4C77-9E83-BCEA54553CCD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -141,6 +143,10 @@ Global
 		{199F27D8-A905-4DDC-82CA-1FE1A90B1788}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{199F27D8-A905-4DDC-82CA-1FE1A90B1788}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{199F27D8-A905-4DDC-82CA-1FE1A90B1788}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9E1362D-29EC-4C77-9E83-BCEA54553CCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9E1362D-29EC-4C77-9E83-BCEA54553CCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9E1362D-29EC-4C77-9E83-BCEA54553CCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9E1362D-29EC-4C77-9E83-BCEA54553CCD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/UnitTests.AOT/UnitTests.AOT.csproj
+++ b/Tests/UnitTests.AOT/UnitTests.AOT.csproj
@@ -1,0 +1,96 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Version numbers are automatically updated by gitversion when a release is released -->
+    <!-- In the source tree the version will always be 2.0 for all projects. -->
+    <!-- Do not modify these. -->
+    <AssemblyVersion>2.0</AssemblyVersion>
+    <FileVersion>2.0</FileVersion>
+    <Version>2.0</Version>
+    <InformationalVersion>2.0</InformationalVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+	  <!-- Enable AOT compilation -->
+	  <PublishAot>true</PublishAot>
+	  <RunAotCompilation>true</RunAotCompilation>
+	  <DefineConstants>AOT</DefineConstants>
+    <UseDataCollector />
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineTrace>true</DefineTrace>
+    <DebugType>portable</DebugType>
+    <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS;CONTRACTS_FULL</DefineConstants>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoLogo>true</NoLogo>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineDebug>true</DefineDebug>
+    <DefineConstants>$(DefineConstants);DEBUG_IDISPOSABLE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="ReportGenerator" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="Xunit.Combinatorial" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Terminal.Gui\Terminal.Gui.csproj" />
+    <ProjectReference Include="..\..\Examples\UICatalog\UICatalog.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Drawing" />
+    <Using Include="Terminal.Gui" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <PropertyGroup Label="FineCodeCoverage">
+    <Enabled>
+      False
+    </Enabled>
+    <Exclude>
+      [UICatalog]*
+    </Exclude>
+    <Include></Include>
+    <ExcludeByFile>
+      <!--**/Migrations/*
+      **/Hacks/*.cs-->
+    </ExcludeByFile>
+    <ExcludeByAttribute>
+      <!--MyCustomExcludeFromCodeCoverage-->
+    </ExcludeByAttribute>
+    <IncludeTestAssembly>
+      False
+    </IncludeTestAssembly>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<!-- Link all .cs files from UnitTests, excluding bin and obj folders -->
+		<Compile Include="../UnitTests/**/*.cs" Exclude="../UnitTests/**/bin/**;../UnitTests/**/obj/**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+		<!-- Link other potential files like .cshtml, .resx, etc., if needed -->
+		<None Include="../UnitTests/**/*.*" Exclude="../UnitTests/**/bin/**;../UnitTests/**/obj/**;../UnitTests/MoqTests/**;../UnitTests/**/*.cs;../UnitTests/**/*.csproj;../UnitTests/**/*.sln" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!-- Reference the original project to ensure dependencies are included -->
+		<ProjectReference Include="..\UnitTests\UnitTests.csproj" />
+		<TrimmerRootAssembly Include="Tests.UnitTests.AOT" />
+		<TrimmerRootAssembly Include="..\..\Terminal.Gui\Terminal.Gui.csproj" />
+	</ItemGroup>
+</Project>

--- a/Tests/UnitTests/UnitTests.csproj
+++ b/Tests/UnitTests/UnitTests.csproj
@@ -57,9 +57,6 @@
 		<Using Include="Terminal.Gui" />
 		<Using Include="Xunit" />
 	</ItemGroup>
-	<ItemGroup>
-		<Folder Include="Input\Mouse\" />
-	</ItemGroup>
 	<PropertyGroup Label="FineCodeCoverage">
 		<Enabled>
 			False


### PR DESCRIPTION
## Fixes

- Fixes #4102

## Proposed Changes/Todos

- [x] Add `UnitTests.AOT` project
- [ ] Add skip AOT unit tests for `Moq` packages due to not be AOT compatible. Our concern is only to make `Terminal.Gui` AOT compatible

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
