### PR TITLE
Fixes #4204. v2win and v2net aren't refreshing the Character Map correctly

### DIFF
--- a/Terminal.Gui/Drivers/V2/ApplicationV2.cs
+++ b/Terminal.Gui/Drivers/V2/ApplicationV2.cs
@@ -232,6 +232,9 @@ public class ApplicationV2 : ApplicationImpl
         if (Application.MainThreadId == Thread.CurrentThread.ManagedThreadId)
         {
             action ();
+            // Ensure the action is executed and forces LayoutAndDrawImpl
+            Application.LayoutAndDrawImpl (true);
+
             return;
         }
 


### PR DESCRIPTION
## Fixes

- Fixes #4204

## Proposed Changes/Todos

- [x] Only needed to call `Application.LayoutAndDrawImpl (true);` in the `MainThreadId`

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
