### PR TITLE
Fixes #4211. Annoying sporadic System.NullReferenceException in NetEvents

### DIFF
--- a/Terminal.Gui/Drivers/NetDriver/NetEvents.cs
+++ b/Terminal.Gui/Drivers/NetDriver/NetEvents.cs
@@ -50,7 +50,7 @@ internal class NetEvents : IDisposable
 
     public InputResult? DequeueInput ()
     {
-        while (!_netEventsDisposed.Token.IsCancellationRequested)
+        while (_netEventsDisposed is { Token.IsCancellationRequested: false })
         {
             _winChange.Set ();
 


### PR DESCRIPTION
## Fixes

- Fixes #4211

## Proposed Changes/Todos

- [x] Check for null before

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
