### PR TITLE
Fixes #4191 Make v2 true color 'opt in'

### DIFF
--- a/Terminal.Gui/Drivers/V2/MainLoopCoordinator.cs
+++ b/Terminal.Gui/Drivers/V2/MainLoopCoordinator.cs
@@ -25,7 +25,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
     private ConsoleDriverFacade<T> _facade;
     private Task _inputTask;
     private readonly ITimedEvents _timedEvents;
-    private readonly bool _isWindowsTerminal;
 
     private readonly SemaphoreSlim _startupSemaphore = new (0, 1);
 
@@ -61,7 +60,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
         _inputProcessor = inputProcessor;
         _outputFactory = outputFactory;
         _loop = loop;
-        _isWindowsTerminal = Environment.GetEnvironmentVariable ("WT_SESSION") is { } || Environment.GetEnvironmentVariable ("VSAPPIDNAME") != null;
     }
 
     /// <summary>
@@ -161,11 +159,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
                            _output,
                            _loop.AnsiRequestScheduler,
                            _loop.WindowSizeMonitor);
-
-            if (!_isWindowsTerminal)
-            {
-                Application.Force16Colors = _facade.Force16Colors = true;
-            }
 
             Application.Driver = _facade;
 


### PR DESCRIPTION
## Fixes

- Fixes #4191
- Fixes #4188

## Proposed Changes/Todos

We now assume SupportsTrueColor is `true` unless user explicitly sets `false` themselves.

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
