### PR TITLE
Fixes #4180. Update outdated doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ The full developer documentation for Terminal.Gui is available at [gui-cs.github
 
 ## Getting Started
 
-- [Getting Started](https://gui-cs.github.io/Terminal.Gui/docs/getting-started.md) - Quick start guide to create your first Terminal.Gui application
-- [Migrating from v1 to v2](https://gui-cs.github.io/Terminal.Gui/docs/migratingfromv1.md) - Complete guide for upgrading existing applications
-- [What's New in v2](https://gui-cs.github.io/Terminal.Gui/docs/newinv2.md) - Overview of new features and improvements
+- [Getting Started](https://gui-cs.github.io/Terminal.Gui/docs/getting-started) - Quick start guide to create your first Terminal.Gui application
+- [Migrating from v1 to v2](https://gui-cs.github.io/Terminal.Gui/docs/migratingfromv1) - Complete guide for upgrading existing applications
+- [What's New in v2](https://gui-cs.github.io/Terminal.Gui/docs/newinv2) - Overview of new features and improvements
 
 ## API Reference
 


### PR DESCRIPTION
## Proposed Changes/Todos

- [x] Fix outdated links (they still use `.md` suffix)
- [ ] Shall we also add `dotnet new install Terminal.Gui.Templates::2.0.0-v2-develop.2203` to the Quick Start part as per #3746?

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] I have checked my code and corrected any poor grammar or misspellings
