### PR TITLE
Cleanup Dependencies slighty

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="[4.11,4.12)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[9.0.2,10)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="[9.0.2,10)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6" />
     <PackageVersion Include="System.IO.Abstractions" Version="[22.0.11,23)" />
     <PackageVersion Include="Wcwidth" Version="[2,3)" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="[1.21.2,2)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="[9.0.2,10)" />
     <PackageVersion Include="System.IO.Abstractions" Version="[22.0.11,23)" />
-    <PackageVersion Include="System.Text.Json" Version="[8.0.5,9)" />
     <PackageVersion Include="Wcwidth" Version="[2,3)" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="[1.21.2,2)" />
     <PackageVersion Include="Serilog" Version="4.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="[4.11,4.12)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="[4.11,4.12)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[9.0.2,10)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="[9.0.2,10)" />
     <PackageVersion Include="System.IO.Abstractions" Version="[22.0.11,23)" />
     <PackageVersion Include="Wcwidth" Version="[2,3)" />

--- a/Examples/UICatalog/Scenarios/Scrolling.cs
+++ b/Examples/UICatalog/Scenarios/Scrolling.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
-namespace UICatalog.Scenarios;
+﻿namespace UICatalog.Scenarios;
 
 [ScenarioMetadata ("Scrolling", "Content scrolling, IScrollBars, etc...")]
 [ScenarioCategory ("Controls")]

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -62,7 +62,6 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="System.IO.Abstractions" />
-        <PackageReference Include="System.Text.Json" />
         <PackageReference Include="Wcwidth" />
     </ItemGroup>
 

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -64,8 +64,11 @@
         <PackageReference Include="System.IO.Abstractions" />
         <PackageReference Include="System.Text.Json" />
         <PackageReference Include="Wcwidth" />
-        <!-- Enable Nuget Source Link for github -->
-        <PackageReference Include="Microsoft.SourceLink.GitHub" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Enable Nuget Source Link for github -->
+      <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     </ItemGroup>
     <!-- =================================================================== -->
     <!-- Global Usings and Type Aliases -->

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -57,9 +57,6 @@
     <ItemGroup>
         <PackageReference Include="ColorHelper" />
         <PackageReference Include="JetBrains.Annotations" />
-        <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions " />
         <PackageReference Include="System.IO.Abstractions" />
         <PackageReference Include="Wcwidth" />

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -60,7 +60,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis" />
         <PackageReference Include="Microsoft.CodeAnalysis.Common" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions " />
         <PackageReference Include="System.IO.Abstractions" />
         <PackageReference Include="Wcwidth" />
     </ItemGroup>

--- a/Tests/TerminalGuiFluentTesting/TerminalGuiFluentTesting.csproj
+++ b/Tests/TerminalGuiFluentTesting/TerminalGuiFluentTesting.csproj
@@ -11,4 +11,8 @@
 		<ProjectReference Include="..\..\Terminal.Gui\Terminal.Gui.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Fixes

- Fixes dependencies in the main library

## Proposed Changes/Todos

- SourceLink should be used with PrivateAssets
- The System.Text.Json reference is unnecessary since NET8 has that included and nothing specific from v9 or higher is used
- Logging abstractions should be used instead of logging since nothing in the code depends directly on specific logging things
- Code Analysis references are also not needed in the main lib

I think overall the dependencies and the management of the dependencies needs a bit of an overhaul. For example mixing in the central package management the shippable references with ranges together with all others makes it difficult to follow what is needed and why. It might even be possible to even further improve things, but I ran out of time.

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
