### PR TITLE
Fixes #4162. Keyword dynamic isn't AOT-Compatible and must be removed

### DIFF
--- a/Examples/UICatalog/Scenarios/NumericUpDownDemo.cs
+++ b/Examples/UICatalog/Scenarios/NumericUpDownDemo.cs
@@ -252,7 +252,7 @@ internal class NumericUpDownEditor<T> : View where T : notnull
             {
                 X = Pos.Center (),
                 Y = Pos.Bottom (_increment) + 1,
-                Increment = (dynamic)1,
+                Increment = NumericUpDown<int>.TryConvert (1, out T? increment) ? increment : default,
             };
 
             _numericUpDown.ValueChanged += NumericUpDownOnValueChanged;

--- a/Examples/UICatalog/Scenarios/TextAlignmentAndDirection.cs
+++ b/Examples/UICatalog/Scenarios/TextAlignmentAndDirection.cs
@@ -410,7 +410,7 @@ public class TextAlignmentAndDirection : Scenario
         // Save Alignment in Data
         foreach (View t in multiLineLabels)
         {
-            t.Data = new { h = t.TextAlignment, v = t.VerticalTextAlignment };
+            t.Data = new TextAlignmentData (t.TextAlignment, t.VerticalTextAlignment);
         }
 
         container.Add (txtLabelTL);
@@ -594,8 +594,9 @@ public class TextAlignmentAndDirection : Scenario
 
                 foreach (View t in multiLineLabels)
                 {
-                    t.TextAlignment = (Alignment)((dynamic)t.Data).h;
-                    t.VerticalTextAlignment = (Alignment)((dynamic)t.Data).v;
+                    var data = (TextAlignmentData)t.Data;
+                    t.TextAlignment = data!.h;
+                    t.VerticalTextAlignment = data.v;
                 }
             }
             else
@@ -607,24 +608,23 @@ public class TextAlignmentAndDirection : Scenario
                         justifyOptions.Enabled = true;
                     }
 
+                    var data = (TextAlignmentData)t.Data;
+
                     if (TextFormatter.IsVerticalDirection (t.TextDirection))
                     {
                         switch (justifyOptions.SelectedItem)
                         {
                             case 0:
                                 t.VerticalTextAlignment = Alignment.Fill;
-                                t.TextAlignment = ((dynamic)t.Data).h;
-
+                                t.TextAlignment = data!.h;
                                 break;
                             case 1:
-                                t.VerticalTextAlignment = (Alignment)((dynamic)t.Data).v;
+                                t.VerticalTextAlignment = data!.v;
                                 t.TextAlignment = Alignment.Fill;
-
                                 break;
                             case 2:
                                 t.VerticalTextAlignment = Alignment.Fill;
                                 t.TextAlignment = Alignment.Fill;
-
                                 break;
                         }
                     }
@@ -634,23 +634,26 @@ public class TextAlignmentAndDirection : Scenario
                         {
                             case 0:
                                 t.TextAlignment = Alignment.Fill;
-                                t.VerticalTextAlignment = ((dynamic)t.Data).v;
-
+                                t.VerticalTextAlignment = data!.v;
                                 break;
                             case 1:
-                                t.TextAlignment = (Alignment)((dynamic)t.Data).h;
+                                t.TextAlignment = data!.h;
                                 t.VerticalTextAlignment = Alignment.Fill;
-
                                 break;
                             case 2:
                                 t.TextAlignment = Alignment.Fill;
                                 t.VerticalTextAlignment = Alignment.Fill;
-
                                 break;
                         }
                     }
                 }
             }
         }
+    }
+
+    private class TextAlignmentData (Alignment h, Alignment v)
+    {
+        public Alignment h { get; } = h;
+        public Alignment v { get; } = v;
     }
 }

--- a/Terminal.Gui/ViewBase/View.Layout.cs
+++ b/Terminal.Gui/ViewBase/View.Layout.cs
@@ -730,8 +730,6 @@ public partial class View // Layout APIs
     /// </value>
     public bool NeedsLayout { get; private set; } = true;
 
-    private readonly object _layoutLock = new ();
-
     /// <summary>
     ///     Sets <see cref="NeedsLayout"/> to return <see langword="true"/>, indicating this View and all of it's subviews
     ///     (including adornments) need to be laid out in the next Application iteration.
@@ -765,35 +763,32 @@ public partial class View // Layout APIs
         // Use a stack to avoid recursion
         Stack<View> stack = new (SubViews);
 
-        lock (_layoutLock)
+        while (stack.Count > 0)
         {
-            while (stack.Count > 0)
+            View current = stack.Pop ();
+
+            if (!current.NeedsLayout)
             {
-                View current = stack.Pop ();
+                current.NeedsLayout = true;
 
-                if (!current.NeedsLayout)
+                if (current.Margin is { SubViews.Count: > 0 })
                 {
-                    current.NeedsLayout = true;
+                    current.Margin.SetNeedsLayout ();
+                }
 
-                    if (current.Margin is { SubViews.Count: > 0 })
-                    {
-                        current.Margin.SetNeedsLayout ();
-                    }
+                if (current.Border is { SubViews.Count: > 0 })
+                {
+                    current.Border.SetNeedsLayout ();
+                }
 
-                    if (current.Border is { SubViews.Count: > 0 })
-                    {
-                        current.Border.SetNeedsLayout ();
-                    }
+                if (current.Padding is { SubViews.Count: > 0 })
+                {
+                    current.Padding.SetNeedsLayout ();
+                }
 
-                    if (current.Padding is { SubViews.Count: > 0 })
-                    {
-                        current.Padding.SetNeedsLayout ();
-                    }
-
-                    foreach (View subview in current.SubViews)
-                    {
-                        stack.Push (subview);
-                    }
+                foreach (View subview in current.SubViews)
+                {
+                    stack.Push (subview);
                 }
             }
         }

--- a/Terminal.Gui/ViewBase/View.Layout.cs
+++ b/Terminal.Gui/ViewBase/View.Layout.cs
@@ -730,6 +730,8 @@ public partial class View // Layout APIs
     /// </value>
     public bool NeedsLayout { get; private set; } = true;
 
+    private readonly object _layoutLock = new ();
+
     /// <summary>
     ///     Sets <see cref="NeedsLayout"/> to return <see langword="true"/>, indicating this View and all of it's subviews
     ///     (including adornments) need to be laid out in the next Application iteration.
@@ -763,32 +765,35 @@ public partial class View // Layout APIs
         // Use a stack to avoid recursion
         Stack<View> stack = new (SubViews);
 
-        while (stack.Count > 0)
+        lock (_layoutLock)
         {
-            View current = stack.Pop ();
-
-            if (!current.NeedsLayout)
+            while (stack.Count > 0)
             {
-                current.NeedsLayout = true;
+                View current = stack.Pop ();
 
-                if (current.Margin is { SubViews.Count: > 0 })
+                if (!current.NeedsLayout)
                 {
-                    current.Margin.SetNeedsLayout ();
-                }
+                    current.NeedsLayout = true;
 
-                if (current.Border is { SubViews.Count: > 0 })
-                {
-                    current.Border.SetNeedsLayout ();
-                }
+                    if (current.Margin is { SubViews.Count: > 0 })
+                    {
+                        current.Margin.SetNeedsLayout ();
+                    }
 
-                if (current.Padding is { SubViews.Count: > 0 })
-                {
-                    current.Padding.SetNeedsLayout ();
-                }
+                    if (current.Border is { SubViews.Count: > 0 })
+                    {
+                        current.Border.SetNeedsLayout ();
+                    }
 
-                foreach (View subview in current.SubViews)
-                {
-                    stack.Push (subview);
+                    if (current.Padding is { SubViews.Count: > 0 })
+                    {
+                        current.Padding.SetNeedsLayout ();
+                    }
+
+                    foreach (View subview in current.SubViews)
+                    {
+                        stack.Push (subview);
+                    }
                 }
             }
         }

--- a/Terminal.Gui/Views/NumericUpDown.cs
+++ b/Terminal.Gui/Views/NumericUpDown.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.ComponentModel;
+using System.Numerics;
 
 namespace Terminal.Gui.Views;
 
@@ -26,13 +27,7 @@ public class NumericUpDown<T> : View where T : notnull
     {
         Type type = typeof (T);
 
-        if (!(type == typeof (object)
-              || type == typeof (int)
-              || type == typeof (long)
-              || type == typeof (double)
-              || type == typeof (float)
-              || type == typeof (double)
-              || type == typeof (decimal)))
+        if (!(type == typeof (object) || NumericHelper.SupportsType (type)))
         {
             throw new InvalidOperationException ("T must be a numeric type that supports addition and subtraction.");
         }
@@ -40,8 +35,20 @@ public class NumericUpDown<T> : View where T : notnull
         // `object` is supported only for AllViewsTester
         if (type != typeof (object))
         {
-            Increment = (dynamic)1;
-            Value = (dynamic)0;
+            try
+            {
+                if (NumericHelper.TryGetHelper (typeof (T), out INumericHelper? helper))
+                {
+                    Increment = (T)helper!.One;
+                    Value = (T)helper!.Zero;
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine (e);
+
+                throw;
+            }
         }
 
         Width = Dim.Auto (DimAutoStyle.Content);
@@ -106,11 +113,10 @@ public class NumericUpDown<T> : View where T : notnull
                         //    return true;
                         //}
 
-                        if (Value is { } && Increment is { })
+                        if (Value is { } v && Increment is { } i && NumericHelper.TryGetHelper (typeof (T), out INumericHelper? helper))
                         {
-                            Value = (dynamic)Value + (dynamic)Increment;
+                            Value = (T)helper!.Add (v, i);
                         }
-
                         return true;
                     });
 
@@ -129,12 +135,10 @@ public class NumericUpDown<T> : View where T : notnull
                         //    return true;
                         //}
 
-                        if (Value is { } && Increment is { })
+                        if (Value is { } v && Increment is { } i && NumericHelper.TryGetHelper (typeof (T), out INumericHelper? helper))
                         {
-                            Value = (dynamic)Value - (dynamic)Increment;
+                            Value = (T)helper!.Subtract (v, i);
                         }
-
-
                         return true;
                     });
 
@@ -248,7 +252,7 @@ public class NumericUpDown<T> : View where T : notnull
         get => _increment;
         set
         {
-            if (_increment is { } && value is { } && (dynamic)_increment == (dynamic)value)
+            if (_increment is { } oldVal && value is { } newVal && oldVal.Equals (newVal))
             {
                 return;
             }
@@ -267,6 +271,34 @@ public class NumericUpDown<T> : View where T : notnull
     // Prevent the drawing of Text
     /// <inheritdoc />
     protected override bool OnDrawingText () { return true; }
+
+    /// <summary>
+    ///     Attempts to convert the specified <paramref name="value"/> to type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type to which the value should be converted.</typeparam>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="result">
+    ///     When this method returns, contains the converted value if the conversion succeeded,
+    ///     or the default value of <typeparamref name="T"/> if the conversion failed.
+    /// </param>
+    /// <returns>
+    ///     <c>true</c> if the conversion was successful; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool TryConvert<T> (object value, out T? result)
+    {
+        try
+        {
+            result = (T)Convert.ChangeType (value, typeof (T));
+
+            return true;
+        }
+        catch
+        {
+            result = default (T);
+
+            return false;
+        }
+    }
 }
 
 /// <summary>
@@ -274,3 +306,45 @@ public class NumericUpDown<T> : View where T : notnull
 /// </summary>
 public class NumericUpDown : NumericUpDown<int>
 { }
+
+internal interface INumericHelper
+{
+    object One { get; }
+    object Zero { get; }
+    object Add (object a, object b);
+    object Subtract (object a, object b);
+}
+
+internal static class NumericHelper
+{
+    private static readonly Dictionary<Type, INumericHelper> _helpers = new ();
+
+    static NumericHelper ()
+    {
+        // Register known INumber<T> types
+        Register<int> ();
+        Register<long> ();
+        Register<float> ();
+        Register<double> ();
+        Register<decimal> ();
+        // Add more as needed
+    }
+
+    private static void Register<T> () where T : INumber<T>
+    {
+        _helpers [typeof (T)] = new NumericHelperImpl<T> ();
+    }
+
+    public static bool TryGetHelper (Type t, out INumericHelper? helper)
+        => _helpers.TryGetValue (t, out helper);
+
+    private class NumericHelperImpl<T> : INumericHelper where T : INumber<T>
+    {
+        public object One => T.One;
+        public object Zero => T.Zero;
+        public object Add (object a, object b) => (T)a + (T)b;
+        public object Subtract (object a, object b) => (T)a - (T)b;
+    }
+
+    public static bool SupportsType (Type type) => _helpers.ContainsKey (type);
+}

--- a/Terminal.Gui/Views/NumericUpDown.cs
+++ b/Terminal.Gui/Views/NumericUpDown.cs
@@ -35,19 +35,10 @@ public class NumericUpDown<T> : View where T : notnull
         // `object` is supported only for AllViewsTester
         if (type != typeof (object))
         {
-            try
+            if (NumericHelper.TryGetHelper (typeof (T), out INumericHelper? helper))
             {
-                if (NumericHelper.TryGetHelper (typeof (T), out INumericHelper? helper))
-                {
-                    Increment = (T)helper!.One;
-                    Value = (T)helper!.Zero;
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine (e);
-
-                throw;
+                Increment = (T)helper!.One;
+                Value = (T)helper!.Zero;
             }
         }
 

--- a/Tests/UnitTestsParallelizable/Views/NumericUpDownTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/NumericUpDownTests.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using Xunit.Abstractions;
 
 namespace Terminal.Gui.ViewsTests;
 
@@ -100,6 +99,13 @@ public class NumericUpDownTests
     {
         Exception exception = Record.Exception (() => new NumericUpDown<object> ());
         Assert.Null (exception);
+    }
+
+    [Fact]
+    public void WhenCreatedWithValidNumberType_ShouldThrowInvalidOperationException_UnlessTheyAreRegisterAsValid ()
+    {
+        Exception exception = Record.Exception (() => new NumericUpDown<short> ());
+        Assert.NotNull (exception);
     }
 
     [Fact]


### PR DESCRIPTION
## Fixes

- Fixes #4162

## Proposed Changes/Todos

- [x] Replaced with helper classes

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
