### PR TITLE
Fixes #4214. Annoying sporadic System.NullReferenceException in WindowsConsole

### DIFF
--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsConsole.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsConsole.cs
@@ -62,7 +62,7 @@ internal partial class WindowsConsole
         InputRecord inputRecord = default;
         uint numberEventsRead = 0;
 
-        while (!_inputReadyCancellationTokenSource!.IsCancellationRequested)
+        while (_inputReadyCancellationTokenSource is { IsCancellationRequested: false })
         {
             try
             {


### PR DESCRIPTION
## Fixes

- Fixes #4214

## Proposed Changes/Todos

- [x] Check for null before

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
