### PR TITLE
Fixes 4191 - Consider width 2 chars that are not IsBmp

### DIFF
--- a/Terminal.Gui/Drivers/V2/MainLoopCoordinator.cs
+++ b/Terminal.Gui/Drivers/V2/MainLoopCoordinator.cs
@@ -25,7 +25,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
     private ConsoleDriverFacade<T> _facade;
     private Task _inputTask;
     private readonly ITimedEvents _timedEvents;
-    private readonly bool _isWindowsTerminal;
 
     private readonly SemaphoreSlim _startupSemaphore = new (0, 1);
 
@@ -61,7 +60,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
         _inputProcessor = inputProcessor;
         _outputFactory = outputFactory;
         _loop = loop;
-        _isWindowsTerminal = Environment.GetEnvironmentVariable ("WT_SESSION") is { } || Environment.GetEnvironmentVariable ("VSAPPIDNAME") != null;
     }
 
     /// <summary>
@@ -161,11 +159,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
                            _output,
                            _loop.AnsiRequestScheduler,
                            _loop.WindowSizeMonitor);
-
-            if (!_isWindowsTerminal)
-            {
-                Application.Force16Colors = _facade.Force16Colors = true;
-            }
 
             Application.Driver = _facade;
 

--- a/Terminal.Gui/Drivers/V2/WindowsOutput.cs
+++ b/Terminal.Gui/Drivers/V2/WindowsOutput.cs
@@ -146,7 +146,7 @@ internal partial class WindowsOutput : IConsoleOutput
 
                 outputBuffer [position].Empty = false;
 
-                var rune = buffer.Contents [row, col].Rune;
+                Rune rune = buffer.Contents [row, col].Rune;
                 int width = rune.GetColumns ();
 
                 if (rune.IsBmp)

--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsDriver.cs
@@ -344,37 +344,16 @@ internal class WindowsDriver : ConsoleDriver
 
                 _outputBuffer [position].Empty = false;
 
-                Rune rune = Contents [row, col].Rune;
-                int width = rune.GetColumns ();
-
-                if (rune.IsBmp)
+                if (Contents [row, col].Rune.IsBmp)
                 {
-                    if (width == 1)
-                    {
-                        // Single-width char, just encode first UTF-16 char
-                        _outputBuffer [position].Char = (char)rune.Value;
-                    }
-                    else if (width == 2 && col + 1 < Cols)
-                    {
-                        // Double-width char: encode to UTF-16 surrogate pair and write both halves
-                        var utf16 = new char [2];
-                        rune.EncodeToUtf16 (utf16);
-                        _outputBuffer [position].Char = utf16 [0];
-                        _outputBuffer [position].Empty = false;
-
-                        // Write second half into next cell
-                        col++;
-                        position = row * Cols + col;
-                        _outputBuffer [position].Char = utf16 [1];
-                        _outputBuffer [position].Empty = false;
-                    }
+                    _outputBuffer [position].Char = (char)Contents [row, col].Rune.Value;
                 }
                 else
                 {
                     //_outputBuffer [position].Empty = true;
                     _outputBuffer [position].Char = (char)Rune.ReplacementChar.Value;
 
-                    if (width > 1 && col + 1 < Cols)
+                    if (Contents [row, col].Rune.GetColumns () > 1 && col + 1 < Cols)
                     {
                         // TODO: This is a hack to deal with non-BMP and wide characters.
                         col++;

--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsDriver.cs
@@ -344,16 +344,37 @@ internal class WindowsDriver : ConsoleDriver
 
                 _outputBuffer [position].Empty = false;
 
-                if (Contents [row, col].Rune.IsBmp)
+                var rune = Contents [row, col].Rune;
+                int width = rune.GetColumns ();
+
+                if (rune.IsBmp)
                 {
-                    _outputBuffer [position].Char = (char)Contents [row, col].Rune.Value;
+                    if (width == 1)
+                    {
+                        // Single-width char, just encode first UTF-16 char
+                        _outputBuffer [position].Char = (char)rune.Value;
+                    }
+                    else if (width == 2 && col + 1 < Cols)
+                    {
+                        // Double-width char: encode to UTF-16 surrogate pair and write both halves
+                        var utf16 = new char [2];
+                        rune.EncodeToUtf16 (utf16);
+                        _outputBuffer [position].Char = utf16 [0];
+                        _outputBuffer [position].Empty = false;
+
+                        // Write second half into next cell
+                        col++;
+                        position = row * Cols + col;
+                        _outputBuffer [position].Char = utf16 [1];
+                        _outputBuffer [position].Empty = false;
+                    }
                 }
                 else
                 {
                     //_outputBuffer [position].Empty = true;
                     _outputBuffer [position].Char = (char)Rune.ReplacementChar.Value;
 
-                    if (Contents [row, col].Rune.GetColumns () > 1 && col + 1 < Cols)
+                    if (width > 1 && col + 1 < Cols)
                     {
                         // TODO: This is a hack to deal with non-BMP and wide characters.
                         col++;

--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsDriver.cs
@@ -344,7 +344,7 @@ internal class WindowsDriver : ConsoleDriver
 
                 _outputBuffer [position].Empty = false;
 
-                var rune = Contents [row, col].Rune;
+                Rune rune = Contents [row, col].Rune;
                 int width = rune.GetColumns ();
 
                 if (rune.IsBmp)


### PR DESCRIPTION
## Fixes

- Fixes #4191
- Fixes #4188

## Proposed Changes/Todos

We now assume SupportsTrueColor is `true` unless user explicitly sets `false` themselves.

Not all width 2 characters are `Rune.IsBmp`.  The old code only ever considered `rune.GetColumns()` in the `IsBmp` pathway.

Fix is applied only to v2win

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
