### PR TITLE
Fixes #4196. Application.Begin doesn't refresh the screen at start

### DIFF
--- a/Terminal.Gui/App/Application.Run.cs
+++ b/Terminal.Gui/App/Application.Run.cs
@@ -160,9 +160,9 @@ public static partial class Application // Run (Begin, Run, End, Stop)
             Top = toplevel;
         }
 
-        if ((Top.Modal == false && toplevel.Modal)
-            || (Top.Modal == false && !toplevel.Modal)
-            || (Top.Modal == true && toplevel.Modal))
+        if ((Top?.Modal == false && toplevel.Modal)
+            || (Top?.Modal == false && !toplevel.Modal)
+            || (Top?.Modal == true && toplevel.Modal))
         {
             if (toplevel.Visible)
             {

--- a/Terminal.Gui/App/Application.Run.cs
+++ b/Terminal.Gui/App/Application.Run.cs
@@ -160,9 +160,9 @@ public static partial class Application // Run (Begin, Run, End, Stop)
             Top = toplevel;
         }
 
-        if ((Top?.Modal == false && toplevel.Modal)
-            || (Top?.Modal == false && !toplevel.Modal)
-            || (Top?.Modal == true && toplevel.Modal))
+        if ((Top.Modal == false && toplevel.Modal)
+            || (Top.Modal == false && !toplevel.Modal)
+            || (Top.Modal == true && toplevel.Modal))
         {
             if (toplevel.Visible)
             {

--- a/Terminal.Gui/App/Application.Run.cs
+++ b/Terminal.Gui/App/Application.Run.cs
@@ -214,11 +214,12 @@ public static partial class Application // Run (Begin, Run, End, Stop)
 
         if (!ConsoleDriver.RunningUnitTests)
         {
-            // Force an Idle event so that an Iteration (and Refresh) happen.
+            // Force an Idle event to be added to timeout outside the Application.MainThreadId,
+            // so that an Iteration (and Refresh) happen in the Application.MainThreadId
             Task.Run (() =>
                       {
                           Invoke (() => { });
-                          Task.Delay (10).Wait ();
+                          Task.Delay (1).Wait ();
                       });
         }
 

--- a/Terminal.Gui/App/Application.Run.cs
+++ b/Terminal.Gui/App/Application.Run.cs
@@ -212,8 +212,15 @@ public static partial class Application // Run (Begin, Run, End, Stop)
 
         NotifyNewRunState?.Invoke (toplevel, new (rs));
 
-        // Force an Idle event so that an Iteration (and Refresh) happen.
-        Invoke (() => { });
+        if (!ConsoleDriver.RunningUnitTests)
+        {
+            // Force an Idle event so that an Iteration (and Refresh) happen.
+            Task.Run (() =>
+                      {
+                          Invoke (() => { });
+                          Task.Delay (10).Wait ();
+                      });
+        }
 
         return rs;
     }

--- a/Terminal.Gui/ViewBase/View.Drawing.cs
+++ b/Terminal.Gui/ViewBase/View.Drawing.cs
@@ -807,7 +807,7 @@ public partial class View // Drawing APIs
         }
 
         // There was multiple enumeration error here, so calling ToArray - probably a stop gap
-        foreach (View subview in SubViews.ToArray ())
+        foreach (View subview in InternalSubViews)
         {
             if (subview.Frame.IntersectsWith (viewPortRelativeRegion))
             {

--- a/Tests/UnitTests/Views/SpinnerViewTests.cs
+++ b/Tests/UnitTests/Views/SpinnerViewTests.cs
@@ -11,6 +11,8 @@ public class SpinnerViewTests (ITestOutputHelper output)
     [InlineData (false)]
     public void TestSpinnerView_AutoSpin (bool callStop)
     {
+        ConsoleDriver.RunningUnitTests = true;
+
         SpinnerView view = GetSpinnerView ();
 
         Assert.Empty (Application.MainLoop.TimedEvents.Timeouts);


### PR DESCRIPTION
## Fixes

- Fixes #4196

## Proposed Changes/Todos

- [x] Enclosing the action inside a `Task.Run`

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
