### PR TITLE
Fixes #4206. There is no need to use a Task.Run to force Invoke in the MainThreadId

### DIFF
--- a/Terminal.Gui/App/Application.Run.cs
+++ b/Terminal.Gui/App/Application.Run.cs
@@ -212,16 +212,8 @@ public static partial class Application // Run (Begin, Run, End, Stop)
 
         NotifyNewRunState?.Invoke (toplevel, new (rs));
 
-        if (!ConsoleDriver.RunningUnitTests)
-        {
-            // Force an Idle event to be added to timeout outside the Application.MainThreadId,
-            // so that an Iteration (and Refresh) happen in the Application.MainThreadId
-            Task.Run (() =>
-                      {
-                          Invoke (() => { });
-                          Task.Delay (1).Wait ();
-                      });
-        }
+        // Force an Idle event so that an Iteration (and Refresh) happen.
+        Invoke (() => { });
 
         return rs;
     }

--- a/Terminal.Gui/App/ApplicationImpl.cs
+++ b/Terminal.Gui/App/ApplicationImpl.cs
@@ -275,6 +275,8 @@ public class ApplicationImpl : IApplication
         if (Application.MainThreadId == Thread.CurrentThread.ManagedThreadId)
         {
             action ();
+            WakeupMainLoop ();
+
             return;
         }
 
@@ -294,9 +296,14 @@ public class ApplicationImpl : IApplication
                            }
                           );
 
-        // Ensure the action is executed in the main loop
-        // Wakeup mainloop if it's waiting for events
-        Application.MainLoop.Wakeup ();
+        WakeupMainLoop ();
+
+        void WakeupMainLoop ()
+        {
+            // Ensure the action is executed in the main loop
+            // Wakeup mainloop if it's waiting for events
+            Application.MainLoop?.Wakeup ();
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Fixes

- Fixes #4206

## Proposed Changes/Todos

- [x] Only need to call Application.MainLoop?.Wakeup in the MainThreadId

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
