### PR TITLE
Fixes #4139. Application.Run<T> isn't initializing properly by setting the Application.ForceDriver property

### DIFF
--- a/Examples/UICatalog/Properties/launchSettings.json
+++ b/Examples/UICatalog/Properties/launchSettings.json
@@ -32,6 +32,13 @@
       "commandLineArgs": "dotnet UICatalog.dll --driver NetDriver",
       "distributionName": ""
     },
+    "WSL: UICatalog --driver v2net": {
+      "commandName": "Executable",
+      "executablePath": "wsl",
+      "commandLineArgs": "dotnet UICatalog.dll --driver v2net",
+      "distributionName": ""
+    },
+
     "Benchmark All": {
       "commandName": "Project",
       "commandLineArgs": "--benchmark"

--- a/Terminal.Gui/App/Application.Initialization.cs
+++ b/Terminal.Gui/App/Application.Initialization.cs
@@ -77,6 +77,17 @@ public static partial class Application // Initialization (Init/Shutdown)
             throw new InvalidOperationException ("Init has already been called and must be bracketed by Shutdown.");
         }
 
+        var driverNameOrForceDriver = driverName ?? ForceDriver;
+
+        if (driverNameOrForceDriver?.StartsWith ("v2") ?? false)
+        {
+            ApplicationImpl.ChangeInstance (new ApplicationV2 ());
+            ApplicationImpl.Instance.Init (driver, driverNameOrForceDriver);
+            Debug.Assert (Driver is { });
+
+            return;
+        }
+
         if (!calledViaRunT)
         {
             // Reset all class variables (Application is a singleton).

--- a/Terminal.Gui/App/ApplicationImpl.cs
+++ b/Terminal.Gui/App/ApplicationImpl.cs
@@ -34,7 +34,7 @@ public class ApplicationImpl : IApplication
     [RequiresDynamicCode ("AOT")]
     public virtual void Init (IConsoleDriver? driver = null, string? driverName = null)
     {
-        Application.InternalInit (driver, driverName);
+        Application.InternalInit (driver, driverName ?? Application.ForceDriver);
     }
 
     /// <summary>
@@ -85,7 +85,12 @@ public class ApplicationImpl : IApplication
         if (!Application.Initialized)
         {
             // Init() has NOT been called.
-            Application.InternalInit (driver, null, true);
+            Application.InternalInit (driver, Application.ForceDriver, true);
+        }
+
+        if (Instance is ApplicationV2)
+        {
+            return Instance.Run<T> (errorHandler, driver);
         }
 
         var top = new T ();
@@ -227,6 +232,8 @@ public class ApplicationImpl : IApplication
 
             Application.OnInitializedChanged (this, new (in init));
         }
+
+        _lazyInstance = new (() => new ApplicationImpl ());
     }
 
     /// <inheritdoc />

--- a/Terminal.Gui/Drivers/V2/ConsoleDriverFacade.cs
+++ b/Terminal.Gui/Drivers/V2/ConsoleDriverFacade.cs
@@ -64,7 +64,19 @@ internal class ConsoleDriverFacade<T> : IConsoleDriver, IConsoleDriverFacade
     }
 
     /// <summary>Gets the location and size of the terminal screen.</summary>
-    public Rectangle Screen => new (new (0, 0), _output.GetWindowSize ());
+    public Rectangle Screen
+    {
+        get
+        {
+            if (ConsoleDriver.RunningUnitTests)
+            {
+                // In unit tests, we don't have a real output, so we return an empty rectangle.
+                return Rectangle.Empty;
+            }
+
+            return new (new (0, 0), _output.GetWindowSize ());
+        }
+    }
 
     /// <summary>
     ///     Gets or sets the clip rectangle that <see cref="AddRune(Rune)"/> and <see cref="AddStr(string)"/> are subject

--- a/Terminal.Gui/Drivers/V2/NetOutput.cs
+++ b/Terminal.Gui/Drivers/V2/NetOutput.cs
@@ -47,6 +47,11 @@ public class NetOutput : IConsoleOutput
     /// <inheritdoc/>
     public void Write (IOutputBuffer buffer)
     {
+        if (ConsoleDriver.RunningUnitTests)
+        {
+            return;
+        }
+
         if (Console.WindowHeight < 1
             || buffer.Contents.Length != buffer.Rows * buffer.Cols
             || buffer.Rows != Console.WindowHeight)
@@ -197,7 +202,16 @@ public class NetOutput : IConsoleOutput
     }
 
     /// <inheritdoc/>
-    public Size GetWindowSize () { return new (Console.WindowWidth, Console.WindowHeight); }
+    public Size GetWindowSize ()
+    {
+        if (ConsoleDriver.RunningUnitTests)
+        {
+            // For unit tests, we return a default size.
+            return Size.Empty;
+        }
+
+        return new (Console.WindowWidth, Console.WindowHeight);
+    }
 
     private void WriteToConsole (StringBuilder output, ref int lastCol, int row, ref int outputWidth)
     {

--- a/Terminal.Gui/Drivers/V2/WindowSizeMonitor.cs
+++ b/Terminal.Gui/Drivers/V2/WindowSizeMonitor.cs
@@ -20,6 +20,11 @@ internal class WindowSizeMonitor : IWindowSizeMonitor
     /// <inheritdoc/>
     public bool Poll ()
     {
+        if (ConsoleDriver.RunningUnitTests)
+        {
+            return false;
+        }
+
         Size size = _consoleOut.GetWindowSize ();
 
         if (size != _lastSize)

--- a/Terminal.Gui/Drivers/V2/WindowsInput.cs
+++ b/Terminal.Gui/Drivers/V2/WindowsInput.cs
@@ -38,6 +38,12 @@ internal class WindowsInput : ConsoleInput<WindowsConsole.InputRecord>, IWindows
     public WindowsInput ()
     {
         Logging.Logger.LogInformation ($"Creating {nameof (WindowsInput)}");
+
+        if (ConsoleDriver.RunningUnitTests)
+        {
+            return;
+        }
+
         _inputHandle = GetStdHandle (STD_INPUT_HANDLE);
 
         GetConsoleMode (_inputHandle, out uint v);
@@ -110,5 +116,13 @@ internal class WindowsInput : ConsoleInput<WindowsConsole.InputRecord>, IWindows
         }
     }
 
-    public override void Dispose () { SetConsoleMode (_inputHandle, _originalConsoleMode); }
+    public override void Dispose ()
+    {
+        if (ConsoleDriver.RunningUnitTests)
+        {
+            return;
+        }
+
+        SetConsoleMode (_inputHandle, _originalConsoleMode);
+    }
 }

--- a/Terminal.Gui/Drivers/V2/WindowsOutput.cs
+++ b/Terminal.Gui/Drivers/V2/WindowsOutput.cs
@@ -68,6 +68,11 @@ internal partial class WindowsOutput : IConsoleOutput
     {
         Logging.Logger.LogInformation ($"Creating {nameof (WindowsOutput)}");
 
+        if (ConsoleDriver.RunningUnitTests)
+        {
+            return;
+        }
+
         _screenBuffer = CreateConsoleScreenBuffer (
                                                    DesiredAccess.GenericRead | DesiredAccess.GenericWrite,
                                                    ShareMode.FileShareRead | ShareMode.FileShareWrite,
@@ -171,12 +176,13 @@ internal partial class WindowsOutput : IConsoleOutput
         };
 
         //size, ExtendedCharInfo [] charInfoBuffer, Coord , SmallRect window,
-        if (!WriteToConsole (
-                             new (buffer.Cols, buffer.Rows),
-                             outputBuffer,
-                             bufferCoords,
-                             damageRegion,
-                             Application.Driver!.Force16Colors))
+        if (!ConsoleDriver.RunningUnitTests
+            && !WriteToConsole (
+                                new (buffer.Cols, buffer.Rows),
+                                outputBuffer,
+                                bufferCoords,
+                                damageRegion,
+                                Application.Driver!.Force16Colors))
         {
             int err = Marshal.GetLastWin32Error ();
 
@@ -312,6 +318,11 @@ internal partial class WindowsOutput : IConsoleOutput
     /// <inheritdoc/>
     public void SetCursorVisibility (CursorVisibility visibility)
     {
+        if (ConsoleDriver.RunningUnitTests)
+        {
+            return;
+        }
+
         if (Application.Driver!.Force16Colors)
         {
             var info = new WindowsConsole.ConsoleCursorInfo

--- a/Tests/UnitTests/Application/ApplicationTests.cs
+++ b/Tests/UnitTests/Application/ApplicationTests.cs
@@ -655,7 +655,17 @@ public class ApplicationTests
         Assert.NotNull (SynchronizationContext.Current);
     }
 
-    private void Shutdown () { Application.Shutdown (); }
+    private void Shutdown ()
+    {
+        if (ApplicationImpl.Instance is ApplicationV2)
+        {
+            ApplicationImpl.Instance.Shutdown ();
+        }
+        else
+        {
+            Application.Shutdown ();
+        }
+    }
 
     #region RunTests
 
@@ -1102,6 +1112,45 @@ public class ApplicationTests
 
         Application.Shutdown ();
         Assert.Null (Application.Top);
+    }
+
+    private class TestToplevel : Toplevel { }
+
+    [Theory]
+    [InlineData ("v2win", typeof (ConsoleDriverFacade<WindowsConsole.InputRecord>))]
+    [InlineData ("v2net", typeof (ConsoleDriverFacade<ConsoleKeyInfo>))]
+    [InlineData ("FakeDriver", typeof (FakeDriver))]
+    [InlineData ("NetDriver", typeof (NetDriver))]
+    [InlineData ("WindowsDriver", typeof (WindowsDriver))]
+    [InlineData ("CursesDriver", typeof (CursesDriver))]
+    public void Run_T_Call_Init_ForceDriver_Should_Pick_Correct_Driver (string driverName, Type expectedType)
+    {
+        var result = false;
+
+        Task.Run (() =>
+                  {
+                      Task.Delay (300).Wait ();
+                  }).ContinueWith (
+                                   (t, _) =>
+                                   {
+                                       // no longer loading
+                                       Application.Invoke (() =>
+                                                           {
+                                                               result = true;
+                                                               Application.RequestStop ();
+                                                           });
+                                   },
+                                   TaskScheduler.FromCurrentSynchronizationContext ());
+
+        Application.ForceDriver = driverName;
+        Application.Run<TestToplevel> ();
+        Assert.NotNull (Application.Driver);
+        Assert.Equal (expectedType, Application.Driver?.GetType ());
+        Assert.NotNull (Application.Top);
+        Assert.False (Application.Top!.Running);
+        Application.Top!.Dispose ();
+        Shutdown ();
+        Assert.True (result);
     }
 
     // TODO: Add tests for Run that test errorHandler

--- a/Tests/UnitTests/ConsoleDrivers/V2/ApplicationV2Tests.cs
+++ b/Tests/UnitTests/ConsoleDrivers/V2/ApplicationV2Tests.cs
@@ -362,7 +362,6 @@ public class ApplicationV2Tests
                                               if (Application.Top != null)
                                               {
                                                   Application.RaiseKeyDownEvent (Application.QuitKey);
-                                                  return false;
                                               }
 
                                               return false;
@@ -575,8 +574,6 @@ public class ApplicationV2Tests
                                               {
                                                   b.NewKeyDownEvent (Key.Enter);
                                                   b.NewKeyUpEvent (Key.Enter);
-
-                                                  return false;
                                               }
 
                                               return false;


### PR DESCRIPTION
## Fixes

- Fixes #4139

## Proposed Changes/Todos

- [x] Add WSL: UICatalog --driver v2net to the launchSettings.json
- [x] Checking for v2 drivers in the `InternalInit` method
- [x] Using ForceDriver if the driverName is null
- [x] Ensuring the running the correct app Instance
- [x] Reset _lazyInstance on Shutdown
- [x] Avoiding run console functions when running unit tests

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
