### PR TITLE
Fixes #4198. Application.Invoke isn't wakeup the driver if idle

### DIFF
--- a/Terminal.Gui/App/ApplicationImpl.cs
+++ b/Terminal.Gui/App/ApplicationImpl.cs
@@ -293,6 +293,10 @@ public class ApplicationImpl : IApplication
                                return false;
                            }
                           );
+
+        // Ensure the action is executed in the main loop
+        // Wakeup mainloop if it's waiting for events
+        Application.MainLoop.Wakeup ();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Fixes

- Fixes #4198

## Proposed Changes/Todos

- [x] Call `Application.MainLoop.Wakeup` method

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
