### PR TITLE
Fixes #4221 Extra modifiers f1 to f4 in v2net

### DIFF
--- a/Terminal.Gui/Drivers/AnsiResponseParser/Keyboard/CsiCursorPattern.cs
+++ b/Terminal.Gui/Drivers/AnsiResponseParser/Keyboard/CsiCursorPattern.cs
@@ -62,16 +62,16 @@ public class CsiCursorPattern : AnsiKeyboardParserPattern
         if (int.TryParse (modifierGroup, out int modifier))
         {
             key = modifier switch
-                  {
-                      2 => key.WithShift,
-                      3 => key.WithAlt,
-                      4 => key.WithAlt.WithShift,
-                      5 => key.WithCtrl,
-                      6 => key.WithCtrl.WithShift,
-                      7 => key.WithCtrl.WithAlt,
-                      8 => key.WithCtrl.WithAlt.WithShift,
-                      _ => key
-                  };
+            {
+                2 => key.WithShift,
+                3 => key.WithAlt,
+                4 => key.WithAlt.WithShift,
+                5 => key.WithCtrl,
+                6 => key.WithCtrl.WithShift,
+                7 => key.WithCtrl.WithAlt,
+                8 => key.WithCtrl.WithAlt.WithShift,
+                _ => key
+            };
         }
 
         return key;

--- a/Terminal.Gui/Drivers/AnsiResponseParser/Keyboard/CsiCursorPattern.cs
+++ b/Terminal.Gui/Drivers/AnsiResponseParser/Keyboard/CsiCursorPattern.cs
@@ -11,7 +11,7 @@ namespace Terminal.Gui.Drivers;
 /// </summary>
 public class CsiCursorPattern : AnsiKeyboardParserPattern
 {
-    private readonly Regex _pattern = new (@"^\u001b\[(?:1;(\d+))?([A-DHF])$");
+    private readonly Regex _pattern = new (@"^\u001b\[(?:1;(\d+))?([A-DFHPQRS])$");
 
     private readonly Dictionary<char, Key> _cursorMap = new ()
     {
@@ -20,7 +20,13 @@ public class CsiCursorPattern : AnsiKeyboardParserPattern
         { 'C', Key.CursorRight },
         { 'D', Key.CursorLeft },
         { 'H', Key.Home },
-        { 'F', Key.End }
+        { 'F', Key.End },
+
+        // F1–F4 as per xterm VT100-style CSI sequences
+        { 'P', Key.F1 },
+        { 'Q', Key.F2 },
+        { 'R', Key.F3 },
+        { 'S', Key.F4 }
     };
 
     /// <inheritdoc/>

--- a/Terminal.Gui/Drivers/AnsiResponseParser/Keyboard/CsiCursorPattern.cs
+++ b/Terminal.Gui/Drivers/AnsiResponseParser/Keyboard/CsiCursorPattern.cs
@@ -7,7 +7,7 @@ namespace Terminal.Gui.Drivers;
 ///     Detects ansi escape sequences in strings that have been read from
 ///     the terminal (see <see cref="IAnsiResponseParser"/>).
 ///     Handles navigation CSI key parsing such as <c>\x1b[A</c> (Cursor up)
-///     and <c>\x1b[1;5A</c> (Cursor up with Ctrl)
+///     and <c>\x1b[1;5A</c> (Cursor/Function with modifier(s))
 /// </summary>
 public class CsiCursorPattern : AnsiKeyboardParserPattern
 {

--- a/Terminal.Gui/Drivers/AnsiResponseParser/Keyboard/CsiCursorPattern.cs
+++ b/Terminal.Gui/Drivers/AnsiResponseParser/Keyboard/CsiCursorPattern.cs
@@ -62,16 +62,16 @@ public class CsiCursorPattern : AnsiKeyboardParserPattern
         if (int.TryParse (modifierGroup, out int modifier))
         {
             key = modifier switch
-            {
-                2 => key.WithShift,
-                3 => key.WithAlt,
-                4 => key.WithAlt.WithShift,
-                5 => key.WithCtrl,
-                6 => key.WithCtrl.WithShift,
-                7 => key.WithCtrl.WithAlt,
-                8 => key.WithCtrl.WithAlt.WithShift,
-                _ => key
-            };
+                  {
+                      2 => key.WithShift,
+                      3 => key.WithAlt,
+                      4 => key.WithAlt.WithShift,
+                      5 => key.WithCtrl,
+                      6 => key.WithCtrl.WithShift,
+                      7 => key.WithCtrl.WithAlt,
+                      8 => key.WithCtrl.WithAlt.WithShift,
+                      _ => key
+                  };
         }
 
         return key;

--- a/Terminal.Gui/Drivers/V2/MainLoopCoordinator.cs
+++ b/Terminal.Gui/Drivers/V2/MainLoopCoordinator.cs
@@ -25,7 +25,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
     private ConsoleDriverFacade<T> _facade;
     private Task _inputTask;
     private readonly ITimedEvents _timedEvents;
-    private readonly bool _isWindowsTerminal;
 
     private readonly SemaphoreSlim _startupSemaphore = new (0, 1);
 
@@ -61,7 +60,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
         _inputProcessor = inputProcessor;
         _outputFactory = outputFactory;
         _loop = loop;
-        _isWindowsTerminal = Environment.GetEnvironmentVariable ("WT_SESSION") is { } || Environment.GetEnvironmentVariable ("VSAPPIDNAME") != null;
     }
 
     /// <summary>
@@ -161,11 +159,6 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
                            _output,
                            _loop.AnsiRequestScheduler,
                            _loop.WindowSizeMonitor);
-
-            if (!_isWindowsTerminal)
-            {
-                Application.Force16Colors = _facade.Force16Colors = true;
-            }
 
             Application.Driver = _facade;
 

--- a/Terminal.Gui/Drivers/V2/MainLoopCoordinator.cs
+++ b/Terminal.Gui/Drivers/V2/MainLoopCoordinator.cs
@@ -25,6 +25,7 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
     private ConsoleDriverFacade<T> _facade;
     private Task _inputTask;
     private readonly ITimedEvents _timedEvents;
+    private readonly bool _isWindowsTerminal;
 
     private readonly SemaphoreSlim _startupSemaphore = new (0, 1);
 
@@ -60,6 +61,7 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
         _inputProcessor = inputProcessor;
         _outputFactory = outputFactory;
         _loop = loop;
+        _isWindowsTerminal = Environment.GetEnvironmentVariable ("WT_SESSION") is { } || Environment.GetEnvironmentVariable ("VSAPPIDNAME") != null;
     }
 
     /// <summary>
@@ -159,6 +161,11 @@ internal class MainLoopCoordinator<T> : IMainLoopCoordinator
                            _output,
                            _loop.AnsiRequestScheduler,
                            _loop.WindowSizeMonitor);
+
+            if (!_isWindowsTerminal)
+            {
+                Application.Force16Colors = _facade.Force16Colors = true;
+            }
 
             Application.Driver = _facade;
 

--- a/Tests/UnitTests/ConsoleDrivers/AnsiKeyboardParserTests.cs
+++ b/Tests/UnitTests/ConsoleDrivers/AnsiKeyboardParserTests.cs
@@ -100,11 +100,10 @@ public class AnsiKeyboardParserTests
         yield return new object [] { "\u001b[24~", Key.F12 };
 
         // Function keys with modifiers
-        /*  Not currently supported
         yield return new object [] { "\u001b[1;2P", Key.F1.WithShift };
         yield return new object [] { "\u001b[1;3Q", Key.F2.WithAlt };
         yield return new object [] { "\u001b[1;5R", Key.F3.WithCtrl };
-        */
+        
     }
 
     // Consolidated test for all keyboard events (e.g., arrow keys)


### PR DESCRIPTION
## Fixes

- Fixes #4221 

## Proposed Changes/Todos

F1 key can be 
`<esc>OP`

But if combined with modifier keys it can instead be:

`<esc>[1;3P`

This PR updates key parsing to support this sequence

- [x] Support Alt+F1, Shift+F1 etc

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
