### PR TITLE
Fixes #4272 - Update ListView's AllowsMultipleSelection to adhere to docs

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -43,7 +43,7 @@ namespace Terminal.Gui.Views;
 public class ListView : View, IDesignable
 {
     private bool _allowsMarking;
-    private bool _allowsMultipleSelection = true;
+    private bool _allowsMultipleSelection = false;
     private int _lastSelectedItem = -1;
     private int _selected = -1;
     private IListDataSource _source;

--- a/Tests/UnitTests/Views/ListViewTests.cs
+++ b/Tests/UnitTests/Views/ListViewTests.cs
@@ -16,6 +16,7 @@ public class ListViewTests (ITestOutputHelper output)
         Assert.Null (lv.Source);
         Assert.True (lv.CanFocus);
         Assert.Equal (-1, lv.SelectedItem);
+        Assert.False (lv.AllowsMultipleSelection);
 
         lv = new () { Source = new ListWrapper<string> (["One", "Two", "Three"]) };
         Assert.NotNull (lv.Source);
@@ -37,6 +38,7 @@ public class ListViewTests (ITestOutputHelper output)
         Assert.NotNull (lv.Source);
         Assert.Equal (-1, lv.SelectedItem);
         Assert.Equal (new (0, 1, 10, 20), lv.Frame);
+
     }
 
     [Fact]
@@ -524,10 +526,72 @@ Item 6",
     }
 
     [Fact]
-    public void AllowsMarking_True_SpaceWithShift_SelectsThenDown ()
+    public void AllowsMarking_True_SpaceWithShift_SelectsThenDown_SingleSelection ()
     {
         var lv = new ListView { Source = new ListWrapper<string> (["One", "Two", "Three"]) };
         lv.AllowsMarking = true;
+        lv.AllowsMultipleSelection = false;
+
+        Assert.NotNull (lv.Source);
+
+        // first item should be deselected by default
+        Assert.Equal (-1, lv.SelectedItem);
+
+        // nothing is ticked
+        Assert.False (lv.Source.IsMarked (0));
+        Assert.False (lv.Source.IsMarked (1));
+        Assert.False (lv.Source.IsMarked (2));
+
+        // view should indicate that it has accepted and consumed the event
+        Assert.True (lv.NewKeyDownEvent (Key.Space.WithShift));
+
+        // first item should now be selected
+        Assert.Equal (0, lv.SelectedItem);
+
+        // none of the items should be ticked
+        Assert.False (lv.Source.IsMarked (0));
+        Assert.False (lv.Source.IsMarked (1));
+        Assert.False (lv.Source.IsMarked (2));
+
+        // Press key combo again
+        Assert.True (lv.NewKeyDownEvent (Key.Space.WithShift));
+
+        // second item should now be selected
+        Assert.Equal (1, lv.SelectedItem);
+
+        // first item only should be ticked
+        Assert.True (lv.Source.IsMarked (0));
+        Assert.False (lv.Source.IsMarked (1));
+        Assert.False (lv.Source.IsMarked (2));
+
+        // Press key combo again
+        Assert.True (lv.NewKeyDownEvent (Key.Space.WithShift));
+        Assert.Equal (2, lv.SelectedItem);
+        Assert.False (lv.Source.IsMarked (0));
+        Assert.True (lv.Source.IsMarked (1));
+        Assert.False (lv.Source.IsMarked (2));
+
+        // Press key combo again
+        Assert.True (lv.NewKeyDownEvent (Key.Space.WithShift));
+        Assert.Equal (2, lv.SelectedItem); // cannot move down any further
+        Assert.False (lv.Source.IsMarked (0));
+        Assert.False (lv.Source.IsMarked (1));
+        Assert.True (lv.Source.IsMarked (2)); // but can toggle marked
+
+        // Press key combo again 
+        Assert.True (lv.NewKeyDownEvent (Key.Space.WithShift));
+        Assert.Equal (2, lv.SelectedItem); // cannot move down any further
+        Assert.False (lv.Source.IsMarked (0));
+        Assert.False (lv.Source.IsMarked (1));
+        Assert.False (lv.Source.IsMarked (2)); // untoggle toggle marked
+    }
+
+    [Fact]
+    public void AllowsMarking_True_SpaceWithShift_SelectsThenDown_MultipleSelection ()
+    {
+        var lv = new ListView { Source = new ListWrapper<string> (["One", "Two", "Three"]) };
+        lv.AllowsMarking = true;
+        lv.AllowsMultipleSelection = true;
 
         Assert.NotNull (lv.Source);
 


### PR DESCRIPTION
## Fixes

- Fixes #4272

## Pull Request checklist:

- [X] I've named my PR in the form of "Fixes #issue. Terse description."
- [X] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [X] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [X] I ran `dotnet test` before commit
- [X] I have made corresponding changes to the API documentation (using `///` style comments)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
