### PR TITLE
Fixes #4167. Button is always raising Accepting event 2 more times by mouse

### DIFF
--- a/Examples/UICatalog/Scenarios/Generic.cs
+++ b/Examples/UICatalog/Scenarios/Generic.cs
@@ -27,8 +27,6 @@ public sealed class Generic : Scenario
 
         button.Accepting += (s, e) =>
                             {
-                                // When Accepting is handled, set e.Handled to true to prevent further processing.
-                                e.Handled = true;
                                 MessageBox.ErrorQuery ("Error", "You pressed the button!", "_Ok");
                             };
 

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -99,6 +99,7 @@ public class Button : View, IDesignable
 
         return false;
     }
+
     private void Button_MouseClick (object sender, MouseEventArgs e)
     {
         if (e.Handled)
@@ -107,7 +108,8 @@ public class Button : View, IDesignable
         }
 
         // TODO: With https://github.com/gui-cs/Terminal.Gui/issues/3778 we won't have to pass data:
-        e.Handled = InvokeCommand<KeyBinding> (Command.HotKey, new KeyBinding ([Command.HotKey], this, data: null)) == true;
+        InvokeCommand<KeyBinding> (Command.HotKey, new KeyBinding ([Command.HotKey], this, data: null));
+        e.Handled = true;
     }
 
     private void Button_TitleChanged (object sender, EventArgs<string> e)


### PR DESCRIPTION
## Fixes

- Fixes #4167

## Proposed Changes/Todos

- [x] Button must always set `Handled = true` no matter what the user have done to prevent further processing to itself

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
