### PR TITLE
Fixes #4160. Benchmark All launch throws System.IndexOutOfRangeException: 'Index was outside the bounds of the array.'

### DIFF
--- a/Examples/UICatalog/UICatalog.cs
+++ b/Examples/UICatalog/UICatalog.cs
@@ -428,11 +428,6 @@ public class UICatalog
 
         Application.Init (driverName: _forceDriver);
 
-        if (benchmark)
-        {
-            Application.Screen = new (0, 0, 120, 40);
-        }
-
         scenario.Main ();
 
         BenchmarkResults? results = null;


### PR DESCRIPTION
## Fixes

- Fixes #4160

## Proposed Changes/Todos

- [x] `Application.Screen` cannot be larger than the terminal size.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
