### PR TITLE
Root SchemeName can only be set when the popover is not null

### DIFF
--- a/Terminal.Gui/Views/Menu/MenuBarv2.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarv2.cs
@@ -397,10 +397,10 @@ public class MenuBarv2 : Menuv2, IDesignable
 
         // If the active Application Popover is part of this MenuBar, hide it.
         if (Application.Popover?.GetActivePopover () is PopoverMenu popoverMenu
-            && popoverMenu?.Root?.SuperMenuItem?.SuperView == this)
+            && popoverMenu.Root?.SuperMenuItem?.SuperView == this)
         {
             // Logging.Debug ($"{Title} - Calling Application.Popover?.Hide ({popoverMenu.Title})");
-            Application.Popover?.Hide (popoverMenu);
+            Application.Popover.Hide (popoverMenu);
         }
 
         if (menuBarItem is null)

--- a/Terminal.Gui/Views/Menu/MenuBarv2.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarv2.cs
@@ -429,7 +429,10 @@ public class MenuBarv2 : Menuv2, IDesignable
         void OnMenuItemAccepted (object? sender, EventArgs args)
         {
             // Logging.Debug ($"{Title} - OnMenuItemAccepted");
-            menuBarItem.PopoverMenu!.VisibleChanged -= OnMenuItemAccepted;
+            if (menuBarItem.PopoverMenu is { })
+            {
+                menuBarItem.PopoverMenu.VisibleChanged -= OnMenuItemAccepted;
+            }
 
             if (Active && menuBarItem.PopoverMenu is { Visible: false })
             {

--- a/Terminal.Gui/Views/Menu/MenuBarv2.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarv2.cs
@@ -416,14 +416,13 @@ public class MenuBarv2 : Menuv2, IDesignable
         if (menuBarItem.PopoverMenu?.Root is { })
         {
             menuBarItem.PopoverMenu.Root.SuperMenuItem = menuBarItem;
+            menuBarItem.PopoverMenu.Root.SchemeName = SchemeName;
         }
 
         // Logging.Debug ($"{Title} - \"{menuBarItem.PopoverMenu?.Title}\".MakeVisible");
         menuBarItem.PopoverMenu?.MakeVisible (new Point (menuBarItem.FrameToScreen ().X, menuBarItem.FrameToScreen ().Bottom));
 
         menuBarItem.Accepting += OnMenuItemAccepted;
-
-        menuBarItem.PopoverMenu!.Root.SchemeName = SchemeName;
 
         return;
 


### PR DESCRIPTION
## Fixes

NullReferenceException when the PopOverMenu is not set

## Proposed Changes/Todos

- [ ] Todo 1

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
